### PR TITLE
chore: fix publish experimental hash

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -32,7 +32,7 @@ jobs:
 
       # create an experimental version at this SHA (vX.X.X-experimental-4742ef14cc0ea07e3569eee56899937452a55a9c)
       - name: Version
-        run: npm version "$(npm run current-version -s)-experimental-$GITHUB_SHA" --no-git-tag-version
+        run: npm version "$(npm run current-version -s)-experimental-$(git rev-parse HEAD)" --no-git-tag-version
 
       - name: Publish
         run: npm publish --tag experimental --access public

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,7 @@
-# These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 * @toddbaert @beeme1mr
 
-# The publish-experimental workflow is sensitive because if modified,
-# it could publish something experimental as a proper version. 
-# We should carefully monitor changes to this file
-.github/workflows/publish-experimental.yml @toddbaert @beeme1mr
+# The publish workflows are sensitive because if modified,
+# they could publish something experimental as a proper version. 
+# We should carefully monitor changes to this folder
+.github/workflows/* @toddbaert @beeme1mr


### PR DESCRIPTION
@beeme1mr  I'm not sure if this was always the case, or something changed, but there's a minor bug in the experimental publish that caused it to be labeled with the wrong SHA.

The contents are correct, but the SHA would actually be the SHA of the HEAD of main (which is a bit confusing). This fixes that to be the SHA of the PR branch HEAD.