### PR TITLE
feat: ability to get current provider state

### DIFF
--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1,6 +1,10 @@
-import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger } from '@openfeature/core';
+import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger, ProviderStatus } from '@openfeature/core';
 import { Features } from '../evaluation';
 
 export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing {
   readonly metadata: ClientMetadata;
+  /**
+   * Returns the status of the associated provider.
+   */
+  readonly providerStatus: ProviderStatus;
 }

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -11,6 +11,7 @@ import {
   Logger,
   OpenFeatureError,
   ProviderEvents,
+  ProviderStatus,
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
@@ -47,6 +48,10 @@ export class OpenFeatureClient implements Client {
       version: this.options.version,
       providerMetadata: this.providerAccessor().metadata,
     };
+  }
+
+  get providerStatus(): ProviderStatus {
+    return this.providerAccessor()?.status || ProviderStatus.READY;
   }
 
   addHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -528,5 +528,17 @@ describe('OpenFeatureClient', () => {
       });
     });
   });
+
+  describe('providerStatus', () => {
+    it('should return current provider status', ()=> {
+      OpenFeature.setProvider({ ...MOCK_PROVIDER, status: ProviderStatus.STALE});
+      expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.STALE);
+    });
+
+    it('should return READY if not defined', ()=> {
+      OpenFeature.setProvider(MOCK_PROVIDER);
+      expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.READY);
+    });
+  });
 });
 


### PR DESCRIPTION
This is separate PR for a similar change [here](https://github.com/open-feature/js-sdk/pull/698).

I'm hesitant to spec this at the moment. I'm only implementing it in the client because it seems particularly useful for React.