### PR TITLE
chore: renovate regex manager to monitor test-harness version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,14 @@ Run tests with `npm test`.
 
 ### Integration tests
 
-The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests run with the "integration" npm script. If you'd like to run them locally, you can start the flagd testbed with `docker run -p 8013:8013 ghcr.io/open-feature/flagd-testbed:latest` and then run `npm run integration`.
+The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features/evaluation.feature) using [`flagd`](https://github.com/open-feature/flagd). These tests run with the "integration" npm script. If you'd like to run them locally, you can start the flagd testbed with
+```
+docker run -p 8013:8013 ghcr.io/open-feature/flagd-testbed:latest
+```
+and then run
+```
+npm run integration
+```
 
 ### Packaging
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,13 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^.github/workflows/build-and-push.yml$", "^CONTRIBUTING.md$", "^.github/workflows/pr-checks.yaml$"],
+      "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd-testbed:(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "open-feature/test-harness",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["^.github/workflows/build-and-push.yml$", "^CONTRIBUTING.md$", "^.github/workflows/pr-checks.yaml$"],
+      "fileMatch": ["^CONTRIBUTING.md$", "^.github/workflows/pr-checks.yaml$"],
       "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd-testbed:(?<currentValue>.*?)\\n"],
       "depNameTemplate": "open-feature/test-harness",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Add renovate config to monitor test-harness version and upgrade flagd-testbed image.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #358 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

