### PR TITLE
fix: remove events exports from server

### DIFF
--- a/packages/client/integration/step-definitions/evaluation.spec.ts
+++ b/packages/client/integration/step-definitions/evaluation.spec.ts
@@ -6,9 +6,8 @@ import {
   EvaluationContext,
   ResolutionDetails,
   StandardResolutionReasons,
-  ProviderEvents,
 } from '@openfeature/shared';
-import { OpenFeature, Client } from '../../';
+import { OpenFeature, ProviderEvents } from '../../';
 // load the feature file.
 const feature = loadFeature('packages/client/integration/features/evaluation.feature');
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,22 +1,19 @@
 import { EvaluationContext, OpenFeatureError } from '@openfeature/shared';
 import { SafeLogger } from '@openfeature/shared';
 import {
-  ApiEvents,
   ClientMetadata,
   ErrorCode,
   EvaluationDetails,
   FlagValue,
   FlagValueType,
-  Handler,
   HookContext,
   JsonValue,
   Logger,
-  ProviderEvents,
   ResolutionDetails,
   StandardResolutionReasons
 } from '@openfeature/shared';
 import { OpenFeature } from './open-feature';
-import { Client, FlagEvaluationOptions, Hook, OpenFeatureEventEmitter, Provider } from './types';
+import { ApiEvents, Client, FlagEvaluationOptions, Handler, Hook, OpenFeatureEventEmitter, Provider, ProviderEvents } from './types';
 
 type OpenFeatureClientOptions = {
   name?: string;

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -1,16 +1,14 @@
 import {
-  ApiEvents,
   EvaluationContext,
   FlagValue,
   Logger,
   OpenFeatureCommonAPI,
-  ProviderEvents,
   ProviderMetadata,
   SafeLogger,
 } from '@openfeature/shared';
 import { OpenFeatureClient } from './client';
 import { NOOP_PROVIDER } from './no-op-provider';
-import { Client, Hook, OpenFeatureEventEmitter, Provider } from './types';
+import { ApiEvents, Client, Hook, OpenFeatureEventEmitter, Provider, ProviderEvents } from './types';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -21,7 +19,6 @@ type OpenFeatureGlobal = {
 const _globalThis = globalThis as OpenFeatureGlobal;
 
 export class OpenFeatureAPI extends OpenFeatureCommonAPI {
-
   private _apiEvents = new OpenFeatureEventEmitter();
   private _providerReady = false;
   protected _hooks: Hook[] = [];
@@ -95,12 +92,15 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
       }
 
       if (typeof this._provider?.initialize === 'function') {
-        this._provider.initialize?.(this._context)?.then(() => {
-          this._providerReady = true;
-          this._provider.events?.emit(ProviderEvents.Ready);
-        })?.catch(() => {
-          this._provider.events?.emit(ProviderEvents.Error);
-        });
+        this._provider
+          .initialize?.(this._context)
+          ?.then(() => {
+            this._providerReady = true;
+            this._provider.events?.emit(ProviderEvents.Ready);
+          })
+          ?.catch(() => {
+            this._provider.events?.emit(ProviderEvents.Error);
+          });
       } else {
         this._providerReady = true;
         this._provider.events?.emit(ProviderEvents.Ready);
@@ -118,12 +118,12 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
   getClient(name?: string, version?: string): Client {
     return new OpenFeatureClient(
       // functions are passed here to make sure that these values are always up to date,
-      // and so we don't have to make these public properties on the API class. 
+      // and so we don't have to make these public properties on the API class.
       () => this._provider,
       () => this._providerReady,
       () => this._apiEvents,
       () => this._logger,
-      { name, version },
+      { name, version }
     );
   }
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -4,7 +4,6 @@ import {
   CommonProvider,
   EvaluationContext,
   EvaluationDetails,
-  Eventing,
   FlagValue,
   HookContext,
   HookHints,
@@ -18,6 +17,50 @@ import {
 } from '@openfeature/shared';
 import { EventEmitter as OpenFeatureEventEmitter } from 'events';
 export { OpenFeatureEventEmitter };
+
+export enum ProviderEvents {
+  /**
+   * The provider is ready to evaluate flags.
+   */
+  Ready = 'PROVIDER_READY',
+
+  /**
+   * The provider is in an error state.
+   */
+  Error = 'PROVIDER_ERROR',
+  
+  /**
+   * The flag configuration in the source-of-truth has changed.
+   */
+  ConfigurationChanged = 'PROVIDER_CONFIGURATION_CHANGED',
+  
+  /**
+   * The provider's cached state is not longer valid and may not be up-to-date with the source of truth.
+   */
+  Stale = 'PROVIDER_STALE',
+};
+
+export interface EventData {
+  flagKeysChanged?: string[],
+  changeMetadata?: { [key: string]: boolean | string } // similar to flag metadata
+}
+
+export enum ApiEvents {
+  ProviderChanged = 'providerChanged',
+}
+
+export interface Eventing {
+  addHandler(notificationType: string, handler: Handler): void
+}
+
+export type EventContext = {
+  notificationType: string;
+  [key: string]: unknown;
+}
+
+export type Handler = (eventContext?: EventContext) => void
+
+export type EventCallbackMessage = (eventContext: EventContext) => void
 
 /**
  * Interface that providers must implement to resolve flag values for their particular

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -4,7 +4,6 @@ import {
   EvaluationDetails,
   FlagValue,
   FlagValueType,
-  Handler,
   HookContext,
   JsonValue,
   Logger, OpenFeatureError, ResolutionDetails, SafeLogger, StandardResolutionReasons
@@ -17,17 +16,12 @@ type OpenFeatureClientOptions = {
   version?: string;
 };
 
-type HandlerWrapper = {
-  eventType: string;
-  handler: Handler;
-}
 
 export class OpenFeatureClient implements Client {
   readonly metadata: ClientMetadata;
   private _context: EvaluationContext;
   private _hooks: Hook[] = [];
   private _clientLogger?: Logger;
-  private _handlerWrappers: HandlerWrapper[] = [];
 
   constructor(
     // we always want the client to use the current provider,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,49 +1,5 @@
 export type PrimitiveValue = null | boolean | string | number;
 
-export enum ProviderEvents {
-  /**
-   * The provider is ready to evaluate flags.
-   */
-  Ready = 'PROVIDER_READY',
-
-  /**
-   * The provider is in an error state.
-   */
-  Error = 'PROVIDER_ERROR',
-  
-  /**
-   * The flag configuration in the source-of-truth has changed.
-   */
-  ConfigurationChanged = 'PROVIDER_CONFIGURATION_CHANGED',
-  
-  /**
-   * The provider is transitioning to a state of unavailability.
-   */
-  Shutdown = 'PROVIDER_SHUTDOWN',
-};
-
-export interface EventData {
-  flagKeysChanged?: string[],
-  changeMetadata?: { [key: string]: boolean | string } // similar to flag metadata
-}
-
-export enum ApiEvents {
-  ProviderChanged = 'providerChanged',
-}
-
-export interface Eventing {
-  addHandler(notificationType: string, handler: Handler): void
-}
-
-export type EventContext = {
-  notificationType: string;
-  [key: string]: unknown;
-}
-
-export type Handler = (eventContext?: EventContext) => void
-
-export type EventCallbackMessage = (eventContext: EventContext) => void
-
 export type JsonObject = { [key: string]: JsonValue };
 
 export type JsonArray = JsonValue[];


### PR DESCRIPTION
Moves some events-related exports (unused by server API) from `/shared` to `/client`. We will eventually move some of these back, but for now I don't want these types to be seen by the server SDK (even if they are unused) since they are experimental.