### PR TITLE
docs: add web client docs

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -127,7 +127,7 @@ sequenceDiagram
     Feature Flag Provider-->-Client: Flags values
 ```
 
-In 1 the Client sends a request to the provider backend in order to get all values from all feature flags that it has.
+In (1) the Client sends a request to the provider backend in order to get all values from all feature flags that it has.
 Once the provider backend replies (2) the client holds all flag values and therefore the flag evaluation process is synchronous.
 
 In order to prevent flag evaluation to the default value while flags are still being fetched, it is highly recommended to only look for flag value after the provider has emitted the `Ready` event.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -158,7 +158,9 @@ If the flag management system you're using supports targeting, you can provide t
 await OpenFeature.setContext({ origin: document.location.host });
 ```
 
-Context is global and setting it is `async`. Providers may implement a `onContextChanged` method that receives the old context and the newer one. This method identifies if an update is needed in flags values, which might result in a request from the cliente to the provider to get all flag values given the new context.
+Context is global and setting it is `async`.
+Providers may implement an `onContextChanged` method that receives the old context and the newer one.
+This method identifies if an update is needed in flag values, which might result in a request from the client to the provider to get all flag values given the new context.
 
 ### Hooks
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -91,7 +91,7 @@ See [here](https://open-feature.github.io/js-sdk/modules/OpenFeature_Web_SDK.htm
 | Status | Features                        | Description                                                                                                                        |
 | ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | ✅      | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
-| ✅      | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
+| ✅      | [Targeting](#targeting-and-context)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
 | ✅      | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
 | ✅      | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
 | ✅      | [Named clients](#named-clients) | Utilize multiple providers in a single application.                                                                                |
@@ -160,7 +160,7 @@ await OpenFeature.setContext({ origin: document.location.host });
 
 Context is global and setting it is `async`.
 Providers may implement an `onContextChanged` method that receives the old context and the newer one.
-This method identifies if an update is needed in flag values, which might result in a request from the client to the provider to get all flag values given the new context.
+This method is used internally by the provider to detect if, given the context change, the flags values cached on client side are invalid. If needed a request will be made to the provider with the new context in order to get the correct flags values.
 
 ### Hooks
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -130,7 +130,8 @@ sequenceDiagram
 In 1 the Client sends a request to the provider backend in order to get all values from all feature flags that it has.
 Once the provider backend replies (2) the client holds all flag values and therefore the flag evaluation process is synchronous.
 
-In order to prevent flag evaluation to the default value while flags are still being fetched it is highly recommended to only lookup for flags value after the provider has emitted the `Ready` event. The following code snipet provides an example.
+In order to prevent flag evaluation to the default value while flags are still being fetched, it is highly recommended to only look for flag value after the provider has emitted the `Ready` event.
+The following code snippet provides an example.
 
 ```ts
 import { OpenFeature, ProviderEvents } from '@openfeature/web-sdk';


### PR DESCRIPTION
## This PR

Adds docs to JavaScript web-client sdk regarding flag evaluation flow and context.

### Related Issues

Closes #570 

### Notes

Mermaid diagrams were used but I'm not sure if they are currently supported.