### PR TITLE
feat: add named client support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
         "ts-jest": "^29.0.5",
         "ts-node": "^10.8.2",
         "typedoc": "^0.24.0",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -7486,6 +7487,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-cucumber/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-cucumber/node_modules/v8-to-istanbul": {
       "version": "7.1.2",
       "dev": true,
@@ -8834,6 +8844,15 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.4.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.3.tgz",
@@ -9658,6 +9677,16 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.3.0",
         "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-releases": {
@@ -11981,9 +12010,10 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -65,11 +65,15 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.8.2",
     "typedoc": "^0.24.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "uuid": "^9.0.0"
   },
   "workspaces": [
     "packages/server",
     "packages/client",
     "packages/shared"
-  ]
+  ],
+  "dependencies": {
+
+  }
 }

--- a/packages/client/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/client/e2e/step-definitions/evaluation.spec.ts
@@ -7,7 +7,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/shared';
-import { OpenFeature, ProviderEvents } from '../../';
+import { OpenFeature, ProviderEvents } from '../../src';
 // load the feature file.
 const feature = loadFeature('packages/client/e2e/features/evaluation.feature');
 
@@ -24,7 +24,9 @@ const givenAnOpenfeatureClientIsRegisteredWithCacheDisabled = (
 defineFeature(feature, (test) => {
   beforeAll((done) => {
     client.addHandler(ProviderEvents.Ready, () => {
-      done();
+      setTimeout(() => {
+        done(); // TODO Fix by setting readiness correctly in provider
+      }, 2000);
     });
   });
 

--- a/packages/client/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/client/e2e/step-definitions/evaluation.spec.ts
@@ -25,7 +25,7 @@ defineFeature(feature, (test) => {
   beforeAll((done) => {
     client.addHandler(ProviderEvents.Ready, () => {
       setTimeout(() => {
-        done(); // TODO Fix by setting readiness correctly in provider
+        done(); // TODO remove this once flagd provider properly implements readiness (for now, we add a 2s wait).
       }, 2000);
     });
   });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,19 +1,29 @@
-import { EvaluationContext, OpenFeatureError } from '@openfeature/shared';
-import { SafeLogger } from '@openfeature/shared';
 import {
   ClientMetadata,
   ErrorCode,
+  EvaluationContext,
   EvaluationDetails,
   FlagValue,
   FlagValueType,
   HookContext,
   JsonValue,
   Logger,
+  OpenFeatureError,
+  ProviderStatus,
   ResolutionDetails,
-  StandardResolutionReasons
+  SafeLogger,
+  StandardResolutionReasons,
 } from '@openfeature/shared';
 import { OpenFeature } from './open-feature';
-import { Client, FlagEvaluationOptions, Handler, Hook, OpenFeatureEventEmitter, Provider, ProviderEvents } from './types';
+import {
+  Client,
+  FlagEvaluationOptions,
+  Handler,
+  Hook,
+  OpenFeatureEventEmitter,
+  Provider,
+  ProviderEvents,
+} from './types';
 
 type OpenFeatureClientOptions = {
   name?: string;
@@ -21,28 +31,31 @@ type OpenFeatureClientOptions = {
 };
 
 export class OpenFeatureClient implements Client {
-  readonly metadata: ClientMetadata;
   private _hooks: Hook[] = [];
   private _clientLogger?: Logger;
 
   constructor(
     // functions are passed here to make sure that these values are always up to date,
-    // and so we don't have to make these public properties on the API class. 
+    // and so we don't have to make these public properties on the API class.
     private readonly providerAccessor: () => Provider,
-    private readonly providerReady: () => boolean,
     private readonly events: () => OpenFeatureEventEmitter,
     private readonly globalLogger: () => Logger,
-    options: OpenFeatureClientOptions,
-  ) {
-    this.metadata = {
-      name: options.name,
-      version: options.version,
-    } as const;
+    private readonly options: OpenFeatureClientOptions
+  ) {}
+
+  get metadata(): ClientMetadata {
+    return {
+      name: this.options.name,
+      version: this.options.version,
+      provider: this.providerAccessor().metadata,
+    };
   }
 
   addHandler(eventType: ProviderEvents, handler: Handler): void {
     this.events().on(eventType, handler);
-    if (eventType === ProviderEvents.Ready && this.providerReady()) {
+    const providerReady = !this._provider.status || this._provider.status === ProviderStatus.READY;
+
+    if (eventType === ProviderEvents.Ready && providerReady) {
       // run immediately, we're ready.
       handler();
     }
@@ -67,11 +80,7 @@ export class OpenFeatureClient implements Client {
     return this;
   }
 
-  getBooleanValue(
-    flagKey: string,
-    defaultValue: boolean,
-    options?: FlagEvaluationOptions
-  ): boolean {
+  getBooleanValue(flagKey: string, defaultValue: boolean, options?: FlagEvaluationOptions): boolean {
     return this.getBooleanDetails(flagKey, defaultValue, options).value;
   }
 
@@ -80,20 +89,10 @@ export class OpenFeatureClient implements Client {
     defaultValue: boolean,
     options?: FlagEvaluationOptions
   ): EvaluationDetails<boolean> {
-    return this.evaluate<boolean>(
-      flagKey,
-      this._provider.resolveBooleanEvaluation,
-      defaultValue,
-      'boolean',
-      options
-    );
+    return this.evaluate<boolean>(flagKey, this._provider.resolveBooleanEvaluation, defaultValue, 'boolean', options);
   }
 
-  getStringValue<T extends string = string>(
-    flagKey: string,
-    defaultValue: T,
-    options?: FlagEvaluationOptions
-  ): T {
+  getStringValue<T extends string = string>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T {
     return this.getStringDetails<T>(flagKey, defaultValue, options).value;
   }
 
@@ -112,11 +111,7 @@ export class OpenFeatureClient implements Client {
     );
   }
 
-  getNumberValue<T extends number = number>(
-    flagKey: string,
-    defaultValue: T,
-    options?: FlagEvaluationOptions
-  ): T {
+  getNumberValue<T extends number = number>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T {
     return this.getNumberDetails(flagKey, defaultValue, options).value;
   }
 
@@ -153,12 +148,7 @@ export class OpenFeatureClient implements Client {
 
   private evaluate<T extends FlagValue>(
     flagKey: string,
-    resolver: (
-      flagKey: string,
-      defaultValue: T,
-      context: EvaluationContext,
-      logger: Logger
-    ) => ResolutionDetails<T>,
+    resolver: (flagKey: string, defaultValue: T, context: EvaluationContext, logger: Logger) => ResolutionDetails<T>,
     defaultValue: T,
     flagType: FlagValueType,
     options: FlagEvaluationOptions = {}

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -47,7 +47,7 @@ export class OpenFeatureClient implements Client {
     return {
       name: this.options.name,
       version: this.options.version,
-      provider: this.providerAccessor().metadata,
+      providerMetadata: this.providerAccessor().metadata,
     };
   }
 

--- a/packages/client/src/no-op-provider.ts
+++ b/packages/client/src/no-op-provider.ts
@@ -12,6 +12,12 @@ class NoopFeatureProvider implements Provider {
   } as const;
 
   get status(): ProviderStatus {
+    /**
+     * This is due to the NoopProvider not being a real provider.
+     * We do not want it to trigger the Ready event handlers, so we never set this to ready.
+     * With the NoopProvider assigned, the client can be assumed to be uninitialized.
+     * https://github.com/open-feature/js-sdk/pull/429#discussion_r1202642654
+     */
     return ProviderStatus.NOT_READY;
   }
 

--- a/packages/client/src/no-op-provider.ts
+++ b/packages/client/src/no-op-provider.ts
@@ -1,4 +1,4 @@
-import { ResolutionDetails, JsonValue } from '@openfeature/shared';
+import { JsonValue, ProviderStatus, ResolutionDetails } from '@openfeature/shared';
 import { Provider } from './types';
 
 const REASON_NO_OP = 'No-op';
@@ -10,6 +10,10 @@ class NoopFeatureProvider implements Provider {
   readonly metadata = {
     name: 'No-op Provider',
   } as const;
+
+  get status(): ProviderStatus {
+    return ProviderStatus.NOT_READY;
+  }
 
   resolveBooleanEvaluation(_: string, defaultValue: boolean): ResolutionDetails<boolean> {
     return this.noOp(defaultValue);

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -93,11 +93,11 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * Sets the provider that OpenFeature will use for flag evaluations of providers with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
    *
-   * @param {string} client The name to identify the client
+   * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API
    */
-  setProvider(client: string, provider: Provider): this;
+  setProvider(clientName: string, provider: Provider): this;
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
     const client = stringOrUndefined(clientOrProvider);
     const provider = objectOrUndefined<Provider>(clientOrProvider) ?? objectOrUndefined<Provider>(providerOrUndefined);

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -9,6 +9,7 @@ import {
 import { OpenFeatureClient } from './client';
 import { NOOP_PROVIDER } from './no-op-provider';
 import { Client, Hook, OpenFeatureEventEmitter, Provider, ProviderEvents } from './types';
+import { objectOrUndefined, stringOrUndefined } from '@openfeature/shared/src/type-guards';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -19,9 +20,9 @@ type OpenFeatureGlobal = {
 const _globalThis = globalThis as OpenFeatureGlobal;
 
 export class OpenFeatureAPI extends OpenFeatureCommonAPI {
-  private _providerReady = false;
   protected _hooks: Hook[] = [];
   protected _provider: Provider = NOOP_PROVIDER;
+  protected _providers: Map<string, Provider> = new Map();
   private readonly _events = new OpenFeatureEventEmitter();
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -80,32 +81,61 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
     await this._provider?.onContextChange?.(oldContext, context);
   }
 
-  setProvider(provider: Provider): OpenFeatureCommonAPI {
-    // ignore no-ops
-    if (this._provider !== provider) {
-      const oldProvider = this._provider;
-      this._provider = provider;
-      this._providerReady = false;
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations of providers without a name.
+   * Setting a provider supersedes the current provider used in new and existing clients without a name.
+   *
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {GlobalApi} OpenFeature API
+   */
+  setProvider(provider: Provider): this;
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations of providers with the given name.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   *
+   * @param {string} client The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {GlobalApi} OpenFeature API
+   */
+  setProvider(client: string, provider: Provider): this;
+  setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
+    const client = stringOrUndefined(clientOrProvider);
+    const provider = objectOrUndefined<Provider>(clientOrProvider) ?? objectOrUndefined<Provider>(providerOrUndefined);
 
-      this.removeListeners(oldProvider);
-      this.attachListeners(this._provider);
-
-      if (typeof this._provider?.initialize === 'function') {
-        this._provider
-          .initialize?.(this._context)
-          ?.then(() => {
-            this._providerReady = true;
-            this._events?.emit(ProviderEvents.Ready);
-          })
-          ?.catch(() => {
-            this._events?.emit(ProviderEvents.Error);
-          });
-      } else {
-        this._providerReady = true;
-        this._events?.emit(ProviderEvents.Ready);
-      }
-      oldProvider?.onClose?.();
+    if (!provider) {
+      return this;
     }
+
+    const oldProvider = client ? this._providers.get(client) ?? this._provider : this._provider;
+
+    // ignore no-ops
+    if (oldProvider === provider) {
+      return this;
+    }
+
+    if (client) {
+      this._providers.set(client, provider);
+    } else {
+      this._provider = provider;
+    }
+
+    this.removeListeners(oldProvider);
+    this.attachListeners(provider);
+
+    if (typeof provider.initialize === 'function') {
+      provider
+        .initialize?.(this._context)
+        ?.then(() => {
+          this._events?.emit(ProviderEvents.Ready);
+        })
+        ?.catch(() => {
+          this._events?.emit(ProviderEvents.Error);
+        });
+    } else {
+      this._events?.emit(ProviderEvents.Ready);
+    }
+
+    oldProvider?.onClose?.();
     return this;
   }
 
@@ -113,25 +143,45 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
     await this?._provider?.onClose?.();
   }
 
+  /**
+   * A factory function for creating new named OpenFeature clients. Clients can contain
+   * their own state (e.g. logger, hook, context). Multiple clients can be used
+   * to segment feature flag configuration.
+   *
+   * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
+   * Otherwise, the default provider is used until a provider is assigned to that name.
+   *
+   * @param {string} name The name of the client
+   * @param {string} version The version of the client (only used for metadata)
+   * @returns {Client} OpenFeature Client
+   */
   getClient(name?: string, version?: string): Client {
     return new OpenFeatureClient(
       // functions are passed here to make sure that these values are always up to date,
       // and so we don't have to make these public properties on the API class.
-      () => this._provider,
-      () => this._providerReady,
+      () => this.getProviderForClient(name),
       () => this._events,
       () => this._logger,
       { name, version }
     );
   }
 
+  private getProviderForClient(name?: string): Provider {
+    if (!name) {
+      return this._provider;
+    }
+
+    return this._providers.get(name) ?? this._provider;
+  }
+
   private attachListeners(newProvider: Provider) {
     // iterate over the event types
-    Object.values(ProviderEvents)
-      .forEach(eventType => newProvider.events?.on(eventType, () => {
+    Object.values(ProviderEvents).forEach((eventType) =>
+      newProvider.events?.on(eventType, () => {
         // on each event type, fire the associated handlers
         this._events.emit(eventType);
-      }));
+      })
+    );
   }
 
   private removeListeners(oldProvider: Provider) {

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -106,7 +106,7 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
       return this;
     }
 
-    const oldProvider = client ? this._providers.get(client) ?? this._provider : this._provider;
+    const oldProvider = this.getProviderForClient(client);
 
     // ignore no-ops
     if (oldProvider === provider) {

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -33,7 +33,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
   /**
    * Gets a singleton instance of the OpenFeature API.
-   *
    * @ignore
    * @returns {OpenFeatureAPI} OpenFeature API
    */
@@ -50,7 +49,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
   /**
    * Get metadata about registered provider.
-   *
    * @returns {ProviderMetadata} Provider Metadata
    */
   get providerMetadata(): ProviderMetadata {
@@ -86,18 +84,16 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * Sets the default provider for flag evaluations.
    * This provider will be used by unnamed clients and named clients to which no provider is bound.
    * Setting a provider supersedes the current provider used in new and existing clients without a name.
-   *
    * @param {Provider} provider The provider responsible for flag evaluations.
-   * @returns {GlobalApi} OpenFeature API
+   * @returns {OpenFeatureAPI} OpenFeature API
    */
   setProvider(provider: Provider): this;
   /**
    * Sets the provider that OpenFeature will use for flag evaluations of providers with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
-   *
    * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
-   * @returns {GlobalApi} OpenFeature API
+   * @returns {OpenFeatureAPI} OpenFeature API
    */
   setProvider(clientName: string, provider: Provider): this;
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
@@ -155,7 +151,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    *
    * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
    * Otherwise, the default provider is used until a provider is assigned to that name.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client (only used for metadata)
    * @returns {Client} OpenFeature Client
@@ -207,7 +202,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
 /**
  * A singleton instance of the OpenFeature API.
- *
  * @returns {OpenFeatureAPI} OpenFeature API
  */
 export const OpenFeature = OpenFeatureAPI.getInstance();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -75,7 +75,6 @@ export interface Provider extends CommonProvider {
 
   /**
    * An event emitter for ProviderEvents.
-   *
    * @see ProviderEvents
    */
   events?: OpenFeatureEventEmitter;
@@ -83,7 +82,6 @@ export interface Provider extends CommonProvider {
   /**
    * A handler function to reconcile changes when the static context.
    * Called by the SDK when the context is changed.
-   *
    * @param oldContext
    * @param newContext
    */
@@ -99,7 +97,6 @@ export interface Provider extends CommonProvider {
    * When the returned promise resolves, the SDK fires the ProviderEvents.Ready event.
    * If the returned promise rejects, the SDK fires the ProviderEvents.Error event.
    * Use this function to perform any context-dependent setup within the provider.
-   *
    * @param context
    */
   initialize?(context: EvaluationContext): Promise<void>;
@@ -149,7 +146,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
   /**
    * Runs before flag values are resolved from the provider.
    * If an EvaluationContext is returned, it will be merged with the pre-existing EvaluationContext.
-   *
    * @param hookContext
    * @param hookHints
    */
@@ -157,7 +153,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
 
   /**
    * Runs after flag values are successfully resolved from the provider.
-   *
    * @param hookContext
    * @param evaluationDetails
    * @param hookHints
@@ -166,7 +161,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
 
   /**
    * Runs in the event of an unhandled error or promise rejection during flag resolution, or any attached hooks.
-   *
    * @param hookContext
    * @param error
    * @param hookHints
@@ -176,7 +170,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
   /**
    * Runs after all other hook stages, regardless of success or error.
    * Errors thrown here are unhandled by the client and will surface in application code.
-   *
    * @param hookContext
    * @param hookHints
    */
@@ -190,7 +183,6 @@ interface EvaluationLifeCycle<T> {
    * will not remove existing hooks.
    * Hooks registered on the global API object run with all evaluations.
    * Hooks registered on the client run with all evaluations on that client.
-   *
    * @template T The type of the receiver
    * @param {Hook<FlagValue>[]} hooks A list of hooks that should always run
    * @returns {T} The receiver (this object)
@@ -199,14 +191,12 @@ interface EvaluationLifeCycle<T> {
 
   /**
    * Access all the hooks that are registered on this receiver.
-   *
    * @returns {Hook<FlagValue>[]} A list of the client hooks
    */
   getHooks(): Hook[];
 
   /**
    * Clears all the hooks that are registered on this receiver.
-   *
    * @template T The type of the receiver
    * @returns {T} The receiver (this object)
    */
@@ -221,7 +211,6 @@ export interface FlagEvaluationOptions {
 export interface Features {
   /**
    * Performs a flag evaluation that returns a boolean.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
@@ -231,7 +220,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
@@ -245,7 +233,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns a string.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {string} T A optional generic argument constraining the string
    * @param {T} defaultValue The value returned if an error occurs
@@ -257,7 +244,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {string} T A optional generic argument constraining the string
    * @param {T} defaultValue The value returned if an error occurs
@@ -273,7 +259,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns a number.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {number} T A optional generic argument constraining the number
    * @param {T} defaultValue The value returned if an error occurs
@@ -285,7 +270,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {number} T A optional generic argument constraining the number
    * @param {T} defaultValue The value returned if an error occurs
@@ -301,7 +285,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns an object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {JsonValue} T A optional generic argument describing the structure
    * @param {T} defaultValue The value returned if an error occurs
@@ -313,7 +296,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {JsonValue} T A optional generic argument describing the structure
    * @param {T} defaultValue The value returned if an error occurs
@@ -346,7 +328,6 @@ export interface GlobalApi
    * A factory function for creating new OpenFeature clients. Clients can contain
    * their own state (e.g. logger, hook, context). Multiple clients can be used
    * to segment feature flag configuration.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
@@ -357,7 +338,6 @@ export interface GlobalApi
   /**
    * Sets the provider that OpenFeature will use for flag evaluations. Setting
    * a provider supersedes the current provider used in new and existing clients.
-   *
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API
    */

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -28,35 +28,35 @@ export enum ProviderEvents {
    * The provider is in an error state.
    */
   Error = 'PROVIDER_ERROR',
-  
+
   /**
    * The flag configuration in the source-of-truth has changed.
    */
   ConfigurationChanged = 'PROVIDER_CONFIGURATION_CHANGED',
-  
+
   /**
    * The provider's cached state is not longer valid and may not be up-to-date with the source of truth.
    */
   Stale = 'PROVIDER_STALE',
-};
+}
 
 export interface EventData {
-  flagKeysChanged?: string[],
-  changeMetadata?: { [key: string]: boolean | string } // similar to flag metadata
+  flagKeysChanged?: string[];
+  changeMetadata?: { [key: string]: boolean | string }; // similar to flag metadata
 }
 
 export interface Eventing {
-  addHandler(notificationType: string, handler: Handler): void
+  addHandler(notificationType: string, handler: Handler): void;
 }
 
 export type EventContext = {
   notificationType: string;
   [key: string]: unknown;
-}
+};
 
-export type Handler = (eventContext?: EventContext) => void
+export type Handler = (eventContext?: EventContext) => void;
 
-export type EventCallbackMessage = (eventContext: EventContext) => void
+export type EventCallbackMessage = (eventContext: EventContext) => void;
 
 /**
  * Interface that providers must implement to resolve flag values for their particular
@@ -65,7 +65,6 @@ export type EventCallbackMessage = (eventContext: EventContext) => void
  * Implementation for resolving all the required flag types must be defined.
  */
 export interface Provider extends CommonProvider {
-
   /**
    * A provider hook exposes a mechanism for provider authors to register hooks
    * to tap into various stages of the flag evaluation lifecycle. These hooks can
@@ -76,7 +75,7 @@ export interface Provider extends CommonProvider {
 
   /**
    * An event emitter for ProviderEvents.
-   * 
+   *
    * @see ProviderEvents
    */
   events?: OpenFeatureEventEmitter;
@@ -84,11 +83,11 @@ export interface Provider extends CommonProvider {
   /**
    * A handler function to reconcile changes when the static context.
    * Called by the SDK when the context is changed.
-   * 
-   * @param oldContext 
-   * @param newContext 
+   *
+   * @param oldContext
+   * @param newContext
    */
-  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>
+  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>;
 
   // TODO: move to common Provider type when we want close in server
   onClose?(): Promise<void>;
@@ -100,8 +99,8 @@ export interface Provider extends CommonProvider {
    * When the returned promise resolves, the SDK fires the ProviderEvents.Ready event.
    * If the returned promise rejects, the SDK fires the ProviderEvents.Error event.
    * Use this function to perform any context-dependent setup within the provider.
-   * 
-   * @param context 
+   *
+   * @param context
    */
   initialize?(context: EvaluationContext): Promise<void>;
 
@@ -154,10 +153,7 @@ export interface Hook<T extends FlagValue = FlagValue> {
    * @param hookContext
    * @param hookHints
    */
-  before?(
-    hookContext: BeforeHookContext,
-    hookHints?: HookHints
-  ): EvaluationContext | void;
+  before?(hookContext: BeforeHookContext, hookHints?: HookHints): EvaluationContext | void;
 
   /**
    * Runs after flag values are successfully resolved from the provider.
@@ -166,11 +162,7 @@ export interface Hook<T extends FlagValue = FlagValue> {
    * @param evaluationDetails
    * @param hookHints
    */
-  after?(
-    hookContext: Readonly<HookContext<T>>,
-    evaluationDetails: EvaluationDetails<T>,
-    hookHints?: HookHints
-  ): void;
+  after?(hookContext: Readonly<HookContext<T>>, evaluationDetails: EvaluationDetails<T>, hookHints?: HookHints): void;
 
   /**
    * Runs in the event of an unhandled error or promise rejection during flag resolution, or any attached hooks.
@@ -235,11 +227,7 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {boolean} Flag evaluation response
    */
-  getBooleanValue(
-    flagKey: string,
-    defaultValue: boolean,
-    options?: FlagEvaluationOptions
-  ): boolean;
+  getBooleanValue(flagKey: string, defaultValue: boolean, options?: FlagEvaluationOptions): boolean;
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
@@ -264,16 +252,8 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {T} Flag evaluation response
    */
-  getStringValue(
-    flagKey: string,
-    defaultValue: string,
-    options?: FlagEvaluationOptions
-  ): string;
-  getStringValue<T extends string = string>(
-    flagKey: string,
-    defaultValue: T,
-    options?: FlagEvaluationOptions
-  ): T;
+  getStringValue(flagKey: string, defaultValue: string, options?: FlagEvaluationOptions): string;
+  getStringValue<T extends string = string>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T;
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
@@ -284,11 +264,7 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {EvaluationDetails<T>} Flag evaluation details response
    */
-  getStringDetails(
-    flagKey: string,
-    defaultValue: string,
-    options?: FlagEvaluationOptions
-  ): EvaluationDetails<string>;
+  getStringDetails(flagKey: string, defaultValue: string, options?: FlagEvaluationOptions): EvaluationDetails<string>;
   getStringDetails<T extends string = string>(
     flagKey: string,
     defaultValue: T,
@@ -304,16 +280,8 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {T} Flag evaluation response
    */
-  getNumberValue(
-    flagKey: string,
-    defaultValue: number,
-    options?: FlagEvaluationOptions
-  ): number
-  getNumberValue<T extends number = number>(
-    flagKey: string,
-    defaultValue: T,
-    options?: FlagEvaluationOptions
-  ): T;
+  getNumberValue(flagKey: string, defaultValue: number, options?: FlagEvaluationOptions): number;
+  getNumberValue<T extends number = number>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T;
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
@@ -324,11 +292,7 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {Promise<EvaluationDetails<T>>} Flag evaluation details response
    */
-  getNumberDetails(
-    flagKey: string,
-    defaultValue: number,
-    options?: FlagEvaluationOptions
-  ): EvaluationDetails<number>;
+  getNumberDetails(flagKey: string, defaultValue: number, options?: FlagEvaluationOptions): EvaluationDetails<number>;
   getNumberDetails<T extends number = number>(
     flagKey: string,
     defaultValue: T,
@@ -344,16 +308,8 @@ export interface Features {
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {Promise<T>} Flag evaluation response
    */
-  getObjectValue(
-    flagKey: string,
-    defaultValue: JsonValue,
-    options?: FlagEvaluationOptions
-  ): JsonValue;
-  getObjectValue<T extends JsonValue = JsonValue>(
-    flagKey: string,
-    defaultValue: T,
-    options?: FlagEvaluationOptions
-  ): T;
+  getObjectValue(flagKey: string, defaultValue: JsonValue, options?: FlagEvaluationOptions): JsonValue;
+  getObjectValue<T extends JsonValue = JsonValue>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T;
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
@@ -376,11 +332,7 @@ export interface Features {
   ): EvaluationDetails<T>;
 }
 
-export interface Client
-  extends EvaluationLifeCycle<Client>,
-    Features,
-    ManageLogger<Client>,
-    Eventing {
+export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing {
   readonly metadata: ClientMetadata;
 }
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -8,18 +8,14 @@ import {
   StandardResolutionReasons,
   FlagNotFoundError,
 } from '../src';
-import {OpenFeatureClient} from '../src/client';
-import {OpenFeature} from '../src/open-feature';
-import {
-  Client, Provider,
-
-} from '../src/types';
+import { OpenFeatureClient } from '../src/client';
+import { OpenFeature } from '../src/open-feature';
+import { Client, Provider } from '../src/types';
 
 const BOOLEAN_VALUE = true;
 const STRING_VALUE = 'val';
 const NUMBER_VALUE = 10;
 const ARRAY_VALUE: JsonValue[] = [];
-
 
 const INNER_KEY = 'inner';
 const INNER_NULL_KEY = 'nullKey';
@@ -44,19 +40,21 @@ const NUMBER_VARIANT = `${NUMBER_VALUE}`;
 const OBJECT_VARIANT = 'json';
 const REASON = 'mocked-value';
 
-
 // a mock provider with some jest spies
 const MOCK_PROVIDER: Provider = {
-
   metadata: {
     name: 'mock',
   },
 
-  events: undefined, hooks: [], initialize(): Promise<void> {
+  events: undefined,
+  hooks: [],
+  initialize(): Promise<void> {
     return Promise.resolve(undefined);
-  }, onClose(): Promise<void> {
+  },
+  onClose(): Promise<void> {
     return Promise.resolve(undefined);
-  }, onContextChange(): Promise<void> {
+  },
+  onContextChange(): Promise<void> {
     return Promise.resolve(undefined);
   },
 
@@ -69,12 +67,11 @@ const MOCK_PROVIDER: Provider = {
   }),
 
   resolveObjectEvaluation: jest.fn(<U extends JsonValue>(): ResolutionDetails<U> => {
-
-    return <ResolutionDetails<U>>({
+    return <ResolutionDetails<U>>{
       value: OBJECT_VALUE as U,
       variant: OBJECT_VARIANT,
       reason: REASON,
-    });
+    };
   }) as <U>() => ResolutionDetails<U>,
 
   resolveBooleanEvaluation: jest.fn((): ResolutionDetails<boolean> => {
@@ -83,15 +80,14 @@ const MOCK_PROVIDER: Provider = {
       variant: BOOLEAN_VARIANT,
       reason: REASON,
     };
-
   }),
-  resolveStringEvaluation: jest.fn( (): ResolutionDetails<string> => {
+  resolveStringEvaluation: jest.fn((): ResolutionDetails<string> => {
     return {
       value: STRING_VALUE,
       variant: STRING_VARIANT,
       reason: REASON,
     };
-  })
+  }),
 };
 
 describe('OpenFeatureClient', () => {
@@ -469,6 +465,3 @@ describe('Evaluation details structure', () => {
     });
   });
 });
-
-
-

--- a/packages/client/test/events.spec.ts
+++ b/packages/client/test/events.spec.ts
@@ -80,7 +80,7 @@ describe('Events', () => {
   let clientId = uuid();
 
   afterEach(() => {
-    // jest.clearAllMocks();
+    jest.clearAllMocks();
     clientId = uuid();
   });
 

--- a/packages/client/test/events.spec.ts
+++ b/packages/client/test/events.spec.ts
@@ -91,7 +91,7 @@ describe('Events', () => {
         const client = OpenFeature.getClient(clientId);
         client.addHandler(ProviderEvents.Ready, () => {
           try {
-            expect(client.metadata.provider.name).toBe(provider.metadata.name);
+            expect(client.metadata.providerMetadata.name).toBe(provider.metadata.name);
             expect(provider.initialize).toHaveBeenCalled();
             done();
           } catch (err) {
@@ -108,7 +108,7 @@ describe('Events', () => {
 
         client.addHandler(ProviderEvents.Error, () => {
           try {
-            expect(client.metadata.provider.name).toBe(provider.metadata.name);
+            expect(client.metadata.providerMetadata.name).toBe(provider.metadata.name);
             expect(provider.initialize).toHaveBeenCalled();
             done();
           } catch (err) {
@@ -127,7 +127,7 @@ describe('Events', () => {
 
         client.addHandler(ProviderEvents.Ready, () => {
           try {
-            expect(client.metadata.provider.name).toBe(provider.metadata.name);
+            expect(client.metadata.providerMetadata.name).toBe(provider.metadata.name);
             done();
           } catch (err) {
             done(err);
@@ -143,7 +143,7 @@ describe('Events', () => {
 
         client.addHandler(ProviderEvents.Error, () => {
           try {
-            expect(client.metadata.provider.name).toBe(provider.metadata.name);
+            expect(client.metadata.providerMetadata.name).toBe(provider.metadata.name);
             expect(provider.initialize).toHaveBeenCalled();
             done();
           } catch (err) {
@@ -217,13 +217,13 @@ describe('Events', () => {
 
       let counter = 0;
       client.addHandler(ProviderEvents.Ready, () => {
-        if (client.metadata.provider.name === provider1.metadata.name) {
+        if (client.metadata.providerMetadata.name === provider1.metadata.name) {
           OpenFeature.setProvider(clientId, provider2);
           counter++;
         } else {
           console.log(counter);
           expect(counter).toBeGreaterThan(0);
-          expect(client.metadata.provider.name).toBe(provider2.metadata.name);
+          expect(client.metadata.providerMetadata.name).toBe(provider2.metadata.name);
           if (counter == 1) {
             done();
           }

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -54,7 +54,7 @@ describe('OpenFeature', () => {
     it('should set the default provider if no name is provided', () => {
       OpenFeature.setProvider(MOCK_PROVIDER);
       const client = OpenFeature.getClient();
-      expect(client.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
+      expect(client.metadata.providerMetadata.name).toEqual(MOCK_PROVIDER.metadata.name);
     });
 
     it('should not change named providers when setting a new default provider', () => {
@@ -66,8 +66,8 @@ describe('OpenFeature', () => {
       const unnamedClient = OpenFeature.getClient();
       const namedClient = OpenFeature.getClient(name);
 
-      expect(unnamedClient.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(unnamedClient.metadata.providerMetadata.name).toEqual(MOCK_PROVIDER.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
 
     it('should assign a new provider to existing clients', () => {
@@ -78,7 +78,7 @@ describe('OpenFeature', () => {
       const namedClient = OpenFeature.getClient(name);
       OpenFeature.setProvider(name, fakeProvider);
 
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
   });
 
@@ -109,7 +109,7 @@ describe('OpenFeature', () => {
 
     it('should return a client with the default provider if no provider has been bound to the name', () => {
       const namedClient = OpenFeature.getClient('unbound');
-      expect(namedClient.metadata.provider.name).toEqual(OpenFeature.providerMetadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(OpenFeature.providerMetadata.name);
     });
 
     it('should return a client with the provider bound to the name', () => {
@@ -119,7 +119,7 @@ describe('OpenFeature', () => {
 
       const namedClient = OpenFeature.getClient(name);
 
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
 
     it('should be chainable', () => {

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -113,7 +113,7 @@ describe('OpenFeature', () => {
     });
 
     it('should return a client with the provider bound to the name', () => {
-      const name = 'my-client';
+      const name = 'my-named-client';
       const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
       OpenFeature.setProvider(name, fakeProvider);
 

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
-import {OpenFeatureClient} from '../src/client';
-import {OpenFeature, OpenFeatureAPI} from '../src/open-feature';
-import {Provider,} from '../src/types';
+import { OpenFeatureClient } from '../src/client';
+import { OpenFeature, OpenFeatureAPI } from '../src/open-feature';
+import { Provider } from '../src/types';
 
 const MOCK_PROVIDER: Provider = {
   metadata: {
@@ -27,7 +27,7 @@ describe('OpenFeature', () => {
 
   describe('Requirement 1.1.2', () => {
     it('should equal previously set provider', () => {
-      const fakeProvider = {metadata: 'test'} as unknown as Provider;
+      const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
       OpenFeature.setProvider(fakeProvider);
       expect(OpenFeature.providerMetadata === fakeProvider.metadata).toBeTruthy();
     });
@@ -39,31 +39,62 @@ describe('OpenFeature', () => {
         expect(MOCK_PROVIDER.initialize).toHaveBeenCalled();
       });
     });
+
     describe('Requirement 1.1.2.3', () => {
-      it('MUST invoke the `shutdown` function on the previously registered provider once it\'s no longer being used to resolve flag values.', () => {
-        const fakeProvider = {metadata: 'test'} as unknown as Provider;
+      it("MUST invoke the `shutdown` function on the previously registered provider once it's no longer being used to resolve flag values.", () => {
+        const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
         OpenFeature.setProvider(MOCK_PROVIDER);
         OpenFeature.setProvider(fakeProvider);
         expect(MOCK_PROVIDER.onClose).toHaveBeenCalled();
       });
     });
-
-
   });
 
   describe('Requirement 1.1.3', () => {
+    it('should set the default provider if no name is provided', () => {
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      const client = OpenFeature.getClient();
+      expect(client.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
+    });
+
+    it('should not change named providers when setting a new default provider', () => {
+      const name = 'my-client';
+      const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      OpenFeature.setProvider(name, fakeProvider);
+
+      const unnamedClient = OpenFeature.getClient();
+      const namedClient = OpenFeature.getClient(name);
+
+      expect(unnamedClient.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
+      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+    });
+
+    it('should assign a new provider to existing clients', () => {
+      const name = 'my-client';
+      const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
+
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      const namedClient = OpenFeature.getClient(name);
+      OpenFeature.setProvider(name, fakeProvider);
+
+      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+    });
+  });
+
+  describe('Requirement 1.1.4', () => {
     it('should allow addition of hooks', () => {
       expect(OpenFeature.addHooks).toBeDefined();
     });
   });
 
-  describe('Requirement 1.1.4', () => {
+  describe('Requirement 1.1.5', () => {
     it('should implement a provider metadata accessor and mutator', () => {
       expect(OpenFeature.providerMetadata).toBeDefined();
     });
   });
 
-  describe('Requirement 1.1.5', () => {
+  describe('Requirement 1.1.6', () => {
     it('should implement a client factory', () => {
       expect(OpenFeature.getClient).toBeDefined();
       expect(OpenFeature.getClient()).toBeInstanceOf(OpenFeatureClient);
@@ -76,11 +107,23 @@ describe('OpenFeature', () => {
       expect(namedClient.metadata.name).toEqual(name);
     });
 
+    it('should return a client with the default provider if no provider has been bound to the name', () => {
+      const namedClient = OpenFeature.getClient('unbound');
+      expect(namedClient.metadata.provider.name).toEqual(OpenFeature.providerMetadata.name);
+    });
+
+    it('should return a client with the provider bound to the name', () => {
+      const name = 'my-client';
+      const fakeProvider = { metadata: { name: 'test' } } as unknown as Provider;
+      OpenFeature.setProvider(name, fakeProvider);
+
+      const namedClient = OpenFeature.getClient(name);
+
+      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+    });
+
     it('should be chainable', () => {
-      const client = OpenFeature.addHooks()
-        .clearHooks()
-        .setLogger(console)
-        .getClient();
+      const client = OpenFeature.addHooks().clearHooks().setLogger(console).getClient();
       expect(client).toBeDefined();
     });
   });
@@ -89,11 +132,10 @@ describe('OpenFeature', () => {
     it('MUST define a `shutdown` function, which, when called, must call the respective `shutdown` function on the active provider', (done) => {
       OpenFeature.setProvider(MOCK_PROVIDER);
       expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
-      OpenFeature.close().then(
-        () => {
-          expect(MOCK_PROVIDER.onClose).toHaveBeenCalled();
-          done();
-        });
+      OpenFeature.close().then(() => {
+        expect(MOCK_PROVIDER.onClose).toHaveBeenCalled();
+        done();
+      });
     });
   });
 });

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -1,12 +1,17 @@
 import {
   ClientMetadata,
-  ErrorCode, EvaluationContext,
+  ErrorCode,
+  EvaluationContext,
   EvaluationDetails,
   FlagValue,
   FlagValueType,
   HookContext,
   JsonValue,
-  Logger, OpenFeatureError, ResolutionDetails, SafeLogger, StandardResolutionReasons
+  Logger,
+  OpenFeatureError,
+  ResolutionDetails,
+  SafeLogger,
+  StandardResolutionReasons,
 } from '@openfeature/shared';
 import { OpenFeature } from './open-feature';
 import { Client, FlagEvaluationOptions, Hook, Provider } from './types';
@@ -15,7 +20,6 @@ type OpenFeatureClientOptions = {
   name?: string;
   version?: string;
 };
-
 
 export class OpenFeatureClient implements Client {
   readonly metadata: ClientMetadata;
@@ -34,7 +38,8 @@ export class OpenFeatureClient implements Client {
     this.metadata = {
       name: options.name,
       version: options.version,
-    } as const;
+      provider: this.providerAccessor().metadata,
+    };
     this._context = context;
   }
 

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -38,7 +38,7 @@ export class OpenFeatureClient implements Client {
     this.metadata = {
       name: options.name,
       version: options.version,
-      provider: this.providerAccessor().metadata,
+      providerMetadata: this.providerAccessor().metadata,
     };
     this._context = context;
   }

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -15,7 +15,7 @@ const _globalThis = globalThis as OpenFeatureGlobal;
 
 export class OpenFeatureAPI extends OpenFeatureCommonAPI {
   protected _hooks: Hook[] = [];
-  protected _provider: Provider = NOOP_PROVIDER;
+  protected _defaultProvider: Provider = NOOP_PROVIDER;
   protected _providers: Map<string, Provider> = new Map();
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -51,7 +51,7 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * @returns {ProviderMetadata} Provider Metadata
    */
   get providerMetadata(): ProviderMetadata {
-    return this._provider.metadata;
+    return this._defaultProvider.metadata;
   }
 
   addHooks(...hooks: Hook<FlagValue>[]): this {
@@ -74,7 +74,8 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
   }
 
   /**
-   * Sets the provider that OpenFeature will use for flag evaluations of clients without a name.
+   * Sets the default provider for flag evaluations.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
    * Setting a provider supersedes the current provider used in new and existing clients without a name.
    *
    * @param {Provider} provider The provider responsible for flag evaluations.
@@ -91,17 +92,17 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    */
   setProvider(clientName: string, provider: Provider): this;
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
-    const client = stringOrUndefined(clientOrProvider);
+    const clientName = stringOrUndefined(clientOrProvider);
     const provider = objectOrUndefined<Provider>(clientOrProvider) ?? objectOrUndefined<Provider>(providerOrUndefined);
 
     if (!provider) {
       return this;
     }
 
-    if (client) {
-      this._providers.set(client, provider);
+    if (clientName) {
+      this._providers.set(clientName, provider);
     } else {
-      this._provider = provider;
+      this._defaultProvider = provider;
     }
 
     return this;
@@ -169,10 +170,10 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
   private getProviderForClient(name?: string): Provider {
     if (!name) {
-      return this._provider;
+      return this._defaultProvider;
     }
 
-    return this._providers.get(name) ?? this._provider;
+    return this._providers.get(name) ?? this._defaultProvider;
   }
 }
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -3,6 +3,7 @@ import { Logger, OpenFeatureCommonAPI, SafeLogger } from '@openfeature/shared';
 import { EvaluationContext, FlagValue, ProviderMetadata } from '@openfeature/shared';
 import { OpenFeatureClient } from './client';
 import { Client, Hook, Provider } from './types';
+import { objectOrUndefined, stringOrUndefined } from '@openfeature/shared/src/type-guards';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
@@ -15,6 +16,7 @@ const _globalThis = globalThis as OpenFeatureGlobal;
 export class OpenFeatureAPI extends OpenFeatureCommonAPI {
   protected _hooks: Hook[] = [];
   protected _provider: Provider = NOOP_PROVIDER;
+  protected _providers: Map<string, Provider> = new Map();
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {
@@ -71,21 +73,106 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
     return this;
   }
 
-  setProvider(provider: Provider): this {
-    // ignore no-ops
-    if (this._provider !== provider) {
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations of clients without a name.
+   * Setting a provider supersedes the current provider used in new and existing clients without a name.
+   *
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {GlobalApi} OpenFeature API
+   */
+  setProvider(provider: Provider): this;
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations of clients with the given name.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   *
+   * @param {string} client The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {GlobalApi} OpenFeature API
+   */
+  setProvider(client: string, provider: Provider): this;
+  setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
+    const client = stringOrUndefined(clientOrProvider);
+    const provider = objectOrUndefined<Provider>(clientOrProvider) ?? objectOrUndefined<Provider>(providerOrUndefined);
+
+    if (!provider) {
+      return this;
+    }
+
+    if (client) {
+      this._providers.set(client, provider);
+    } else {
       this._provider = provider;
     }
+
     return this;
   }
 
-  getClient(name?: string, version?: string, context?: EvaluationContext): Client {
+  /**
+   * A factory function for creating new unnamed OpenFeature clients. Clients can contain
+   * their own state (e.g. logger, hook, context). Multiple clients can be used
+   * to segment feature flag configuration.
+   *
+   * All unnamed clients use the same provider set via {@link this.setProvider setProvider}.
+   *
+   * @param {string} name The name of the client
+   * @param {string} version The version of the client (only used for metadata)
+   * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
+   * @returns {Client} OpenFeature Client
+   */
+  getClient(context?: EvaluationContext): Client;
+  /**
+   * A factory function for creating new named OpenFeature clients. Clients can contain
+   * their own state (e.g. logger, hook, context). Multiple clients can be used
+   * to segment feature flag configuration.
+   *
+   * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
+   * Otherwise, the default provider is used until a provider is assigned to that name.
+   *
+   * @param {string} name The name of the client
+   * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
+   * @returns {Client} OpenFeature Client
+   */
+  getClient(name: string, context?: EvaluationContext): Client;
+  /**
+   * A factory function for creating new named OpenFeature clients. Clients can contain
+   * their own state (e.g. logger, hook, context). Multiple clients can be used
+   * to segment feature flag configuration.
+   *
+   * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
+   * Otherwise, the default provider is used until a provider is assigned to that name.
+   *
+   * @param {string} name The name of the client
+   * @param {string} version The version of the client (only used for metadata)
+   * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
+   * @returns {Client} OpenFeature Client
+   */
+  getClient(name: string, version: string, context?: EvaluationContext): Client;
+  getClient(
+    nameOrContext?: string | EvaluationContext,
+    versionOrContext?: string | EvaluationContext,
+    contextOrUndefined?: EvaluationContext
+  ): Client {
+    const name = stringOrUndefined(nameOrContext);
+    const version = stringOrUndefined(versionOrContext);
+    const context =
+      objectOrUndefined<EvaluationContext>(nameOrContext) ??
+      objectOrUndefined<EvaluationContext>(versionOrContext) ??
+      objectOrUndefined<EvaluationContext>(contextOrUndefined);
+
     return new OpenFeatureClient(
-      () => this._provider,
+      () => this.getProviderForClient.bind(this)(name),
       () => this._logger,
       { name, version },
       context
     );
+  }
+
+  private getProviderForClient(name?: string): Provider {
+    if (!name) {
+      return this._provider;
+    }
+
+    return this._providers.get(name) ?? this._provider;
   }
 }
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -30,7 +30,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
   /**
    * Gets a singleton instance of the OpenFeature API.
-   *
    * @ignore
    * @returns {OpenFeatureAPI} OpenFeature API
    */
@@ -47,7 +46,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
   /**
    * Get metadata about registered provider.
-   *
    * @returns {ProviderMetadata} Provider Metadata
    */
   get providerMetadata(): ProviderMetadata {
@@ -77,18 +75,16 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * Sets the default provider for flag evaluations.
    * This provider will be used by unnamed clients and named clients to which no provider is bound.
    * Setting a provider supersedes the current provider used in new and existing clients without a name.
-   *
    * @param {Provider} provider The provider responsible for flag evaluations.
-   * @returns {GlobalApi} OpenFeature API
+   * @returns {OpenFeatureAPI} OpenFeature API
    */
   setProvider(provider: Provider): this;
   /**
    * Sets the provider that OpenFeature will use for flag evaluations of clients with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
-   *
    * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
-   * @returns {GlobalApi} OpenFeature API
+   * @returns {OpenFeatureAPI} OpenFeature API
    */
   setProvider(clientName: string, provider: Provider): this;
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
@@ -114,7 +110,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * to segment feature flag configuration.
    *
    * All unnamed clients use the same provider set via {@link this.setProvider setProvider}.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client (only used for metadata)
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
@@ -128,7 +123,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    *
    * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
    * Otherwise, the default provider is used until a provider is assigned to that name.
-   *
    * @param {string} name The name of the client
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
    * @returns {Client} OpenFeature Client
@@ -141,7 +135,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    *
    * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
    * Otherwise, the default provider is used until a provider is assigned to that name.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client (only used for metadata)
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
@@ -179,7 +172,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
 
 /**
  * A singleton instance of the OpenFeature API.
- *
  * @returns {OpenFeatureAPI} OpenFeature API
  */
 export const OpenFeature = OpenFeatureAPI.getInstance();

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -85,11 +85,11 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI {
    * Sets the provider that OpenFeature will use for flag evaluations of clients with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
    *
-   * @param {string} client The name to identify the client
+   * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API
    */
-  setProvider(client: string, provider: Provider): this;
+  setProvider(clientName: string, provider: Provider): this;
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): this {
     const client = stringOrUndefined(clientOrProvider);
     const provider = objectOrUndefined<Provider>(clientOrProvider) ?? objectOrUndefined<Provider>(providerOrUndefined);

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -76,7 +76,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
   /**
    * Runs before flag values are resolved from the provider.
    * If an EvaluationContext is returned, it will be merged with the pre-existing EvaluationContext.
-   *
    * @param hookContext
    * @param hookHints
    */
@@ -87,7 +86,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
 
   /**
    * Runs after flag values are successfully resolved from the provider.
-   *
    * @param hookContext
    * @param evaluationDetails
    * @param hookHints
@@ -100,7 +98,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
 
   /**
    * Runs in the event of an unhandled error or promise rejection during flag resolution, or any attached hooks.
-   *
    * @param hookContext
    * @param error
    * @param hookHints
@@ -110,7 +107,6 @@ export interface Hook<T extends FlagValue = FlagValue> {
   /**
    * Runs after all other hook stages, regardless of success or error.
    * Errors thrown here are unhandled by the client and will surface in application code.
-   *
    * @param hookContext
    * @param hookHints
    */
@@ -124,7 +120,6 @@ interface EvaluationLifeCycle<T> {
    * will not remove existing hooks.
    * Hooks registered on the global API object run with all evaluations.
    * Hooks registered on the client run with all evaluations on that client.
-   *
    * @template T The type of the receiver
    * @param {Hook<FlagValue>[]} hooks A list of hooks that should always run
    * @returns {T} The receiver (this object)
@@ -133,14 +128,12 @@ interface EvaluationLifeCycle<T> {
 
   /**
    * Access all the hooks that are registered on this receiver.
-   *
    * @returns {Hook<FlagValue>[]} A list of the client hooks
    */
   getHooks(): Hook[];
 
   /**
    * Clears all the hooks that are registered on this receiver.
-   *
    * @template T The type of the receiver
    * @returns {T} The receiver (this object)
    */
@@ -155,7 +148,6 @@ export interface FlagEvaluationOptions {
 export interface Features {
   /**
    * Performs a flag evaluation that returns a boolean.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
@@ -171,7 +163,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
@@ -187,7 +178,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns a string.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {string} T A optional generic argument constraining the string
    * @param {T} defaultValue The value returned if an error occurs
@@ -211,7 +201,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {string} T A optional generic argument constraining the string
    * @param {T} defaultValue The value returned if an error occurs
@@ -235,7 +224,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns a number.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {number} T A optional generic argument constraining the number
    * @param {T} defaultValue The value returned if an error occurs
@@ -259,7 +247,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {number} T A optional generic argument constraining the number
    * @param {T} defaultValue The value returned if an error occurs
@@ -283,7 +270,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that returns an object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {JsonValue} T A optional generic argument describing the structure
    * @param {T} defaultValue The value returned if an error occurs
@@ -307,7 +293,6 @@ export interface Features {
 
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
-   *
    * @param {string} flagKey The flag key uniquely identifies a particular flag
    * @template {JsonValue} T A optional generic argument describing the structure
    * @param {T} defaultValue The value returned if an error occurs
@@ -347,7 +332,6 @@ export interface GlobalApi
    * to segment feature flag configuration.
    *
    * All unnamed clients use the same provider set via {@link this.setProvider setProvider}.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client (only used for metadata)
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
@@ -362,7 +346,6 @@ export interface GlobalApi
    *
    * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
    * Otherwise, the default provider is used until a provider is assigned to that name.
-   *
    * @param {string} name The name of the client
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
    * @returns {Client} OpenFeature Client
@@ -376,7 +359,6 @@ export interface GlobalApi
    *
    * If there is already a provider bound to this name via {@link this.setProvider setProvider}, this provider will be used.
    * Otherwise, the default provider is used until a provider is assigned to that name.
-   *
    * @param {string} name The name of the client
    * @param {string} version The version of the client (only used for metadata)
    * @param {EvaluationContext} context Evaluation context that should be set on the client to used during flag evaluations
@@ -396,7 +378,6 @@ export interface GlobalApi
    * Sets the default provider for flag evaluations.
    * This provider will be used by unnamed clients and named clients to which no provider is bound.
    * Setting a provider supersedes the current provider used in new and existing clients without a name.
-   *
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API
    */
@@ -405,7 +386,6 @@ export interface GlobalApi
   /**
    * Sets the provider that OpenFeature will use for flag evaluations of clients with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
-   *
    * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -393,7 +393,8 @@ export interface GlobalApi
   getClient(name?: string, version?: string, context?: EvaluationContext): Client;
 
   /**
-   * Sets the provider that OpenFeature will use for flag evaluations of clients without a name.
+   * Sets the default provider for flag evaluations.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
    * Setting a provider supersedes the current provider used in new and existing clients without a name.
    *
    * @param {Provider} provider The provider responsible for flag evaluations.

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -405,11 +405,11 @@ export interface GlobalApi
    * Sets the provider that OpenFeature will use for flag evaluations of clients with the given name.
    * Setting a provider supersedes the current provider used in new and existing clients with that name.
    *
-   * @param {string} client The name to identify the client
+   * @param {string} clientName The name to identify the client
    * @param {Provider} provider The provider responsible for flag evaluations.
    * @returns {GlobalApi} OpenFeature API
    */
-  setProvider(client: string, provider: Provider): GlobalApi;
+  setProvider(clientName: string, provider: Provider): GlobalApi;
 
   setProvider(clientOrProvider?: string | Provider, providerOrUndefined?: Provider): GlobalApi;
 }

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -33,7 +33,7 @@ describe('OpenFeature', () => {
     it('should set the default provider if no name is provided', () => {
       OpenFeature.setProvider(MOCK_PROVIDER);
       const client = OpenFeature.getClient();
-      expect(client.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
+      expect(client.metadata.providerMetadata.name).toEqual(MOCK_PROVIDER.metadata.name);
     });
 
     it('should not change named providers when setting a new default provider', () => {
@@ -45,8 +45,8 @@ describe('OpenFeature', () => {
       const unnamedClient = OpenFeature.getClient();
       const namedClient = OpenFeature.getClient(name);
 
-      expect(unnamedClient.metadata.provider.name).toEqual(MOCK_PROVIDER.metadata.name);
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(unnamedClient.metadata.providerMetadata.name).toEqual(MOCK_PROVIDER.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
 
     it('should assign a new provider to existing clients', () => {
@@ -57,7 +57,7 @@ describe('OpenFeature', () => {
       const namedClient = OpenFeature.getClient(name);
       OpenFeature.setProvider(name, fakeProvider);
 
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
   });
 
@@ -88,7 +88,7 @@ describe('OpenFeature', () => {
 
     it('should return a client with the default provider if no provider has been bound to the name', () => {
       const namedClient = OpenFeature.getClient('unbound');
-      expect(namedClient.metadata.provider.name).toEqual(OpenFeature.providerMetadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(OpenFeature.providerMetadata.name);
     });
 
     it('should return a client with the provider bound to the name', () => {
@@ -98,7 +98,7 @@ describe('OpenFeature', () => {
       OpenFeature.setProvider(name, fakeProvider);
       const namedClient = OpenFeature.getClient(name);
 
-      expect(namedClient.metadata.provider.name).toEqual(fakeProvider.metadata.name);
+      expect(namedClient.metadata.providerMetadata.name).toEqual(fakeProvider.metadata.name);
     });
   });
 

--- a/packages/shared/src/type-guards.ts
+++ b/packages/shared/src/type-guards.ts
@@ -1,15 +1,35 @@
+/**
+ * Checks whether the parameter is a string.
+ * @param {unknown} value The value to check
+ * @returns {value is string} True if the value is a string
+ */
 export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
+/**
+ * Returns the parameter if it is a string, otherwise returns undefined.
+ * @param {unknown} value The value to check
+ * @returns {string|undefined} The parameter if it is a string, otherwise undefined
+ */
 export function stringOrUndefined(value: unknown): string | undefined {
   return isString(value) ? value : undefined;
 }
 
+/**
+ * Checks whether the parameter is an object.
+ * @param {unknown} value The value to check
+ * @returns {value is string} True if the value is an object
+ */
 export function isObject<T extends object>(value: unknown): value is T {
   return typeof value === 'object';
 }
 
+/**
+ * Returns the parameter if it is an object, otherwise returns undefined.
+ * @param {unknown} value The value to check
+ * @returns {object|undefined} The parameter if it is an object, otherwise undefined
+ */
 export function objectOrUndefined<T extends object>(value: unknown): T | undefined {
   return isObject<T>(value) ? value : undefined;
 }

--- a/packages/shared/src/type-guards.ts
+++ b/packages/shared/src/type-guards.ts
@@ -1,0 +1,15 @@
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function stringOrUndefined(value: unknown): string | undefined {
+  return isString(value) ? value : undefined;
+}
+
+export function isObject<T extends object>(value: unknown): value is T {
+  return typeof value === 'object';
+}
+
+export function objectOrUndefined<T extends object>(value: unknown): T | undefined {
+  return isObject<T>(value) ? value : undefined;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -189,7 +189,7 @@ interface Metadata {}
 export interface ClientMetadata extends Metadata {
   readonly version?: string;
   readonly name?: string;
-  readonly provider: ProviderMetadata;
+  readonly providerMetadata: ProviderMetadata;
 }
 
 export interface ProviderMetadata extends Metadata {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -151,7 +151,6 @@ export type EvaluationDetails<T extends FlagValue> = {
 export interface ManageContext<T> {
   /**
    * Access the evaluation context set on the receiver.
-   *
    * @returns {EvaluationContext} Evaluation context
    */
   getContext(): EvaluationContext;
@@ -159,7 +158,6 @@ export interface ManageContext<T> {
   /**
    * Sets evaluation context that will be used during flag evaluations
    * on this receiver.
-   *
    * @template T The type of the receiver
    * @param {EvaluationContext} context Evaluation context
    * @returns {T} The receiver (this object)
@@ -173,7 +171,6 @@ export interface ManageLogger<T> {
    * and is passed to various components in the SDK.
    * The logger configured on the global API object will be used for all evaluations,
    * unless overridden in a particular client.
-   *
    * @template T The type of the receiver
    * @param {Logger} logger The logger to be used
    * @returns {T} The receiver (this object)
@@ -225,7 +222,6 @@ export interface ManageTransactionContextPropagator<T> extends TransactionContex
    * Sets a transaction context propagator on this receiver. The transaction context
    * propagator is responsible for persisting context for the duration of a single
    * transaction.
-   *
    * @experimental
    * @template T The type of the receiver
    * @param {TransactionContextPropagator} transactionContextPropagator The context propagator to be used
@@ -241,7 +237,6 @@ export interface TransactionContextPropagator {
    *
    * Returns the currently defined transaction context using the registered transaction
    * context propagator.
-   *
    * @experimental
    * @returns {TransactionContext} The current transaction context
    */
@@ -252,7 +247,6 @@ export interface TransactionContextPropagator {
    * The OpenFeature Enhancement Proposal regarding transaction context can be found [here](https://github.com/open-feature/ofep/pull/32).
    *
    * Sets the transaction context using the registered transaction context propagator.
-   *
    * @experimental
    * @template R The return value of the callback
    * @param {TransactionContext} transactionContext The transaction specific context

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -34,11 +34,13 @@ export type FlagValue = boolean | string | number | JsonValue;
 
 export type FlagValueType = 'boolean' | 'string' | 'number' | 'object';
 
-
 export interface Logger {
   error(...args: unknown[]): void;
+
   warn(...args: unknown[]): void;
+
   info(...args: unknown[]): void;
+
   debug(...args: unknown[]): void;
 }
 
@@ -59,7 +61,7 @@ export const StandardResolutionReasons = {
   DISABLED: 'DISABLED',
 
   /**
-   * 	The resolved value was configured statically, or otherwise fell back to a pre-configured value.
+   *  The resolved value was configured statically, or otherwise fell back to a pre-configured value.
    */
   DEFAULT: 'DEFAULT',
 
@@ -67,12 +69,12 @@ export const StandardResolutionReasons = {
    * The reason for the resolved value could not be determined.
    */
   UNKNOWN: 'UNKNOWN',
-  
+
   /**
    * The resolved value is static (no dynamic evaluation).
    */
   STATIC: 'STATIC',
-  
+
   /**
    * The resolved value was retrieved from cache.
    */
@@ -187,6 +189,7 @@ interface Metadata {}
 export interface ClientMetadata extends Metadata {
   readonly version?: string;
   readonly name?: string;
+  readonly provider: ProviderMetadata;
 }
 
 export interface ProviderMetadata extends Metadata {
@@ -263,7 +266,14 @@ export interface TransactionContextPropagator {
   ): void;
 }
 
+export enum ProviderStatus {
+  NOT_READY = 'NOT_READY',
+  READY = 'READY',
+  ERROR = 'ERROR',
+}
+
 export interface CommonProvider {
   readonly metadata: ProviderMetadata;
+  readonly status?: ProviderStatus;
   // TODO: move close from client Provider here once we want it in server
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Implements named client support. #428 

Had to also add the provider status that is defined in the provider lifecycle and used for events.


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
Fixes #428 

### Notes
This feature is part of the recently released v0.6.0 of the OpenFeature spec.

### Follow-up Tasks
I would after this continue with the events and init/shutdown to round everything up.

### How to test
Tests are included for both client and server.

