### PR TITLE
feat!: use bundled event emitter type

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -15,7 +15,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons
 } from '@openfeature/shared';
-import { EventEmitter } from 'events';
+import { OpenFeatureEventEmitter } from '.';
 import { OpenFeature } from './open-feature';
 import { Client, FlagEvaluationOptions, Hook, Provider } from './types';
 
@@ -40,7 +40,7 @@ export class OpenFeatureClient implements Client {
     // and so we don't have to make these public properties on the API class. 
     private readonly providerAccessor: () => Provider,
     private readonly providerReady: () => boolean,
-    apiEvents: () => EventEmitter,
+    apiEvents: () => OpenFeatureEventEmitter,
     private readonly globalLogger: () => Logger,
     options: OpenFeatureClientOptions,
   ) {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,6 @@
-
+import { EventEmitter } from 'events';
+// this must come before the other exports
+export { EventEmitter as OpenFeatureEventEmitter } ;
 export * from './client';
 export * from './no-op-provider';
 export * from './open-feature';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-// this must come before the other exports
+// this must precede other exports
 export { EventEmitter as OpenFeatureEventEmitter };
 export * from './client';
 export * from './no-op-provider';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 // this must come before the other exports
-export { EventEmitter as OpenFeatureEventEmitter } ;
+export { EventEmitter as OpenFeatureEventEmitter };
 export * from './client';
 export * from './no-op-provider';
 export * from './open-feature';

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -1,5 +1,5 @@
 import { ApiEvents, EvaluationContext, FlagValue, Logger, OpenFeatureCommonAPI, ProviderEvents, ProviderMetadata, SafeLogger } from '@openfeature/shared';
-import { EventEmitter } from 'events';
+import { OpenFeatureEventEmitter } from '.';
 import { OpenFeatureClient } from './client';
 import { NOOP_PROVIDER } from './no-op-provider';
 import { Client, Hook, Provider } from './types';
@@ -14,7 +14,7 @@ const _globalThis = globalThis as OpenFeatureGlobal;
 
 export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
-  private _apiEvents = new EventEmitter();
+  private _apiEvents = new OpenFeatureEventEmitter();
   private _providerReady = false;
   protected _hooks: Hook[] = [];
   protected _provider: Provider = NOOP_PROVIDER;
@@ -83,7 +83,7 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
       this._providerReady = false;
 
       if (!this._provider.events) {
-        this._provider.events = new EventEmitter();
+        this._provider.events = new OpenFeatureEventEmitter();
       }
 
       if (typeof this._provider?.initialize === 'function') {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -16,7 +16,7 @@ import {
   ProviderMetadata,
   ResolutionDetails,
 } from '@openfeature/shared';
-import EventEmitter from 'events';
+import { OpenFeatureEventEmitter } from '.';
 
 /**
  * Interface that providers must implement to resolve flag values for their particular
@@ -38,7 +38,7 @@ export interface Provider extends CommonProvider {
    * An event emitter for ProviderEvents.
    * @see ProviderEvents
    */
-  events?: EventEmitter;
+  events?: OpenFeatureEventEmitter;
 
   /**
    * A handler function to reconcile changes when the static context.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -36,6 +36,7 @@ export interface Provider extends CommonProvider {
 
   /**
    * An event emitter for ProviderEvents.
+   * 
    * @see ProviderEvents
    */
   events?: OpenFeatureEventEmitter;

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,10 +10,17 @@ export default {
     file: './dist/types.d.ts',
     format: 'es', // module format doesn't really matter here since output i
   },
+  external: [
+    // function indicating which deps should be considered external: non-external deps will have their types bundled
+    (id) => {
+      // bundle 'events' types
+      return id !== 'events'
+    }
+  ],
   plugins: [
     alias({
       entries: [{ find: '@openfeature/shared', replacement: '../shared/dist/types.d.ts' }],
     }),
-    dts({tsconfig: './tsconfig.json'}),
-  ]
+    dts({tsconfig: './tsconfig.json', respectExternal: true}),
+  ],
 };


### PR DESCRIPTION
:warning: This change only impacts the experimental web-sdk.

This includes an aliased, bundled version of `EventEmitter` so we have full control over that API/implementation, and consumers don't need the `events` dep for browsers.

We currently bundle [events](https://www.npmjs.com/package/events) (a browser polyfill for the node events API) into this package, but a provider author who wants to implement events in their provider would need to install that package as well. This removes the need for that. Interested in others' thoughts.  