### PR TITLE
feat: add typedoc support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,48 +1,56 @@
 {
-	"env":{
-		 "browser":true,
-		 "es2021":true
+	"env": {
+		"browser": true,
+		"es2021": true
 	},
-	"extends":[
-		 "eslint:recommended",
-		 "plugin:@typescript-eslint/recommended",
-		 "prettier",
-		 "plugin:jsdoc/recommended"
+	"extends": [
+		"eslint:recommended",
+		"plugin:@typescript-eslint/recommended",
+		"prettier",
+		"plugin:jsdoc/recommended"
 	],
-	"parser":"@typescript-eslint/parser",
-	"parserOptions":{
-		 "ecmaVersion":"latest",
-		 "sourceType":"module"
+	"parser": "@typescript-eslint/parser",
+	"parserOptions": {
+		"ecmaVersion": "latest",
+		"sourceType": "module"
 	},
-	"plugins":[
-		 "@typescript-eslint",
-		 "check-file",
-		 "jsdoc"
+	"plugins": [
+		"@typescript-eslint",
+		"check-file",
+		"jsdoc"
 	],
-	"rules":{
-		 "linebreak-style":[
-				"error",
-				"unix"
-		 ],
-		 "quotes":[
-				"error",
-				"single",
-				{
-					"avoidEscape": true
-				}
-		 ],
-		 "semi":[
-				"error",
-				"always"
-		 ],
-		 "check-file/filename-naming-convention":[
+	"rules": {
+		"jsdoc/check-tag-names": [
+			"warn",
+			{
+				"definedTags": [
+					"experimental"
+				]
+			}
+		],
+		"linebreak-style": [
+			"error",
+			"unix"
+		],
+		"quotes": [
+			"error",
+			"single",
+			{
+				"avoidEscape": true
+			}
+		],
+		"semi": [
+			"error",
+			"always"
+		],
+		"check-file/filename-naming-convention": [
 			"error",
 			{
-				"**/*.{js,ts}":"KEBAB_CASE"
+				"**/*.{js,ts}": "KEBAB_CASE"
 			},
-      {
-      	"ignoreMiddleExtensions": true
-      }
+			{
+				"ignoreMiddleExtensions": true
+			}
 		]
 	}
 }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,28 +15,41 @@ jobs:
           command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      release_tag_name: ${{ steps.release.outputs.tag_name }}
 
+  npm-release:
+    needs: Release-please
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
       # The logic below handles the npm publication:
       - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
-        if: ${{ steps.release.outputs.releases_created }}
         with:
           node-version: 16
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Build Packages
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm ci
           npm run build
 
-      # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to NPM here
       # Our scripts only publish versions that do not already exist.
       - name: Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npm publish --access public
+
+      - name: Build Docs
+        run: npm run docs
+
+      - name: Deploy Documentation 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: typedoc

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 # yalc stuff
 yalc.lock
 .yalc/
+
+# Ignore generated doc folder
+typedoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "prettier": "^2.6.2",
         "ts-jest": "^28.0.8",
         "ts-node": "^10.8.2",
+        "typedoc": "^0.23.16",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -8396,6 +8397,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "dev": true,
@@ -8484,6 +8491,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -8536,6 +8549,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -9858,6 +9883,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "dev": true,
@@ -10680,6 +10716,48 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.16.tgz",
+      "integrity": "sha512-rumYsCeNRXlyuZVzefD7050n7ptL2uudsCJg50dY0v/stKniqIlRpvx/F/6expC0/Q6Dbab+g/JpZuB7Sw90FA==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -10871,6 +10949,18 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -16786,6 +16876,12 @@
       "version": "2.2.1",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "dev": true
@@ -16844,6 +16940,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -16878,6 +16980,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+      "integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -17720,6 +17828,17 @@
       "dev": true,
       "optional": true
     },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "dev": true,
@@ -18257,6 +18376,38 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.16.tgz",
+      "integrity": "sha512-rumYsCeNRXlyuZVzefD7050n7ptL2uudsCJg50dY0v/stKniqIlRpvx/F/6expC0/Q6Dbab+g/JpZuB7Sw90FA==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -18382,6 +18533,18 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:cjs": "esbuild ./src/index.ts --bundle --sourcemap --target=es2016 --platform=node --format=cjs --outfile=./dist/cjs/index.js --analyze",
     "build": "npm run clean && npm run type && npm run build:esm && npm run build:cjs",
     "postbuild": "cp ./package.esm.json ./dist/esm/package.json",
-    "current-version": "echo $npm_package_version"
+    "current-version": "echo $npm_package_version",
+    "docs": "typedoc"
   },
   "repository": {
     "type": "git",
@@ -61,6 +62,7 @@
     "prettier": "^2.6.2",
     "ts-jest": "^28.0.8",
     "ts-node": "^10.8.2",
+    "typedoc": "^0.23.16",
     "typescript": "^4.7.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-export * from './open-feature';
+export { OpenFeature } from './open-feature';
 export * from './types';
 export * from './errors';
+
+export type { OpenFeatureAPI } from './open-feature';

--- a/src/open-feature.ts
+++ b/src/open-feature.ts
@@ -23,13 +23,22 @@ type OpenFeatureGlobal = {
 };
 const _globalThis = globalThis as OpenFeatureGlobal;
 
-class OpenFeatureAPI implements GlobalApi {
+export class OpenFeatureAPI implements GlobalApi {
   private _provider: Provider = NOOP_PROVIDER;
   private _transactionContextPropagator: TransactionContextPropagator = NOOP_TRANSACTION_CONTEXT_PROPAGATOR;
   private _context: EvaluationContext = {};
   private _hooks: Hook[] = [];
   private _logger: Logger = new DefaultLogger();
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+
+  /**
+   * Gets a singleton instance of the OpenFeature API.
+   *
+   * @ignore
+   * @returns {OpenFeatureAPI} OpenFeature API
+   */
   static getInstance(): OpenFeatureAPI {
     const globalApi = _globalThis[GLOBAL_OPENFEATURE_API_KEY];
     if (globalApi) {
@@ -124,4 +133,9 @@ class OpenFeatureAPI implements GlobalApi {
   }
 }
 
+/**
+ * A singleton instance of the OpenFeature API.
+ *
+ * @returns {OpenFeatureAPI} OpenFeature API
+ */
 export const OpenFeature = OpenFeatureAPI.getInstance();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-type PrimitiveValue = null | boolean | string | number;
+export type PrimitiveValue = null | boolean | string | number;
 
 export type JsonObject = { [key: string]: JsonValue };
 
@@ -544,6 +544,7 @@ interface ManageTransactionContextPropagator<T> extends TransactionContextPropag
    * propagator is responsible for persisting context for the duration of a single
    * transaction.
    *
+   * @experimental
    * @template T The type of the receiver
    * @param {TransactionContextPropagator} transactionContextPropagator The context propagator to be used
    * @returns {T} The receiver (this object)
@@ -559,6 +560,7 @@ export interface TransactionContextPropagator {
    * Returns the currently defined transaction context using the registered transaction
    * context propagator.
    *
+   * @experimental
    * @returns {TransactionContext} The current transaction context
    */
   getTransactionContext(): TransactionContext;
@@ -569,6 +571,7 @@ export interface TransactionContextPropagator {
    *
    * Sets the transaction context using the registered transaction context propagator.
    *
+   * @experimental
    * @template R The return value of the callback
    * @param {TransactionContext} transactionContext The transaction specific context
    * @param {(...args: unknown[]) => R} callback Callback function used to set the transaction context on the stack

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Enable incremental compilation */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,10 +8,11 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "ES2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["ES2020"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "ES2015", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "ES2020"
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -22,11 +22,10 @@
     // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
     /* Modules */
-    "module": "ES2020",                                /* Specify what module code is generated. */
+    "module": "ES2020", /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -35,19 +34,17 @@
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-
     /* Emit */
-    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist/esm",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -63,18 +60,16 @@
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    "declarationDir": "dist/types",                           /* Specify the output directory for generated declaration files. */
+    "declarationDir": "dist/types", /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
     // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -93,11 +88,23 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.js"]
+  "typedocOptions": {
+    "name": "OpenFeature SDK",
+    // "excludePrivate": true,
+    "entryPoints": [
+      "src/index.ts"
+    ],
+    "out": "typedoc"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.js"
+  ]
 }


### PR DESCRIPTION
This PR
Generates documentation based on TypeScript types and deploys the docs using GH pages.

How to test
This was tested in a fork. The generated GH page can be seen [here](https://beeme1mr.github.io/js-sdk/).

Signed-off-by: Michael Beemer [beeme1mr@users.noreply.github.com](mailto:beeme1mr@users.noreply.github.com)