### PR TITLE
feat: add support for flag metadata

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -197,6 +197,7 @@ export class OpenFeatureClient implements Client {
 
       const evaluationDetails = {
         ...resolution,
+        flagMetadata: Object.freeze(resolution.flagMetadata ?? {}),
         flagKey,
       };
 
@@ -214,6 +215,7 @@ export class OpenFeatureClient implements Client {
         errorMessage,
         value: defaultValue,
         reason: StandardResolutionReasons.ERROR,
+        flagMetadata: Object.freeze({}),
         flagKey,
       };
     } finally {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -424,6 +424,39 @@ describe('Evaluation details structure', () => {
       });
     });
   });
+
+  describe('Requirement 1.4.13, Requirement 1.4.14', () => {
+    it('should return immutable `flag metadata` as defined by the provider', () => {
+      const flagMetadata = {
+        url: 'https://test.dev',
+        version: '1',
+      };
+
+      const flagMetadataProvider = {
+        name: 'flag-metadata',
+        resolveBooleanEvaluation: jest.fn((): ResolutionDetails<boolean> => {
+          return {
+            value: true,
+            flagMetadata,
+          };
+        }),
+      } as unknown as Provider;
+
+      OpenFeature.setProvider(flagMetadataProvider);
+      const client = OpenFeature.getClient();
+      const response = client.getBooleanDetails('some-flag', false);
+      expect(response.flagMetadata).toBe(flagMetadata);
+      expect(Object.isFrozen(response.flagMetadata)).toBeTruthy();
+    });
+
+    it('should return empty `flag metadata` because it was not set by the provider', () => {
+      // The mock provider doesn't contain flag metadata
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      const client = OpenFeature.getClient();
+      const response = client.getBooleanDetails('some-flag', false);
+      expect(response.flagMetadata).toEqual({});
+    });
+  });
 });
 
 

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -212,6 +212,7 @@ export class OpenFeatureClient implements Client {
 
       const evaluationDetails = {
         ...resolution,
+        flagMetadata: Object.freeze(resolution.flagMetadata ?? {}),
         flagKey,
       };
 
@@ -229,6 +230,7 @@ export class OpenFeatureClient implements Client {
         errorMessage,
         value: defaultValue,
         reason: StandardResolutionReasons.ERROR,
+        flagMetadata: Object.freeze({}),
         flagKey,
       };
     } finally {

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -402,6 +402,39 @@ describe('OpenFeatureClient', () => {
     });
   });
 
+  describe('Requirement 1.4.13, Requirement 1.4.14', () => {
+    it('should return immutable `flag metadata` as defined by the provider', async () => {
+      const flagMetadata = {
+        url: 'https://test.dev',
+        version: '1',
+      };
+
+      const flagMetadataProvider = {
+        name: 'flag-metadata',
+        resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
+          return Promise.resolve({
+            value: true,
+            flagMetadata,
+          });
+        }),
+      } as unknown as Provider;
+
+      OpenFeature.setProvider(flagMetadataProvider);
+      const client = OpenFeature.getClient();
+      const response = await client.getBooleanDetails('some-flag', false);
+      expect(response.flagMetadata).toBe(flagMetadata);
+      expect(Object.isFrozen(response.flagMetadata)).toBeTruthy();
+    });
+
+    it('should return empty `flag metadata` because it was not set by the provider', async () => {
+      // The mock provider doesn't contain flag metadata
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      const client = OpenFeature.getClient();
+      const response = await client.getBooleanDetails('some-flag', false);
+      expect(response.flagMetadata).toEqual({});
+    });
+  });
+
   describe('Requirement 1.6.1', () => {
     describe('Provider', () => {
       const nonTransformingProvider = {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -125,9 +125,17 @@ export enum ErrorCode {
 
 export type ResolutionReason = keyof typeof StandardResolutionReasons | (string & Record<never, never>);
 
+/**
+ * A structure which supports definition of arbitrary properties, with keys of type string, and values of type boolean, string, or number.
+ * 
+ * This structure is populated by a provider for use by an Application Author (via the Evaluation API) or an Application Integrator (via hooks).
+ */
+export type FlagMetadata = Record<string, string | number | boolean>;
+
 export type ResolutionDetails<U> = {
   value: U;
   variant?: string;
+  flagMetadata?: FlagMetadata;
   reason?: ResolutionReason;
   errorCode?: ErrorCode;
   errorMessage?: string;
@@ -135,6 +143,7 @@ export type ResolutionDetails<U> = {
 
 export type EvaluationDetails<T extends FlagValue> = {
   flagKey: string;
+  flagMetadata: Readonly<FlagMetadata>;
 } & ResolutionDetails<T>;
 
 export interface ManageContext<T> {


### PR DESCRIPTION
## This PR

- add support for flag metadata

### Related Issues

Fixes #425

### Notes

This feature is part of the recently released v0.6.0 of the OpenFeature spec.

### How to test

Tests are included for both client and server.

