### PR TITLE
chore: refactor events

### DIFF
--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -95,14 +95,14 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
           .initialize?.(this._context)
           ?.then(() => {
             this._providerReady = true;
-            this._provider.events?.emit(ProviderEvents.Ready);
+            this._events?.emit(ProviderEvents.Ready);
           })
           ?.catch(() => {
-            this._provider.events?.emit(ProviderEvents.Error);
+            this._events?.emit(ProviderEvents.Error);
           });
       } else {
         this._providerReady = true;
-        this._provider.events?.emit(ProviderEvents.Ready);
+        this._events?.emit(ProviderEvents.Ready);
       }
       oldProvider?.onClose?.();
     }

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -134,8 +134,8 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
       }));
   }
 
-  private removeListeners(newProvider: Provider) {
-    newProvider.events?.removeAllListeners();
+  private removeListeners(oldProvider: Provider) {
+    oldProvider.events?.removeAllListeners();
   }
 }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -45,10 +45,6 @@ export interface EventData {
   changeMetadata?: { [key: string]: boolean | string } // similar to flag metadata
 }
 
-export enum ApiEvents {
-  ProviderChanged = 'providerChanged',
-}
-
 export interface Eventing {
   addHandler(notificationType: string, handler: Handler): void
 }


### PR DESCRIPTION
No functional changes. Refactor to how events are done, specifically with how they are maintained even across provider changes. This code is easier to understand IMHO, and also requires a few less structures/types.

Thanks to @RealAnna 's recent tests, we can do these changes with confidence :partying_face: 