### PR TITLE
feat: react sdk groundwork

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "packages/react": "0.0.1-experimental",
   "packages/client": "0.4.0",
   "packages/server": "1.4.2",
   "packages/shared": "0.0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "workspaces": [
+        "packages/shared",
         "packages/server",
         "packages/client",
-        "packages/shared"
+        "packages/react"
       ],
       "devDependencies": {
         "@openfeature/flagd-provider": "^0.8.1",
@@ -1359,6 +1360,10 @@
     },
     "node_modules/@openfeature/js-sdk": {
       "resolved": "packages/server",
+      "link": true
+    },
+    "node_modules/@openfeature/react-sdk": {
+      "resolved": "packages/react",
       "link": true
     },
     "node_modules/@openfeature/shared": {
@@ -9400,8 +9405,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -9598,7 +9602,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10450,7 +10453,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12540,6 +12542,17 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/shared": "*"
+      }
+    },
+    "packages/react": {
+      "version": "0.0.1-experimental",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@openfeature/web-sdk": "*"
+      },
+      "peerDependencies": {
+        "@openfeature/web-sdk": ">0.4.0",
+        "react": ">18.0.0"
       }
     },
     "packages/server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/events": "^3.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "^18.0.3",
+        "@types/react": "^18.2.20",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
         "esbuild": "^0.17.0",
@@ -39,6 +40,7 @@
         "jest-environment-node": "^29.4.3",
         "jest-junit": "^16.0.0",
         "prettier": "^2.6.2",
+        "react": "^18.2.0",
         "rollup": "^3.18.0",
         "rollup-plugin-dts": "^5.2.0",
         "shx": "^0.3.4",
@@ -1721,6 +1723,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.20.tgz",
+      "integrity": "sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.3.12",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
@@ -2949,6 +2974,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
     },
     "node_modules/cucumber-messages": {
@@ -9563,6 +9594,18 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "dev": true,
@@ -10402,6 +10445,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "e2e-server": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/server/e2e/features && jest --selectProjects=server-e2e --verbose",
     "e2e-client": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/client/e2e/features && jest --selectProjects=client-e2e --verbose",
     "e2e": "npm run e2e-server && npm run e2e-client",
-    "lint": "npm run lint --workspace=packages/shared --workspace=packages/client --workspace=packages/server",
+    "lint": "npm run lint --workspace=packages/shared --workspace=packages/server --workspace=packages/client --workspace=packages/react",
     "clean": "shx rm -rf ./dist",
-    "build": "npm run build --workspace=packages/shared --workspace=packages/client --workspace=packages/server",
-    "publish-all": "npm run publish-if-not-exists --workspace=packages/client --workspace=packages/server",
+    "build": "npm run build --workspace=packages/shared --workspace=packages/server --workspace=packages/client --workspace=packages/react",
+    "publish-all": "npm run publish-if-not-exists --workspace=packages/server --workspace=packages/client --workspace=packages/react",
     "docs": "typedoc"
   },
   "repository": {
@@ -41,6 +41,7 @@
     "@types/events": "^3.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.0.3",
+    "@types/react": "^18.2.20",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
     "esbuild": "^0.17.0",
@@ -59,6 +60,7 @@
     "jest-environment-node": "^29.4.3",
     "jest-junit": "^16.0.0",
     "prettier": "^2.6.2",
+    "react": "^18.2.0",
     "rollup": "^3.18.0",
     "rollup-plugin-dts": "^5.2.0",
     "shx": "^0.3.4",
@@ -69,8 +71,9 @@
     "uuid": "^9.0.0"
   },
   "workspaces": [
+    "packages/shared",
     "packages/server",
     "packages/client",
-    "packages/shared"
+    "packages/react"
   ]
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,8 +33,7 @@ Here's a basic example of how ot use the current API with flagd:
 ```js
 import logo from './logo.svg';
 import './App.css';
-import { OpenFeatureProvider, useFeatureFlag,  } from '@openfeature/react-sdk';
-import { OpenFeature } from '@openfeature/web-sdk';
+import { OpenFeatureProvider, useFeatureFlag, OpenFeature } from '@openfeature/react-sdk';
 import { FlagdWebProvider } from '@openfeature/flagd-web-provider';
 
 const provider = new FlagdWebProvider({

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,28 @@
+<!-- markdownlint-disable MD033 -->
+<!-- x-hide-in-docs-start -->
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
+    <img align="center" alt="OpenFeature Logo">
+  </picture>
+</p>
+
+<h2 align="center">OpenFeature React SDK</h2>
+
+<!-- x-hide-in-docs-end -->
+<!-- The 'github-badges' class is used in the docs -->
+<p align="center" class="github-badges">
+  <a href="https://github.com/open-feature/spec/tree/v0.6.0">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.6.0&color=yellow&style=for-the-badge" />
+  </a>
+  <br/>
+  <a href="https://codecov.io/gh/open-feature/js-sdk">
+    <img alt="codecov" src="https://codecov.io/gh/open-feature/js-sdk/branch/main/graph/badge.svg?token=3DC5XOEHMY" />
+  </a>
+</p>
+<!-- x-hide-in-docs-start -->
+
+[OpenFeature](https://openfeature.dev) is an open standard that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
+
+🧪 This is SDK is experimental.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,7 +33,8 @@ Here's a basic example of how ot use the current API with flagd:
 ```js
 import logo from './logo.svg';
 import './App.css';
-import { OpenFeatureProvider, OpenFeature, useFeatureFlag,  } from '@openfeature/react-sdk';
+import { OpenFeatureProvider, useFeatureFlag,  } from '@openfeature/react-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
 import { FlagdWebProvider } from '@openfeature/flagd-web-provider';
 
 const provider = new FlagdWebProvider({

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -26,3 +26,43 @@
 [OpenFeature](https://openfeature.dev) is an open standard that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
 
 🧪 This is SDK is experimental.
+
+
+Here's a basic example of how ot use the current API with flagd:
+
+```js
+import logo from './logo.svg';
+import './App.css';
+import { OpenFeatureProvider, OpenFeature, useFeatureFlag,  } from '@openfeature/react-sdk';
+import { FlagdWebProvider } from '@openfeature/flagd-web-provider';
+
+const provider = new FlagdWebProvider({
+  host: 'localhost',
+  port: 8013,
+  tls: false,
+  maxRetries: 0,
+});
+OpenFeature.setProvider(provider)
+
+function App() {
+  return (
+    <OpenFeatureProvider>
+      <Page></Page>
+    </OpenFeatureProvider>
+  );
+}
+
+function Page() {
+  const booleanFlag = useFeatureFlag('new-welcome-message', false);
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        {booleanFlag ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
+      </header>
+    </div>
+  )
+}
+
+export default App;
+```

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,8 +47,8 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": ">0.4.0",
-    "react": ">18.0.0"
+    "@openfeature/web-sdk": ">=0.4.0",
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@openfeature/web-sdk": "*"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@openfeature/react-sdk",
+  "version": "0.0.1-experimental",
+  "description": "OpenFeature React SDK",
+  "main": "./dist/cjs/index.js",
+  "files": [
+    "dist/"
+  ],
+  "exports": {
+    "types": "./dist/types.d.ts",
+    "import": "./dist/esm/index.js",
+    "require": "./dist/cjs/index.js",
+    "default": "./dist/cjs/index.js"
+  },
+  "types": "./dist/types.d.ts",
+  "scripts": {
+    "test": "jest --verbose",
+    "lint": "eslint ./",
+    "clean": "shx rm -rf ./dist",
+    "build:react-esm": "esbuild src/index.ts --bundle  --external:react --external:@openfeature/web-sdk --sourcemap --target=es2016 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
+    "build:react-cjs": "esbuild src/index.ts --bundle  --external:react --external:@openfeature/web-sdk --sourcemap --target=es2016 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",
+    "build:rollup-types": "rollup -c ../../rollup.config.mjs",
+    "build": "npm run clean && npm run build:react-esm && npm run build:react-cjs && npm run build:rollup-types",
+    "postbuild": "shx cp ./../../package.esm.json ./dist/esm/package.json",
+    "current-version": "echo $npm_package_version",
+    "prepack": "shx cp ./../../LICENSE ./LICENSE",
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi",
+    "docs": "typedoc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-feature/js-sdk.git"
+  },
+  "keywords": [
+    "openfeature",
+    "feature",
+    "flags",
+    "toggles",
+    "browser",
+    "web",
+    "react"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/open-feature/js-sdk/issues"
+  },
+  "homepage": "https://github.com/open-feature/js-sdk#readme",
+  "peerDependencies": {
+    "@openfeature/web-sdk": ">0.4.0",
+    "react": ">18.0.0"
+  },
+  "devDependencies": {
+    "@openfeature/web-sdk": "*"
+  },
+  "typedoc": {
+    "displayName": "OpenFeature React SDK",
+    "entryPoint": "./src/index.ts"
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,2 @@
-export * from './use-feature-flag'
-export * from './provider'
+export * from './use-feature-flag';
+export * from './provider';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,2 @@
+export * from './use-feature-flag'
+export * from './provider'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,4 @@
 export * from './use-feature-flag';
 export * from './provider';
+// re-export the web-sdk so consumers can access that API from the react-sdk
+export * from '@openfeature/web-sdk';

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { Client, OpenFeature } from '@openfeature/web-sdk'
+
+type ProviderProps = {
+  client?: Client
+  children?: React.ReactNode
+}
+
+const Context = React.createContext<Client | undefined>(undefined)
+
+export const OpenFeatureProvider = ({ client, children }: ProviderProps) => {
+  if (!client) {
+    client = OpenFeature.getClient()
+  }
+
+  return <Context.Provider value={client}>{children}</Context.Provider>
+}
+
+export const useOpenFeatureClient = () => {
+  const client = React.useContext(Context)
+
+  if (!client) {
+    throw new Error(
+      'No OpenFeature client available - components using OpenFeature must be wrapped with an <OpenFeatureProvider>'
+    )
+  }
+
+  return client
+}

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,29 +1,29 @@
-import * as React from 'react'
-import { Client, OpenFeature } from '@openfeature/web-sdk'
+import * as React from 'react';
+import { Client, OpenFeature } from '@openfeature/web-sdk';
 
 type ProviderProps = {
-  client?: Client
-  children?: React.ReactNode
-}
+  client?: Client;
+  children?: React.ReactNode;
+};
 
-const Context = React.createContext<Client | undefined>(undefined)
+const Context = React.createContext<Client | undefined>(undefined);
 
 export const OpenFeatureProvider = ({ client, children }: ProviderProps) => {
   if (!client) {
-    client = OpenFeature.getClient()
+    client = OpenFeature.getClient();
   }
 
-  return <Context.Provider value={client}>{children}</Context.Provider>
-}
+  return <Context.Provider value={client}>{children}</Context.Provider>;
+};
 
 export const useOpenFeatureClient = () => {
-  const client = React.useContext(Context)
+  const client = React.useContext(Context);
 
   if (!client) {
     throw new Error(
       'No OpenFeature client available - components using OpenFeature must be wrapped with an <OpenFeatureProvider>'
-    )
+    );
   }
 
-  return client
-}
+  return client;
+};

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -1,21 +1,11 @@
-import {
-  Client,
-  EvaluationDetails,
-  FlagValue,
-  ProviderEvents,
-  ResolutionDetails,
-} from '@openfeature/web-sdk'
-import { useEffect, useState } from 'react'
-import { useOpenFeatureClient } from './provider'
+import { Client, EvaluationDetails, FlagValue, ProviderEvents, ResolutionDetails } from '@openfeature/web-sdk';
+import { useEffect, useState } from 'react';
+import { useOpenFeatureClient } from './provider';
 
-export function useFeatureFlag<T extends FlagValue>(
-  flagKey: string,
-  defaultValue: T
-): T {
-  const [flagEvaluationDetails, setFlagEvaluationDetails] =
-    useState<ResolutionDetails<T> | null>(null)
+export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValue: T): T {
+  const [flagEvaluationDetails, setFlagEvaluationDetails] = useState<ResolutionDetails<T> | null>(null);
 
-  const client = useOpenFeatureClient()
+  const client = useOpenFeatureClient();
 
   useEffect(() => {
     getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
@@ -26,12 +16,12 @@ export function useFeatureFlag<T extends FlagValue>(
     client.addHandler(ProviderEvents.ConfigurationChanged, () => {
       getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
     });
-  }, [flagKey, defaultValue, client])
+  }, [flagKey, defaultValue, client]);
 
   if (flagEvaluationDetails) {
-    return flagEvaluationDetails.value
+    return flagEvaluationDetails.value;
   } else {
-    return defaultValue
+    return defaultValue;
   }
 }
 
@@ -42,16 +32,16 @@ async function getFlag<T extends FlagValue>(
   setFlagDetails: (details: EvaluationDetails<T>) => void
 ): Promise<void> {
   if (typeof defaultValue === 'boolean') {
-    const flagDetails = await client.getBooleanDetails(flagKey, defaultValue)
-    setFlagDetails(flagDetails as EvaluationDetails<T>)
+    const flagDetails = await client.getBooleanDetails(flagKey, defaultValue);
+    setFlagDetails(flagDetails as EvaluationDetails<T>);
   } else if (typeof defaultValue === 'string') {
-    const flagDetails = await client.getStringDetails(flagKey, defaultValue)
-    setFlagDetails(flagDetails as EvaluationDetails<T>)
+    const flagDetails = await client.getStringDetails(flagKey, defaultValue);
+    setFlagDetails(flagDetails as EvaluationDetails<T>);
   } else if (typeof defaultValue === 'number') {
-    const flagDetails = await client.getNumberDetails(flagKey, defaultValue)
-    setFlagDetails(flagDetails as EvaluationDetails<T>)
+    const flagDetails = await client.getNumberDetails(flagKey, defaultValue);
+    setFlagDetails(flagDetails as EvaluationDetails<T>);
   } else {
-    const flagDetails = await client.getObjectDetails(flagKey, defaultValue)
-    setFlagDetails(flagDetails as EvaluationDetails<T>)
+    const flagDetails = await client.getObjectDetails(flagKey, defaultValue);
+    setFlagDetails(flagDetails as EvaluationDetails<T>);
   }
 }

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -1,0 +1,57 @@
+import {
+  Client,
+  EvaluationDetails,
+  FlagValue,
+  ProviderEvents,
+  ResolutionDetails,
+} from '@openfeature/web-sdk'
+import { useEffect, useState } from 'react'
+import { useOpenFeatureClient } from './provider'
+
+export function useFeatureFlag<T extends FlagValue>(
+  flagKey: string,
+  defaultValue: T
+): T {
+  const [flagEvaluationDetails, setFlagEvaluationDetails] =
+    useState<ResolutionDetails<T> | null>(null)
+
+  const client = useOpenFeatureClient()
+
+  useEffect(() => {
+    getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
+    // adding handlers here mean that changes are immediately reflected in the UI when flags change
+    client.addHandler(ProviderEvents.Ready, () => {
+      getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
+    });
+    client.addHandler(ProviderEvents.ConfigurationChanged, () => {
+      getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
+    });
+  }, [flagKey, defaultValue, client])
+
+  if (flagEvaluationDetails) {
+    return flagEvaluationDetails.value
+  } else {
+    return defaultValue
+  }
+}
+
+async function getFlag<T extends FlagValue>(
+  client: Client,
+  flagKey: string,
+  defaultValue: T,
+  setFlagDetails: (details: EvaluationDetails<T>) => void
+): Promise<void> {
+  if (typeof defaultValue === 'boolean') {
+    const flagDetails = await client.getBooleanDetails(flagKey, defaultValue)
+    setFlagDetails(flagDetails as EvaluationDetails<T>)
+  } else if (typeof defaultValue === 'string') {
+    const flagDetails = await client.getStringDetails(flagKey, defaultValue)
+    setFlagDetails(flagDetails as EvaluationDetails<T>)
+  } else if (typeof defaultValue === 'number') {
+    const flagDetails = await client.getNumberDetails(flagKey, defaultValue)
+    setFlagDetails(flagDetails as EvaluationDetails<T>)
+  } else {
+    const flagDetails = await client.getObjectDetails(flagKey, defaultValue)
+    setFlagDetails(flagDetails as EvaluationDetails<T>)
+  }
+}

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -11,14 +11,14 @@ export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValu
     getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
     const handler = () => {
       getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
-    }
+    };
     // adding handlers here means that changes are immediately reflected in the UI when flags change
     client.addHandler(ProviderEvents.Ready, handler);
     client.addHandler(ProviderEvents.ConfigurationChanged, handler);
     return () => {
       // be sure to cleanup the handlers
-      client.removeHandler(ProviderEvents.Ready, handler)
-      client.removeHandler(ProviderEvents.ConfigurationChanged, handler)
+      client.removeHandler(ProviderEvents.Ready, handler);
+      client.removeHandler(ProviderEvents.ConfigurationChanged, handler);
     };
   }, [flagKey, defaultValue, client]);
 

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -9,13 +9,17 @@ export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValu
 
   useEffect(() => {
     getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
-    // adding handlers here mean that changes are immediately reflected in the UI when flags change
-    client.addHandler(ProviderEvents.Ready, () => {
+    const handler = () => {
       getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
-    });
-    client.addHandler(ProviderEvents.ConfigurationChanged, () => {
-      getFlag(client, flagKey, defaultValue, setFlagEvaluationDetails);
-    });
+    }
+    // adding handlers here means that changes are immediately reflected in the UI when flags change
+    client.addHandler(ProviderEvents.Ready, handler);
+    client.addHandler(ProviderEvents.ConfigurationChanged, handler);
+    return () => {
+      // be sure to cleanup the handlers
+      client.removeHandler(ProviderEvents.Ready, handler)
+      client.removeHandler(ProviderEvents.ConfigurationChanged, handler)
+    };
   }, [flagKey, defaultValue, client]);
 
   if (flagEvaluationDetails) {

--- a/packages/react/test/tsconfig.json
+++ b/packages/react/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,104 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+    /* Language and Environment */
+    "target": "ES2015", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "ES2020",
+      "DOM"
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    /* Modules */
+    "module": "ES2020", /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+    /* Emit */
+    "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "./dist/esm", /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    "declarationDir": "./dist/types",                      /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    /* Type Checking */
+    "strict": true, /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.js"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,14 @@
       "extra-files": ["README.md"],
       "versioning": "default"
     },
+    "packages/react": {
+      "release-type": "node",
+      "prerelease": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": ["README.md"],
+      "versioning": "default"
+    },
     "packages/shared": {
       "release-type": "node",
       "prerelease": true,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,12 +14,14 @@ export default {
     // function indicating which deps should be considered external: non-external deps will have their types bundled
     (id) => {
       // bundle 'events' types
-      return id !== 'events'
+      return id !== 'events';
     }
   ],
   plugins: [
     alias({
-      entries: [{ find: '@openfeature/shared', replacement: '../shared/dist/types.d.ts' }],
+      entries: [
+        { find: '@openfeature/shared', replacement: '../shared/dist/types.d.ts' },
+      ],
     }),
     dts({tsconfig: './tsconfig.json', respectExternal: true}),
   ],


### PR DESCRIPTION
This PR:

- adds all the necessary groundwork for a new react module in the monorepo (packaging, release, CI, etc)
- adds a _very_ limited implementation based on work by @moredip , see example in [README](https://github.com/open-feature/js-sdk/blob/a9104c1ca2a2fecd75b02e1d804a7bb984dd6d2d/packages/react/README.md)

Things to note:

- I've chosen NOT to bundle in the web-sdk directly into the react-sdk (which I could have done). Instead, the web-sdk is a peer dependency. Reasoning:
  - NPM 16+ automatically downloads peer deps if missing, and otherwise uses the available peer if compatible
  - Providers "don't care" whether they are used by the web-sdk, or the react-sdk, however, they all need a peerDependency on the web-sdk. If we bundled the web-sdk into the react-sdk automatically, it would mean that a consumer only using the react-sdk + some-web-provider would get a "useless" copy of the web-sdk downloaded automatically. For that reason, it's better to have the web-sdk as a peer, with the react SDK purely building on to of that dep, not duplicating/embedding a bunch of its code.
  - the web-sdk objects are re-exported from the react-sdk, so consumers only need to import from there.

relates to: https://github.com/open-feature/js-sdk/pull/546

:mega: I want to make clear that this is not a final API, and I'd love to continue discussion in the linked issue on how this could work. We can merge this PR (and subsequent ones) without releasing so that people can experiment locally with various APIs, via [yalc](https://github.com/wclr/yalc) or `npm link`.