### PR TITLE
fix: include types in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    "default": "./dist/cjs/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "devDependencies": {
     "@openfeature/flagd-provider": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "dist/"
   ],
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js",
-    "types": "./dist/types/index.d.ts"
+    "default": "./dist/cjs/index.js"
   },
   "devDependencies": {
     "@openfeature/flagd-provider": "~0.7.0",


### PR DESCRIPTION
## This PR

- Includes types in the package.json export

### Related Issues

Fixes #354

### Notes

Thanks for reporting the bug @talzion12

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>