### PR TITLE
feat: add support for clearing providers

### DIFF
--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -75,6 +75,10 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider> implements Ma
       { name, version }
     );
   }
+
+  clearProviders() {
+    return super.clearProviders(NOOP_PROVIDER);
+  }
 }
 
 /**

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -76,8 +76,12 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider> implements Ma
     );
   }
 
-  clearProviders() {
-    return super.clearProviders(NOOP_PROVIDER);
+  /**
+   * Clears all registered providers and resets the default provider.
+   * @returns {Promise<void>}
+   */
+  clearProviders(): Promise<void> {
+    return super.clearProvidersAndSetDefault(NOOP_PROVIDER);
   }
 }
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -91,11 +91,12 @@ const MOCK_PROVIDER: Provider = {
 };
 
 describe('OpenFeatureClient', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     OpenFeature.setProvider(MOCK_PROVIDER);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 
@@ -307,164 +308,165 @@ describe('OpenFeatureClient', () => {
       });
     });
   });
-});
 
-describe('Requirement 1.4.3.1', () => {
-  describe('generic support', () => {
-    it('should support generics', () => {
-      // No generic information exists at runtime, but this test has some value in ensuring the generic args still exist in the typings.
-      const client = OpenFeature.getClient();
-      const details: ResolutionDetails<JsonValue> = client.getObjectDetails('flag', { key: 'value' });
-
-      expect(details).toBeDefined();
-    });
-  });
-});
-
-describe('Evaluation details structure', () => {
-  const flagKey = 'number-details';
-  const defaultValue = 1970;
-  let details: EvaluationDetails<number>;
-
-  describe('Normal execution', () => {
-    beforeAll(() => {
-      const client = OpenFeature.getClient();
-      details = client.getNumberDetails(flagKey, defaultValue);
-
-      expect(details).toBeDefined();
-    });
-
-    describe('Requirement 1.4.2, 1.4.3', () => {
-      it('should contain flag value', () => {
-        expect(details.value).toEqual(NUMBER_VALUE);
-      });
-    });
-
-    describe('Requirement 1.4.4', () => {
-      it('should contain flag key', () => {
-        expect(details.flagKey).toEqual(flagKey);
-      });
-    });
-
-    describe('Requirement 1.4.5', () => {
-      it('should contain flag variant', () => {
-        expect(details.variant).toEqual(NUMBER_VARIANT);
-      });
-    });
-
-    describe('Requirement 1.4.6', () => {
-      it('should contain reason', () => {
-        expect(details.reason).toEqual(REASON);
+  describe('Requirement 1.4.3.1', () => {
+    describe('generic support', () => {
+      it('should support generics', () => {
+        // No generic information exists at runtime, but this test has some value in ensuring the generic args still exist in the typings.
+        const client = OpenFeature.getClient();
+        const details: ResolutionDetails<JsonValue> = client.getObjectDetails('flag', { key: 'value' });
+  
+        expect(details).toBeDefined();
       });
     });
   });
-
-  describe('Abnormal execution', () => {
-    const NON_OPEN_FEATURE_ERROR_MESSAGE = 'A null dereference or something, I dunno.';
-    const OPEN_FEATURE_ERROR_MESSAGE = "This ain't the flag you're looking for.";
-    let nonOpenFeatureErrorDetails: EvaluationDetails<number>;
-    let openFeatureErrorDetails: EvaluationDetails<string>;
-    let client: Client;
-    const errorProvider = {
-      metadata: {
-        name: 'error-mock',
-      },
-      resolveNumberEvaluation: jest.fn((): Promise<ResolutionDetails<number>> => {
-        throw new Error(NON_OPEN_FEATURE_ERROR_MESSAGE); // throw a non-open-feature error
-      }),
-      resolveStringEvaluation: jest.fn((): Promise<ResolutionDetails<string>> => {
-        throw new FlagNotFoundError(OPEN_FEATURE_ERROR_MESSAGE); // throw an open-feature error
-      }),
-    } as unknown as Provider;
-    const defaultNumberValue = 123;
-    const defaultStringValue = 'hey!';
-
-    beforeAll(() => {
-      OpenFeature.setProvider(errorProvider);
-      client = OpenFeature.getClient();
-      nonOpenFeatureErrorDetails = client.getNumberDetails('some-flag', defaultNumberValue);
-      openFeatureErrorDetails = client.getStringDetails('some-flag', defaultStringValue);
-    });
-
-    describe('Requirement 1.4.7', () => {
-      describe('OpenFeatureError', () => {
-        it('should contain error code', () => {
-          expect(openFeatureErrorDetails.errorCode).toBeTruthy();
-          expect(openFeatureErrorDetails.errorCode).toEqual(ErrorCode.FLAG_NOT_FOUND); // should get code from thrown OpenFeatureError
+  
+  describe('Evaluation details structure', () => {
+    const flagKey = 'number-details';
+    const defaultValue = 1970;
+    let details: EvaluationDetails<number>;
+  
+    describe('Normal execution', () => {
+      beforeEach(() => {
+        const client = OpenFeature.getClient();
+        details = client.getNumberDetails(flagKey, defaultValue);
+  
+        expect(details).toBeDefined();
+      });
+  
+      describe('Requirement 1.4.2, 1.4.3', () => {
+        it('should contain flag value', () => {
+          expect(details.value).toEqual(NUMBER_VALUE);
         });
       });
-
-      describe('Non-OpenFeatureError', () => {
-        it('should contain error code', () => {
-          expect(nonOpenFeatureErrorDetails.errorCode).toBeTruthy();
-          expect(nonOpenFeatureErrorDetails.errorCode).toEqual(ErrorCode.GENERAL); // should fall back to GENERAL
+  
+      describe('Requirement 1.4.4', () => {
+        it('should contain flag key', () => {
+          expect(details.flagKey).toEqual(flagKey);
+        });
+      });
+  
+      describe('Requirement 1.4.5', () => {
+        it('should contain flag variant', () => {
+          expect(details.variant).toEqual(NUMBER_VARIANT);
+        });
+      });
+  
+      describe('Requirement 1.4.6', () => {
+        it('should contain reason', () => {
+          expect(details.reason).toEqual(REASON);
         });
       });
     });
-
-    describe('Requirement 1.4.8', () => {
-      it('should contain error reason', () => {
-        expect(nonOpenFeatureErrorDetails.reason).toEqual(StandardResolutionReasons.ERROR);
-        expect(openFeatureErrorDetails.reason).toEqual(StandardResolutionReasons.ERROR);
-      });
-    });
-
-    describe('Requirement 1.4.9', () => {
-      it('must not throw, must return default', () => {
-        nonOpenFeatureErrorDetails = client.getNumberDetails('some-flag', defaultNumberValue);
-
-        expect(nonOpenFeatureErrorDetails).toBeTruthy();
-        expect(nonOpenFeatureErrorDetails.value).toEqual(defaultNumberValue);
-      });
-    });
-
-    describe('Requirement 1.4.12', () => {
-      describe('OpenFeatureError', () => {
-        it('should contain "error" message', () => {
-          expect(openFeatureErrorDetails.errorMessage).toEqual(OPEN_FEATURE_ERROR_MESSAGE);
-        });
-      });
-
-      describe('Non-OpenFeatureError', () => {
-        it('should contain "error" message', () => {
-          expect(nonOpenFeatureErrorDetails.errorMessage).toEqual(NON_OPEN_FEATURE_ERROR_MESSAGE);
-        });
-      });
-    });
-  });
-
-  describe('Requirement 1.4.13, Requirement 1.4.14', () => {
-    it('should return immutable `flag metadata` as defined by the provider', () => {
-      const flagMetadata = {
-        url: 'https://test.dev',
-        version: '1',
-      };
-
-      const flagMetadataProvider = {
+  
+    describe('Abnormal execution', () => {
+      const NON_OPEN_FEATURE_ERROR_MESSAGE = 'A null dereference or something, I dunno.';
+      const OPEN_FEATURE_ERROR_MESSAGE = "This ain't the flag you're looking for.";
+      let nonOpenFeatureErrorDetails: EvaluationDetails<number>;
+      let openFeatureErrorDetails: EvaluationDetails<string>;
+      let client: Client;
+      const errorProvider = {
         metadata: {
-          name: 'flag-metadata',
+          name: 'error-mock',
         },
-        resolveBooleanEvaluation: jest.fn((): ResolutionDetails<boolean> => {
-          return {
-            value: true,
-            flagMetadata,
-          };
+        resolveNumberEvaluation: jest.fn((): Promise<ResolutionDetails<number>> => {
+          throw new Error(NON_OPEN_FEATURE_ERROR_MESSAGE); // throw a non-open-feature error
+        }),
+        resolveStringEvaluation: jest.fn((): Promise<ResolutionDetails<string>> => {
+          throw new FlagNotFoundError(OPEN_FEATURE_ERROR_MESSAGE); // throw an open-feature error
         }),
       } as unknown as Provider;
-
-      OpenFeature.setProvider(flagMetadataProvider);
-      const client = OpenFeature.getClient();
-      const response = client.getBooleanDetails('some-flag', false);
-      expect(response.flagMetadata).toBe(flagMetadata);
-      expect(Object.isFrozen(response.flagMetadata)).toBeTruthy();
+      const defaultNumberValue = 123;
+      const defaultStringValue = 'hey!';
+  
+      beforeEach(() => {
+        OpenFeature.setProvider(errorProvider);
+        client = OpenFeature.getClient();
+        nonOpenFeatureErrorDetails = client.getNumberDetails('some-flag', defaultNumberValue);
+        openFeatureErrorDetails = client.getStringDetails('some-flag', defaultStringValue);
+      });
+  
+      describe('Requirement 1.4.7', () => {
+        describe('OpenFeatureError', () => {
+          it('should contain error code', () => {
+            expect(openFeatureErrorDetails.errorCode).toBeTruthy();
+            expect(openFeatureErrorDetails.errorCode).toEqual(ErrorCode.FLAG_NOT_FOUND); // should get code from thrown OpenFeatureError
+          });
+        });
+  
+        describe('Non-OpenFeatureError', () => {
+          it('should contain error code', () => {
+            expect(nonOpenFeatureErrorDetails.errorCode).toBeTruthy();
+            expect(nonOpenFeatureErrorDetails.errorCode).toEqual(ErrorCode.GENERAL); // should fall back to GENERAL
+          });
+        });
+      });
+  
+      describe('Requirement 1.4.8', () => {
+        it('should contain error reason', () => {
+          expect(nonOpenFeatureErrorDetails.reason).toEqual(StandardResolutionReasons.ERROR);
+          expect(openFeatureErrorDetails.reason).toEqual(StandardResolutionReasons.ERROR);
+        });
+      });
+  
+      describe('Requirement 1.4.9', () => {
+        it('must not throw, must return default', () => {
+          nonOpenFeatureErrorDetails = client.getNumberDetails('some-flag', defaultNumberValue);
+  
+          expect(nonOpenFeatureErrorDetails).toBeTruthy();
+          expect(nonOpenFeatureErrorDetails.value).toEqual(defaultNumberValue);
+        });
+      });
+  
+      describe('Requirement 1.4.12', () => {
+        describe('OpenFeatureError', () => {
+          it('should contain "error" message', () => {
+            expect(openFeatureErrorDetails.errorMessage).toEqual(OPEN_FEATURE_ERROR_MESSAGE);
+          });
+        });
+  
+        describe('Non-OpenFeatureError', () => {
+          it('should contain "error" message', () => {
+            expect(nonOpenFeatureErrorDetails.errorMessage).toEqual(NON_OPEN_FEATURE_ERROR_MESSAGE);
+          });
+        });
+      });
     });
-
-    it('should return empty `flag metadata` because it was not set by the provider', () => {
-      // The mock provider doesn't contain flag metadata
-      OpenFeature.setProvider(MOCK_PROVIDER);
-      const client = OpenFeature.getClient();
-      const response = client.getBooleanDetails('some-flag', false);
-      expect(response.flagMetadata).toEqual({});
+  
+    describe('Requirement 1.4.13, Requirement 1.4.14', () => {
+      it('should return immutable `flag metadata` as defined by the provider', () => {
+        const flagMetadata = {
+          url: 'https://test.dev',
+          version: '1',
+        };
+  
+        const flagMetadataProvider = {
+          metadata: {
+            name: 'flag-metadata',
+          },
+          resolveBooleanEvaluation: jest.fn((): ResolutionDetails<boolean> => {
+            return {
+              value: true,
+              flagMetadata,
+            };
+          }),
+        } as unknown as Provider;
+  
+        OpenFeature.setProvider(flagMetadataProvider);
+        const client = OpenFeature.getClient();
+        const response = client.getBooleanDetails('some-flag', false);
+        expect(response.flagMetadata).toBe(flagMetadata);
+        expect(Object.isFrozen(response.flagMetadata)).toBeTruthy();
+      });
+  
+      it('should return empty `flag metadata` because it was not set by the provider', () => {
+        // The mock provider doesn't contain flag metadata
+        OpenFeature.setProvider(MOCK_PROVIDER);
+        const client = OpenFeature.getClient();
+        const response = client.getBooleanDetails('some-flag', false);
+        expect(response.flagMetadata).toEqual({});
+      });
     });
   });
 });
+

--- a/packages/client/test/events.spec.ts
+++ b/packages/client/test/events.spec.ts
@@ -78,7 +78,8 @@ describe('Events', () => {
   jest.setTimeout(TIMEOUT);
   let clientId = uuid();
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
     clientId = uuid();
     // hacky, but it's helpful to clear the handlers between tests

--- a/packages/client/test/hooks.spec.ts
+++ b/packages/client/test/hooks.spec.ts
@@ -45,15 +45,13 @@ describe('Hooks', () => {
   let client: Client;
   const FLAG_KEY = 'my-flag';
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 
-  beforeAll(() => {
+  beforeEach(async () => {
     OpenFeature.setProvider(MOCK_PROVIDER);
-  });
-
-  beforeEach(() => {
     client = OpenFeature.getClient();
   });
 
@@ -226,7 +224,7 @@ describe('Hooks', () => {
   });
 
   describe('"error" stage', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
     });
 

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -21,7 +21,8 @@ const mockProvider = (config?: {
 };
 
 describe('OpenFeature', () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -19,7 +19,6 @@ const _globalThis = globalThis as OpenFeatureGlobal;
 export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider> implements ManageContext<OpenFeatureAPI> {
   protected _defaultProvider: Provider = NOOP_PROVIDER;
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   private constructor() {
     super('server');
   }
@@ -103,6 +102,10 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider> implements Ma
       { name, version },
       context
     );
+  }
+
+  clearProviders() {
+    return super.clearProviders(NOOP_PROVIDER);
   }
 }
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -104,8 +104,12 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider> implements Ma
     );
   }
 
-  clearProviders() {
-    return super.clearProviders(NOOP_PROVIDER);
+  /**
+   * Clears all registered providers and resets the default provider.
+   * @returns {Promise<void>}
+   */
+  clearProviders(): Promise<void> {
+    return super.clearProvidersAndSetDefault(NOOP_PROVIDER);
   }
 }
 

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -82,11 +82,12 @@ const MOCK_PROVIDER: Provider = {
 };
 
 describe('OpenFeatureClient', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     OpenFeature.setProvider(MOCK_PROVIDER);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 
@@ -306,7 +307,7 @@ describe('OpenFeatureClient', () => {
     let details: EvaluationDetails<number>;
 
     describe('Normal execution', () => {
-      beforeAll(async () => {
+      beforeEach(async () => {
         const client = OpenFeature.getClient();
         details = await client.getNumberDetails(flagKey, defaultValue);
 
@@ -358,7 +359,7 @@ describe('OpenFeatureClient', () => {
       const defaultNumberValue = 123;
       const defaultStringValue = 'hey!';
 
-      beforeAll(async () => {
+      beforeEach(async () => {
         OpenFeature.setProvider(errorProvider);
         client = OpenFeature.getClient();
         nonOpenFeatureErrorDetails = await client.getNumberDetails('some-flag', defaultNumberValue);

--- a/packages/server/test/events.spec.ts
+++ b/packages/server/test/events.spec.ts
@@ -81,7 +81,8 @@ describe('Events', () => {
   jest.setTimeout(TIMEOUT);
   let clientId = uuid();
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
     clientId = uuid();
     // hacky, but it's helpful to clear the handlers between tests

--- a/packages/server/test/hooks.spec.ts
+++ b/packages/server/test/hooks.spec.ts
@@ -41,15 +41,13 @@ describe('Hooks', () => {
   let client: Client;
   const FLAG_KEY = 'my-flag';
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 
-  beforeAll(() => {
-    OpenFeature.setProvider(MOCK_PROVIDER);
-  });
-
   beforeEach(() => {
+    OpenFeature.setProvider(MOCK_PROVIDER);
     client = OpenFeature.getClient();
   });
 
@@ -280,7 +278,7 @@ describe('Hooks', () => {
   });
 
   describe('"error" stage', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       OpenFeature.setProvider(MOCK_ERROR_PROVIDER);
     });
 

--- a/packages/server/test/logger.spec.ts
+++ b/packages/server/test/logger.spec.ts
@@ -45,11 +45,12 @@ const MOCK_PROVIDER: Provider = {
 };
 
 describe('Logger', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     OpenFeature.setProvider(MOCK_PROVIDER);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
     // Resetting the default logger on the singleton
     OpenFeature['_logger'] = new DefaultLogger();

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -21,7 +21,8 @@ const mockProvider = (config?: {
 };
 
 describe('OpenFeature', () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
     jest.clearAllMocks();
   });
 

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -17,10 +17,10 @@ import { Paradigm } from './types';
 
 export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProvider>
   implements
-  Eventing,
-  EvaluationLifeCycle<OpenFeatureCommonAPI<P>>,
-  ManageLogger<OpenFeatureCommonAPI<P>>,
-  ManageTransactionContextPropagator<OpenFeatureCommonAPI<P>>
+    Eventing,
+    EvaluationLifeCycle<OpenFeatureCommonAPI<P>>,
+    ManageLogger<OpenFeatureCommonAPI<P>>,
+    ManageTransactionContextPropagator<OpenFeatureCommonAPI<P>>
 {
   protected _hooks: Hook[] = [];
   protected _transactionContextPropagator: TransactionContextPropagator = NOOP_TRANSACTION_CONTEXT_PROPAGATOR;
@@ -296,13 +296,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
     );
   }
 
-  /**
-   * Clears all registered providers and resets the default provider.
-   * @template P
-   * @param {P} defaultProvider The provider that should be set as the default.
-   * @returns {this} OpenFeature API
-   */
-  protected async clearProviders(defaultProvider: P) {
+  protected async clearProvidersAndSetDefault(defaultProvider: P): Promise<void> {
     try {
       await this.close();
     } catch (err) {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -17,10 +17,10 @@ import { Paradigm } from './types';
 
 export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProvider>
   implements
-    Eventing,
-    EvaluationLifeCycle<OpenFeatureCommonAPI<P>>,
-    ManageLogger<OpenFeatureCommonAPI<P>>,
-    ManageTransactionContextPropagator<OpenFeatureCommonAPI<P>>
+  Eventing,
+  EvaluationLifeCycle<OpenFeatureCommonAPI<P>>,
+  ManageLogger<OpenFeatureCommonAPI<P>>,
+  ManageTransactionContextPropagator<OpenFeatureCommonAPI<P>>
 {
   protected _hooks: Hook[] = [];
   protected _transactionContextPropagator: TransactionContextPropagator = NOOP_TRANSACTION_CONTEXT_PROPAGATOR;
@@ -89,7 +89,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
         }
       }
     });
-    
+
     this._events.addHandler(eventType, handler);
   }
 
@@ -149,7 +149,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
 
     if (!provider.runsOn) {
       this._logger.debug(`Provider '${provider.metadata.name}' has not defined its intended use.`);
-    } else if (provider.runsOn !== this._runsOn){
+    } else if (provider.runsOn !== this._runsOn) {
       throw new GeneralError(`Provider '${provider.metadata.name}' is intended for use on the ${provider.runsOn}.`);
     }
 
@@ -175,7 +175,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
         })
         ?.catch((error) => {
           this.getAssociatedEventEmitters(clientName).forEach((emitter) => {
-            emitter?.emit(ProviderEvents.Error, { clientName, providerName,  message: error.message });
+            emitter?.emit(ProviderEvents.Error, { clientName, providerName, message: error.message });
           });
           this._events?.emit(ProviderEvents.Error, { clientName, providerName, message: error.message });
         });
@@ -298,12 +298,15 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
 
   /**
    * Clears all registered providers and resets the default provider.
+   * @template P
+   * @param {P} defaultProvider The provider that should be set as the default.
+   * @returns {this} OpenFeature API
    */
   protected async clearProviders(defaultProvider: P) {
     try {
-      await this.close()
+      await this.close();
     } catch (err) {
-      this._logger.error("Unable to cleanly close providers. Resetting to the default configuration.")
+      this._logger.error('Unable to cleanly close providers. Resetting to the default configuration.');
     } finally {
       this._clientProviders.clear();
       this._defaultProvider = defaultProvider;

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -290,10 +290,24 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
         try {
           await provider.onClose?.();
         } catch (err) {
-          this.handleShutdownError(this._defaultProvider, err);
+          this.handleShutdownError(provider, err);
         }
       })
     );
+  }
+
+  /**
+   * Clears all registered providers and resets the default provider.
+   */
+  protected async clearProviders(defaultProvider: P) {
+    try {
+      await this.close()
+    } catch (err) {
+      this._logger.error("Unable to cleanly close providers. Resetting to the default configuration.")
+    } finally {
+      this._clientProviders.clear();
+      this._defaultProvider = defaultProvider;
+    }
   }
 
   private handleShutdownError(provider: P, err: unknown) {


### PR DESCRIPTION
## This PR

- adds support for clearing providers

### Related Issues

Fixes #526 

### Notes

We may want to consider adding a reset method that calls `clearHooks`, `clearProviders`, rests the logger, and clears event listeners. There are a few tests that use a hacky method to do this already.

