### PR TITLE
ci: update repo to support merge queues

### DIFF
--- a/.github/workflows/dco-merge-group.yml
+++ b/.github/workflows/dco-merge-group.yml
@@ -1,0 +1,12 @@
+name: DCO
+on:
+  merge_group:
+
+# Workaround because the DCO app doesn't run on a merge_group trigger
+# https://github.com/dcoapp/app/pull/200
+jobs:
+  DCO:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'renovate[bot]' }}
+    steps:
+      - run: echo "dummy DCO workflow (it won't run any check actually) to trigger by merge_group in order to enable merge queue"

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,6 +8,7 @@ on:
       - reopened
     branches:
       - main
+  merge_group:
 
 jobs:
   build-test-lint:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
       release_created: ${{ steps.release.outputs.releases_created }}
 
   npm-release:
-    needs: Release-please
+    needs: release-please
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}
     steps:


### PR DESCRIPTION
## This PR

- add merge queue trigger to pr check action
- add dco merge queue workaround

### Follow-up Tasks
`q
Enable merge queues in the repo.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>
