### PR TITLE
chore: wildcard for shared version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12276,15 +12276,15 @@
       "version": "0.3.2-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@openfeature/shared": "0.0.3"
+        "@openfeature/shared": "*"
       }
     },
     "packages/server": {
       "name": "@openfeature/js-sdk",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@openfeature/shared": "0.0.3"
+        "@openfeature/shared": "*"
       },
       "engines": {
         "node": ">=16"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "devDependencies": {
-    "@openfeature/shared": "0.0.3"
+    "@openfeature/shared": "*"
   },
   "typedoc": {
     "displayName": "OpenFeature Web SDK",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,7 +48,7 @@
     "node": ">=16"
   },
   "devDependencies": {
-    "@openfeature/shared": "0.0.3"
+    "@openfeature/shared": "*"
   },
   "typedoc": {
     "displayName": "OpenFeature JS SDK",


### PR DESCRIPTION
use * for shared local dev dep so we don't have to manage it.