### PR TITLE
chore: import fixes to fix e2e tests

### DIFF
--- a/packages/client/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/client/e2e/step-definitions/evaluation.spec.ts
@@ -7,7 +7,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/shared';
-import { OpenFeature, ProviderEvents } from '../../src';
+import { OpenFeature, ProviderEvents } from '../..';
 // load the feature file.
 const feature = loadFeature('packages/client/e2e/features/evaluation.feature');
 

--- a/packages/client/e2e/step-definitions/setup.ts
+++ b/packages/client/e2e/step-definitions/setup.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { OpenFeature } from '../../';
+import { OpenFeature } from '../..';
 import { FlagdWebProvider } from '@openfeature/flagd-web-provider';
 
 const FLAGD_NAME = 'flagd-web';

--- a/packages/server/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/server/e2e/step-definitions/evaluation.spec.ts
@@ -8,7 +8,7 @@ import {
   StandardResolutionReasons,
   ProviderEvents,
 } from '@openfeature/shared';
-import { OpenFeature } from './../../src';
+import { OpenFeature } from '../..';
 // load the feature file.
 const feature = loadFeature('packages/server/e2e/features/evaluation.feature');
 

--- a/packages/server/e2e/step-definitions/setup.ts
+++ b/packages/server/e2e/step-definitions/setup.ts
@@ -1,6 +1,5 @@
-
 import assert from 'assert';
-import { OpenFeature } from '../../src';
+import { OpenFeature } from '../..';
 import { FlagdProvider } from '@openfeature/flagd-provider';
 
 const FLAGD_NAME = 'flagd Provider';
@@ -8,5 +7,8 @@ const FLAGD_NAME = 'flagd Provider';
 // register the flagd provider before the tests.
 console.log('Setting flagd provider...');
 OpenFeature.setProvider(new FlagdProvider({ cache: 'disabled' }));
-assert(OpenFeature.providerMetadata.name === FLAGD_NAME, new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`));
+assert(
+  OpenFeature.providerMetadata.name === FLAGD_NAME,
+  new Error(`Expected ${FLAGD_NAME} provider to be configured, instead got: ${OpenFeature.providerMetadata.name}`)
+);
 console.log('flagd provider configured!');


### PR DESCRIPTION
Both the server and client e2e tests run fine in the CI, but in some local scenarios the "deep imports" we used were causing issues with module resolution.

I've updated the e2e test to always import from the "top level" instead of the /src sub-directory in the test suite.