### PR TITLE
fix: use a different symbol for server/client

### DIFF
--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -4,7 +4,7 @@ import { NOOP_PROVIDER } from './no-op-provider';
 import { Client, Hook, Provider } from './types';
 
 // use a symbol as a key for the global singleton
-const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
+const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');
 
 type OpenFeatureGlobal = {
   [GLOBAL_OPENFEATURE_API_KEY]?: OpenFeatureAPI;

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -6,7 +6,7 @@ import { Client, Hook, Provider } from './types';
 import { objectOrUndefined, stringOrUndefined } from '@openfeature/shared/src/type-guards';
 
 // use a symbol as a key for the global singleton
-const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js.api');
+const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js-sdk/api');
 
 type OpenFeatureGlobal = {
   [GLOBAL_OPENFEATURE_API_KEY]?: OpenFeatureAPI;


### PR DESCRIPTION
Fixes an issue that can cause bunders in repos with both the web-sdk and js-sdk to incorrectly resolve and bundle module components because both modules use the same global symbols for the API.