### PR TITLE
test: add tests to provider init and shutdown

### DIFF
--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -35,7 +35,7 @@ describe('OpenFeature', () => {
     describe('Requirement 1.1.2.2', () => {
       it('MUST invoke the `initialize` function on the newly registered provider before using it to resolve flag values', () => {
         OpenFeature.setProvider(MOCK_PROVIDER);
-        expect(OpenFeature['_provider']).toBe(MOCK_PROVIDER);
+        expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
         expect(MOCK_PROVIDER.initialize).toHaveBeenCalled();
       });
     });
@@ -92,7 +92,7 @@ describe('OpenFeature', () => {
   describe('Requirement 1.6.1', () => {
     it('MUST define a `shutdown` function, which, when called, must call the respective `shutdown` function on the active provider', () => {
       OpenFeature.setProvider(MOCK_PROVIDER);
-      expect(OpenFeature['_provider']).toBe(MOCK_PROVIDER);
+      expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
       OpenFeature.close().then(
         () => {
           expect(MOCK_PROVIDER.onClose).toHaveBeenCalled();

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -81,21 +81,18 @@ describe('OpenFeature', () => {
         .clearHooks()
         .setLogger(console)
         .getClient();
-
-
       expect(client).toBeDefined();
     });
-
-
   });
 
   describe('Requirement 1.6.1', () => {
-    it('MUST define a `shutdown` function, which, when called, must call the respective `shutdown` function on the active provider', () => {
+    it('MUST define a `shutdown` function, which, when called, must call the respective `shutdown` function on the active provider', (done) => {
       OpenFeature.setProvider(MOCK_PROVIDER);
       expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
       OpenFeature.close().then(
         () => {
           expect(MOCK_PROVIDER.onClose).toHaveBeenCalled();
+          done();
         });
     });
   });


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds checks for calls to the init/shutdown methods of a Provider

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #406 


