### PR TITLE
fix: add Provider Not Ready Error

### DIFF
--- a/packages/server/test/errors.spec.ts
+++ b/packages/server/test/errors.spec.ts
@@ -4,6 +4,7 @@ import {
   GeneralError,
   InvalidContextError,
   ParseError,
+  ProviderNotReadyError,
   TargetingKeyMissingError,
   TypeMismatchError,
 } from '../src';
@@ -55,5 +56,13 @@ describe('Errors', () => {
     expect(error.code).toBe(ErrorCode.INVALID_CONTEXT);
     expect(error.name).toBe('InvalidContextError');
     expect(error instanceof InvalidContextError).toBe(true);
+  });
+
+  it('ProviderNotReadyError', () => {
+    const error = new ProviderNotReadyError('message');
+    expect(error.message).toBe('message');
+    expect(error.code).toBe(ErrorCode.PROVIDER_NOT_READY);
+    expect(error.name).toBe('ProviderNotReadyError');
+    expect(error instanceof ProviderNotReadyError).toBe(true);
   });
 });

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -5,3 +5,4 @@ export * from './type-mismatch-error';
 export * from './targeting-key-missing-error';
 export * from './invalid-context-error';
 export * from './open-feature-error-abstract';
+export * from './provider-not-ready-error';

--- a/packages/shared/src/errors/provider-not-ready-error.ts
+++ b/packages/shared/src/errors/provider-not-ready-error.ts
@@ -1,0 +1,12 @@
+import { OpenFeatureError } from './open-feature-error-abstract';
+import { ErrorCode } from '../evaluation';
+
+export class ProviderNotReadyError extends OpenFeatureError {
+  code: ErrorCode;
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, ProviderNotReadyError.prototype);
+    this.name = 'ProviderNotReadyError';
+    this.code = ErrorCode.PROVIDER_NOT_READY;
+  }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Adds an Error class for the error code Provider Not Ready. To match the other error codes. 
