### PR TITLE
docs: update server-side readme to explicitly mention node.js

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -8,7 +8,7 @@
   </picture>
 </p>
 
-<h2 align="center">OpenFeature JS Server-side SDK</h2>
+<h2 align="center">OpenFeature Node.js SDK</h2>
 
 <!-- x-hide-in-docs-end -->
 <!-- The 'github-badges' class is used in the docs -->


### PR DESCRIPTION
## This PR

- update the server-side readme to state that it's intended for use in node.js environments

### Notes

Now that we have client and server SDK, it's important that we clearly denote what each SDK was decided for. Currently, we're only testing the node.js runtime, so I think it makes sense to explicitly state that at the top of the readme. We may support other runtimes in the future (e.g. Deno, Bun). If this happens, we can update the description with the additional runtimes.

### Follow-up Tasks

Update the documentation to say Node.js instead of server-side JS.
