### PR TITLE
feat(react-sdk): return flag evaluation details from hook

### DIFF
--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -2,7 +2,7 @@ import { Client, EvaluationDetails, FlagValue, ProviderEvents } from '@openfeatu
 import { useEffect, useState } from 'react';
 import { useOpenFeatureClient } from './provider';
 
-export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValue: T): T {
+export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValue: T): EvaluationDetails<T> {
   const [, setForceUpdateState] = useState({});
 
   const client = useOpenFeatureClient();
@@ -20,7 +20,7 @@ export function useFeatureFlag<T extends FlagValue>(flagKey: string, defaultValu
     };
   }, [client]);
 
-  return getFlag(client, flagKey, defaultValue).value;
+  return getFlag(client, flagKey, defaultValue);
 }
 
 function getFlag<T extends FlagValue>(client: Client, flagKey: string, defaultValue: T): EvaluationDetails<T> {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This proposes to return the whole feature flag evaluation details from the react `useFeatureFlag` hook.

Only thing i am not sure if we should return an alias type for EvaluationDetails or as is is in this PR, the EvaluationDetails type.  Using an alias maybe like `type FeatureFlag<T> = EvaluationDetails<T>` would make clear that this may be extended later, even though we can still do it without having an alias now.

The hook becomes nicely usable as seen in the following.

```ts
const { value } = useFeatureFlag('feature-enabled', false);
```
