### PR TITLE
chore: fix React SDK README.md to use the resolved value instead of the resolution details

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,10 +24,10 @@
 
 [OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
 
-🧪 This is SDK is experimental.
+🧪 This SDK is experimental.
 
 
-Here's a basic example of how ot use the current API with flagd:
+Here's a basic example of how to use the current API with flagd:
 
 ```js
 import logo from './logo.svg';
@@ -57,7 +57,7 @@ function Page() {
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        {booleanFlag ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
+        {booleanFlag.value ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
       </header>
     </div>
   )


### PR DESCRIPTION
## This PR

The documentation conditionally renders something if the returned value from the hook is truthy, but this implies that it is simply checking for the entirety of the `EvaluationDetails<T>` returned from `useFeatureFlag` which seems off since we will always get an object back according to the typings. It feel like it should be checking against the `.value` to conditionally render the elements.


