### PR TITLE
feat: add PROVIDER_CONTEXT_CHANGED event (web-sdk only)

### DIFF
--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -10,7 +10,6 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
-  ProviderEvents,
   ProviderStatus,
   ResolutionDetails,
   SafeLogger,
@@ -18,6 +17,7 @@ import {
   statusMatchesEvent
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
+import { ProviderEvents } from '../events';
 import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
 import { Hook } from '../hooks';
 import { OpenFeature } from '../open-feature';
@@ -54,7 +54,7 @@ export class OpenFeatureClient implements Client {
     return this.providerAccessor()?.status || ProviderStatus.READY;
   }
 
-  addHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void {
+  addHandler(eventType: ProviderEvents, handler: EventHandler): void {
     this.emitterAccessor().addHandler(eventType, handler);
     const shouldRunNow = statusMatchesEvent(eventType, this._provider.status);
 
@@ -68,7 +68,7 @@ export class OpenFeatureClient implements Client {
     }
   }
 
-  removeHandler<T extends ProviderEvents>(notificationType: T, handler: EventHandler<T>): void {
+  removeHandler(notificationType: ProviderEvents, handler: EventHandler): void {
     this.emitterAccessor().removeHandler(notificationType, handler);
   }
 

--- a/packages/client/src/events/events.ts
+++ b/packages/client/src/events/events.ts
@@ -1,4 +1,8 @@
 import { ClientProviderEvents } from '@openfeature/core';
 
 export { ClientProviderEvents as ProviderEvents};
+
+/**
+ * A subset of events that can be directly emitted by providers.
+ */
 export type ProviderEmittableEvents = Exclude<ClientProviderEvents, ClientProviderEvents.ContextChanged>;

--- a/packages/client/src/events/events.ts
+++ b/packages/client/src/events/events.ts
@@ -1,0 +1,4 @@
+import { ClientProviderEvents } from '@openfeature/core';
+
+export { ClientProviderEvents as ProviderEvents};
+export type ProviderEmittableEvents = Exclude<ClientProviderEvents, ClientProviderEvents.ContextChanged>;

--- a/packages/client/src/events/index.ts
+++ b/packages/client/src/events/index.ts
@@ -1,1 +1,2 @@
 export * from './open-feature-event-emitter';
+export * from './events';

--- a/packages/client/src/events/internal/internal-event-emitter.ts
+++ b/packages/client/src/events/internal/internal-event-emitter.ts
@@ -1,8 +1,9 @@
 import { CommonEventDetails, GenericEventEmitter } from '@openfeature/core';
+import { ProviderEvents } from '../events';
 
 /**
  * The InternalEventEmitter is not exported publicly and should only be used within the SDK. It extends the
  * OpenFeatureEventEmitter to include additional properties that can be included
  * in the event details.
  */
-export abstract class InternalEventEmitter extends GenericEventEmitter<CommonEventDetails> {};
+export abstract class InternalEventEmitter extends GenericEventEmitter<ProviderEvents, CommonEventDetails> {};

--- a/packages/client/src/events/open-feature-event-emitter.ts
+++ b/packages/client/src/events/open-feature-event-emitter.ts
@@ -1,6 +1,6 @@
 import { GenericEventEmitter } from '@openfeature/core';
 import EventEmitter from 'events';
-
+import { ProviderEmittableEvents } from './events';
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit
  * events at various parts of the provider lifecycle.
@@ -8,7 +8,7 @@ import EventEmitter from 'events';
  * NOTE: Ready and error events are automatically emitted by the SDK based on
  * the result of the initialize method.
  */
-export class OpenFeatureEventEmitter extends GenericEventEmitter {
+export class OpenFeatureEventEmitter extends GenericEventEmitter<ProviderEmittableEvents> {
   protected readonly eventEmitter = new EventEmitter({ captureRejections: true });
 
   constructor() {

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -1,15 +1,15 @@
 import {
   EvaluationContext,
+  GenericEventEmitter,
   ManageContext,
   OpenFeatureCommonAPI,
   objectOrUndefined,
   stringOrUndefined,
 } from '@openfeature/core';
 import { Client, OpenFeatureClient } from './client';
-import { NOOP_PROVIDER, Provider } from './provider';
 import { OpenFeatureEventEmitter, ProviderEvents } from './events';
 import { Hook } from './hooks';
-import { GenericEventEmitter } from '@openfeature/core';
+import { NOOP_PROVIDER, Provider } from './provider';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');
@@ -205,9 +205,9 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
       }).catch((err) => {
         this._logger?.error(`Error running ${provider.metadata.name}'s context change handler:`, err);
         this.getAssociatedEventEmitters(clientName).forEach((emitter) => {
-          emitter?.emit(ProviderEvents.Error, { clientName, providerName });
+          emitter?.emit(ProviderEvents.Error, { clientName, providerName, message: err?.message, });
         });
-        this._events?.emit(ProviderEvents.Error, { clientName, providerName });
+        this._events?.emit(ProviderEvents.Error, { clientName, providerName, message: err?.message, });
       });
 
   }

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -197,7 +197,7 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
     newContext: EvaluationContext,
   ): Promise<void> {
       const providerName = provider.metadata.name;
-      return await provider.onContextChange?.(oldContext, newContext).then(() => {
+      return provider.onContextChange?.(oldContext, newContext).then(() => {
         this.getAssociatedEventEmitters(clientName).forEach((emitter) => {
           emitter?.emit(ProviderEvents.ContextChanged, { clientName, providerName });
         });
@@ -209,7 +209,6 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
         });
         this._events?.emit(ProviderEvents.Error, { clientName, providerName, message: err?.message, });
       });
-
   }
 }
 

--- a/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
@@ -6,14 +6,13 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
-  ProviderEvents,
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
   ProviderStatus,
 } from '@openfeature/core';
 import { Provider } from '../provider';
-import { OpenFeatureEventEmitter } from '../../events';
+import { OpenFeatureEventEmitter, ProviderEvents } from '../../events';
 import { FlagConfiguration, Flag } from './flag-configuration';
 import { VariantNotFoundError } from './variant-not-found-error';
 
@@ -62,6 +61,8 @@ export class InMemoryProvider implements Provider {
 
     this.status = ProviderStatus.STALE;
     this.events.emit(ProviderEvents.Stale);
+
+//    this.events.emit(ProviderEvents.ContextChanged)
 
     this._flagConfiguration = { ...flagConfiguration };
     this.events.emit(ProviderEvents.ConfigurationChanged, { flagsChanged });

--- a/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
@@ -62,8 +62,6 @@ export class InMemoryProvider implements Provider {
     this.status = ProviderStatus.STALE;
     this.events.emit(ProviderEvents.Stale);
 
-//    this.events.emit(ProviderEvents.ContextChanged)
-
     this._flagConfiguration = { ...flagConfiguration };
     this.events.emit(ProviderEvents.ConfigurationChanged, { flagsChanged });
 

--- a/packages/client/test/in-memory-provider.spec.ts
+++ b/packages/client/test/in-memory-provider.spec.ts
@@ -1,5 +1,4 @@
-import { FlagNotFoundError, GeneralError, ProviderEvents, ProviderStatus, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
-import { InMemoryProvider } from '../src';
+import { FlagNotFoundError, GeneralError, InMemoryProvider, ProviderEvents, ProviderStatus, StandardResolutionReasons, TypeMismatchError } from '../src';
 import { FlagConfiguration } from '../src/provider/in-memory-provider/flag-configuration';
 import { VariantNotFoundError } from '../src/provider/in-memory-provider/variant-not-found-error';
 

--- a/packages/server/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/server/e2e/step-definitions/evaluation.spec.ts
@@ -1,15 +1,16 @@
-import { defineFeature, loadFeature } from 'jest-cucumber';
 import {
-  JsonValue,
-  JsonObject,
-  EvaluationDetails,
   EvaluationContext,
+  EvaluationDetails,
+  JsonObject,
+  JsonValue,
+  ProviderEvents,
   ResolutionDetails,
   StandardResolutionReasons,
-  ProviderEvents,
 } from '@openfeature/core';
-import { OpenFeature, InMemoryProvider } from '../../src';
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import { InMemoryProvider, OpenFeature } from '../../src';
 import flagConfiguration from './flags-config';
+
 // load the feature file.
 const feature = loadFeature('packages/server/e2e/features/evaluation.feature');
 
@@ -17,7 +18,7 @@ const feature = loadFeature('packages/server/e2e/features/evaluation.feature');
 const client = OpenFeature.getClient();
 
 const givenAnOpenfeatureClientIsRegisteredWithCacheDisabled = (
-  given: (stepMatcher: string, stepDefinitionCallback: () => void) => void
+  given: (stepMatcher: string, stepDefinitionCallback: () => void) => void,
 ) => {
   OpenFeature.setProvider(
     new InMemoryProvider(flagConfiguration),
@@ -28,7 +29,7 @@ const givenAnOpenfeatureClientIsRegisteredWithCacheDisabled = (
 defineFeature(feature, (test) => {
   beforeAll((done) => {
     client.addHandler(ProviderEvents.Ready, async () => {
-        done();
+      done();
     });
   });
 
@@ -47,7 +48,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         value = await client.getBooleanValue(flagKey, defaultValue === 'true');
-      }
+      },
     );
 
     then(/^the resolved boolean value should be "(.*)"$/, (expectedValue: string) => {
@@ -66,7 +67,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         value = await client.getStringValue(flagKey, defaultValue);
-      }
+      },
     );
 
     then(/^the resolved string value should be "(.*)"$/, (expectedValue: string) => {
@@ -85,7 +86,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         value = await client.getNumberValue(flagKey, Number.parseInt(defaultValue));
-      }
+      },
     );
 
     then(/^the resolved integer value should be (\d+)$/, (expectedValue: string) => {
@@ -104,7 +105,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         value = await client.getNumberValue(flagKey, Number.parseFloat(defaultValue));
-      }
+      },
     );
 
     then(/^the resolved float value should be (\d+\.?\d*)$/, (expectedValue: string) => {
@@ -130,7 +131,7 @@ defineFeature(feature, (test) => {
         expect(jsonObject[field1]).toEqual(boolValue === 'true');
         expect(jsonObject[field2]).toEqual(stringValue);
         expect(jsonObject[field3]).toEqual(Number.parseInt(intValue));
-      }
+      },
     );
   });
 
@@ -145,7 +146,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         details = await client.getBooleanDetails(flagKey, defaultValue === 'true');
-      }
+      },
     );
 
     then(
@@ -154,7 +155,7 @@ defineFeature(feature, (test) => {
         expect(details.value).toEqual(expectedValue === 'true');
         expect(details.variant).toEqual(expectedVariant);
         expect(details.reason).toEqual(expectedReason);
-      }
+      },
     );
   });
 
@@ -169,7 +170,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         details = await client.getStringDetails(flagKey, defaultValue);
-      }
+      },
     );
 
     then(
@@ -178,7 +179,7 @@ defineFeature(feature, (test) => {
         expect(details.value).toEqual(expectedValue);
         expect(details.variant).toEqual(expectedVariant);
         expect(details.reason).toEqual(expectedReason);
-      }
+      },
     );
   });
 
@@ -193,7 +194,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         details = await client.getNumberDetails(flagKey, Number.parseInt(defaultValue));
-      }
+      },
     );
 
     then(
@@ -202,7 +203,7 @@ defineFeature(feature, (test) => {
         expect(details.value).toEqual(Number.parseInt(expectedValue));
         expect(details.variant).toEqual(expectedVariant);
         expect(details.reason).toEqual(expectedReason);
-      }
+      },
     );
   });
 
@@ -217,7 +218,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         details = await client.getNumberDetails(flagKey, Number.parseFloat(defaultValue));
-      }
+      },
     );
 
     then(
@@ -226,7 +227,7 @@ defineFeature(feature, (test) => {
         expect(details.value).toEqual(Number.parseFloat(expectedValue));
         expect(details.variant).toEqual(expectedVariant);
         expect(details.reason).toEqual(expectedReason);
-      }
+      },
     );
   });
 
@@ -249,7 +250,7 @@ defineFeature(feature, (test) => {
         expect(jsonObject[field1]).toEqual(boolValue === 'true');
         expect(jsonObject[field2]).toEqual(stringValue);
         expect(jsonObject[field3]).toEqual(Number.parseInt(intValue));
-      }
+      },
     );
 
     and(
@@ -257,7 +258,7 @@ defineFeature(feature, (test) => {
       (expectedVariant: string, expectedReason: string) => {
         expect(details.variant).toEqual(expectedVariant);
         expect(details.reason).toEqual(expectedReason);
-      }
+      },
     );
   });
 
@@ -278,13 +279,13 @@ defineFeature(feature, (test) => {
         stringValue1: string,
         stringValue2: string,
         intValue: string,
-        boolValue: string
+        boolValue: string,
       ) => {
         context[stringField1] = stringValue1;
         context[stringField2] = stringValue2;
         context[intField] = Number.parseInt(intValue);
         context[boolField] = boolValue === 'true';
-      }
+      },
     );
 
     and(
@@ -292,7 +293,7 @@ defineFeature(feature, (test) => {
       async (key: string, defaultValue: string) => {
         flagKey = key;
         value = await client.getStringValue(flagKey, defaultValue, context);
-      }
+      },
     );
 
     then(/^the resolved string response should be "(.*)"$/, (expectedValue: string) => {
@@ -318,7 +319,7 @@ defineFeature(feature, (test) => {
         flagKey = key;
         fallbackValue = defaultValue;
         details = await client.getStringDetails(flagKey, defaultValue);
-      }
+      },
     );
 
     then(/^the default string value should be returned$/, () => {
@@ -330,7 +331,7 @@ defineFeature(feature, (test) => {
       (errorCode: string) => {
         expect(details.reason).toEqual(StandardResolutionReasons.ERROR);
         expect(details.errorCode).toEqual(errorCode);
-      }
+      },
     );
   });
 
@@ -347,7 +348,7 @@ defineFeature(feature, (test) => {
         flagKey = key;
         fallbackValue = Number.parseInt(defaultValue);
         details = await client.getNumberDetails(flagKey, Number.parseInt(defaultValue));
-      }
+      },
     );
 
     then(/^the default integer value should be returned$/, () => {
@@ -359,7 +360,7 @@ defineFeature(feature, (test) => {
       (errorCode: string) => {
         expect(details.reason).toEqual(StandardResolutionReasons.ERROR);
         expect(details.errorCode).toEqual(errorCode);
-      }
+      },
     );
   });
 });

--- a/packages/server/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/server/e2e/step-definitions/evaluation.spec.ts
@@ -3,12 +3,11 @@ import {
   EvaluationDetails,
   JsonObject,
   JsonValue,
-  ProviderEvents,
   ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/core';
 import { defineFeature, loadFeature } from 'jest-cucumber';
-import { InMemoryProvider, OpenFeature } from '../../src';
+import { InMemoryProvider, OpenFeature, ProviderEvents } from '../../src';
 import flagConfiguration from './flags-config';
 
 // load the feature file.

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -11,18 +11,18 @@ import {
   Logger,
   ManageContext,
   OpenFeatureError,
-  ProviderEvents,
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
   statusMatchesEvent,
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
+import { ProviderEvents } from '../events';
+import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
+import { Hook } from '../hooks';
 import { OpenFeature } from '../open-feature';
 import { Provider } from '../provider';
 import { Client } from './client';
-import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
-import { Hook } from '../hooks';
 
 type OpenFeatureClientOptions = {
   name?: string;
@@ -54,7 +54,7 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
     };
   }
 
-  addHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void {
+  addHandler(eventType: ProviderEvents, handler: EventHandler): void {
     this.emitterAccessor().addHandler(eventType, handler);
     const shouldRunNow = statusMatchesEvent(eventType, this._provider.status);
 
@@ -68,7 +68,7 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
     }
   }
 
-  removeHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>) {
+  removeHandler(eventType: ProviderEvents, handler: EventHandler) {
     this.emitterAccessor().removeHandler(eventType, handler);
   }
 

--- a/packages/server/src/events/events.ts
+++ b/packages/server/src/events/events.ts
@@ -1,0 +1,3 @@
+import { ServerProviderEvents } from '@openfeature/core';
+
+export { ServerProviderEvents as ProviderEvents };

--- a/packages/server/src/events/index.ts
+++ b/packages/server/src/events/index.ts
@@ -1,1 +1,2 @@
 export * from './open-feature-event-emitter';
+export * from './events';

--- a/packages/server/src/events/internal/internal-event-emitter.ts
+++ b/packages/server/src/events/internal/internal-event-emitter.ts
@@ -1,8 +1,9 @@
-import { CommonEventDetails, GenericEventEmitter } from '@openfeature/core';
+import { GenericEventEmitter } from '@openfeature/core';
+import { ProviderEvents } from '../events';
 
 /**
  * The InternalEventEmitter is not exported publicly and should only be used within the SDK. It extends the
  * OpenFeatureEventEmitter to include additional properties that can be included
  * in the event details.
  */
-export abstract class InternalEventEmitter extends GenericEventEmitter<CommonEventDetails> {};
+export abstract class InternalEventEmitter extends GenericEventEmitter<ProviderEvents> {};

--- a/packages/server/src/events/open-feature-event-emitter.ts
+++ b/packages/server/src/events/open-feature-event-emitter.ts
@@ -1,5 +1,6 @@
 import { GenericEventEmitter } from '@openfeature/core';
 import EventEmitter from 'events';
+import { ProviderEvents } from './events';
 
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit
@@ -8,7 +9,7 @@ import EventEmitter from 'events';
  * NOTE: Ready and error events are automatically emitted by the SDK based on
  * the result of the initialize method.
  */
-export class OpenFeatureEventEmitter extends GenericEventEmitter {
+export class OpenFeatureEventEmitter extends GenericEventEmitter<ProviderEvents> {
   protected readonly eventEmitter = new EventEmitter({ captureRejections: true });
 
    constructor() {

--- a/packages/server/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/server/src/provider/in-memory-provider/in-memory-provider.ts
@@ -6,7 +6,6 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
-  ProviderEvents,
   ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError
@@ -14,7 +13,7 @@ import {
 import { Provider } from '../provider';
 import { Flag, FlagConfiguration } from './flag-configuration';
 import { VariantFoundError } from './variant-not-found-error';
-import { OpenFeatureEventEmitter } from '../..';
+import { OpenFeatureEventEmitter, ProviderEvents } from '../..';
 
 /**
  * A simple OpenFeature provider intended for demos and as a test stub.

--- a/packages/server/test/in-memory-provider.spec.ts
+++ b/packages/server/test/in-memory-provider.spec.ts
@@ -1,5 +1,4 @@
-import { FlagNotFoundError, ProviderEvents, StandardResolutionReasons, TypeMismatchError } from '@openfeature/core';
-import { InMemoryProvider } from '../src';
+import { FlagNotFoundError, InMemoryProvider, ProviderEvents, StandardResolutionReasons, TypeMismatchError } from '../src';
 import { VariantFoundError } from '../src/provider/in-memory-provider/variant-not-found-error';
 
 describe(InMemoryProvider, () => {

--- a/packages/shared/src/events/event-utils.ts
+++ b/packages/shared/src/events/event-utils.ts
@@ -1,10 +1,10 @@
 import { ProviderStatus } from '../provider';
-import { ProviderEvents } from './events';
+import { AllProviderEvents, AnyProviderEvent } from './events';
 
 const eventStatusMap = {
-    [ProviderStatus.READY]: ProviderEvents.Ready,
-    [ProviderStatus.ERROR]: ProviderEvents.Error,
-    [ProviderStatus.STALE]: ProviderEvents.Stale,
+    [ProviderStatus.READY]: AllProviderEvents.Ready,
+    [ProviderStatus.ERROR]: AllProviderEvents.Error,
+    [ProviderStatus.STALE]: AllProviderEvents.Stale,
     [ProviderStatus.NOT_READY]: undefined,
 };
 
@@ -15,6 +15,6 @@ const eventStatusMap = {
  * @param {ProviderStatus} status  status of provider
  * @returns {boolean} boolean indicating if the provider status corresponds to the event.
  */
-export const statusMatchesEvent = (event: ProviderEvents, status?: ProviderStatus): boolean => {
-    return (!status && event === ProviderEvents.Ready) || eventStatusMap[status!] === event;
+export const statusMatchesEvent = <T extends AnyProviderEvent>(event: T, status?: ProviderStatus): boolean => {
+    return (!status && event === AllProviderEvents.Ready) || eventStatusMap[status!] === event;
 };

--- a/packages/shared/src/events/event-utils.ts
+++ b/packages/shared/src/events/event-utils.ts
@@ -11,7 +11,7 @@ const eventStatusMap = {
 /**
  * Returns true if the provider's status corresponds to the event.
  * If the provider's status is not defined, it matches READY.
- * @param {ProviderEvents} event event to match
+ * @param {AnyProviderEvent} event event to match
  * @param {ProviderStatus} status  status of provider
  * @returns {boolean} boolean indicating if the provider status corresponds to the event.
  */

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -1,4 +1,4 @@
-import { ProviderEvents } from './events';
+import { AllProviderEvents, AnyProviderEvent } from './events';
 
 export type EventMetadata = {
   [key: string]: string | boolean | number;
@@ -20,19 +20,18 @@ export type StaleEvent = CommonEventProps;
 export type ConfigChangeEvent = CommonEventProps & { flagsChanged?: string[] };
 
 type EventMap = {
-  [ProviderEvents.Ready]: ReadyEvent;
-  [ProviderEvents.Error]: ErrorEvent;
-  [ProviderEvents.Stale]: StaleEvent;
-  [ProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
+  [AllProviderEvents.Ready]: ReadyEvent;
+  [AllProviderEvents.Error]: ErrorEvent;
+  [AllProviderEvents.Stale]: StaleEvent;
+  [AllProviderEvents.ContextChanged]: CommonEventProps;
+  [AllProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
 };
 
-export type EventContext<
-  T extends ProviderEvents,
-  U extends Record<string, unknown> = Record<string, unknown>
-> = EventMap[T] & U;
+export type EventContext<  U extends Record<string, unknown> = Record<string, unknown>
+> = EventMap[AllProviderEvents] & U;
 
-export type EventDetails<T extends ProviderEvents> = EventContext<T> & CommonEventDetails;
-export type EventHandler<T extends ProviderEvents> = (eventDetails?: EventDetails<T>) => Promise<unknown> | unknown;
+export type EventDetails = EventContext & CommonEventDetails;
+export type EventHandler = (eventDetails?: EventDetails) => Promise<unknown> | unknown;
 
 export interface Eventing {
   /**
@@ -41,19 +40,19 @@ export interface Eventing {
    * @param {ProviderEvents} eventType The provider event type to listen to
    * @param {EventHandler} handler The handler to run on occurrence of the event type
    */
-  addHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void;
+  addHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 
   /**
    * Removes a handler for the given provider event type.
    * @param {ProviderEvents} eventType The provider event type to remove the listener for
    * @param {EventHandler} handler The handler to remove for the provider event type
    */
-  removeHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void;
+  removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 
   /**
    * Gets the current handlers for the given provider event type.
    * @param {ProviderEvents} eventType The provider event type to get the current handlers for
    * @returns {EventHandler[]} The handlers currently attached to the given provider event type
    */
-  getHandlers<T extends ProviderEvents>(eventType: T): EventHandler<T>[];
+  getHandlers(eventType: AnyProviderEvent): EventHandler[];
 }

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -37,21 +37,21 @@ export interface Eventing {
   /**
    * Adds a handler for the given provider event type.
    * The handlers are called in the order they have been added.
-   * @param {ProviderEvents} eventType The provider event type to listen to
+   * @param {AnyProviderEvent} eventType The provider event type to listen to
    * @param {EventHandler} handler The handler to run on occurrence of the event type
    */
   addHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 
   /**
    * Removes a handler for the given provider event type.
-   * @param {ProviderEvents} eventType The provider event type to remove the listener for
+   * @param {AnyProviderEvent} eventType The provider event type to remove the listener for
    * @param {EventHandler} handler The handler to remove for the provider event type
    */
   removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void;
 
   /**
    * Gets the current handlers for the given provider event type.
-   * @param {ProviderEvents} eventType The provider event type to get the current handlers for
+   * @param {AnyProviderEvent} eventType The provider event type to get the current handlers for
    * @returns {EventHandler[]} The handlers currently attached to the given provider event type
    */
   getHandlers(eventType: AnyProviderEvent): EventHandler[];

--- a/packages/shared/src/events/events.ts
+++ b/packages/shared/src/events/events.ts
@@ -1,4 +1,11 @@
-export enum ProviderEvents {
+// TODO: with TypeScript 5+, we can use computed string properties,
+// so we can extract all of these into a shared set of string consts and use that in both enums
+// for now we have to duplicated them.
+
+/**
+ * An enumeration of possible events for server-sdk providers.
+ */
+export enum ServerProviderEvents {
   /**
    * The provider is ready to evaluate flags.
    */
@@ -19,3 +26,44 @@ export enum ProviderEvents {
    */
   Stale = 'PROVIDER_STALE',
 }
+
+/**
+ * An enumeration of possible events for web-sdk providers.
+ */
+export enum ClientProviderEvents {
+  /**
+   * The provider is ready to evaluate flags.
+   */
+  Ready = 'PROVIDER_READY',
+
+  /**
+   * The provider is in an error state.
+   */
+  Error = 'PROVIDER_ERROR',
+
+  /**
+   * The flag configuration in the source-of-truth has changed.
+   */
+  ConfigurationChanged = 'PROVIDER_CONFIGURATION_CHANGED',
+
+  /**
+   * The context associated with the provider has changed, and the provider has reconciled it's associated state.
+   */
+  ContextChanged = 'PROVIDER_CONTEXT_CHANGED',
+
+  /**
+   * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+   */
+  Stale = 'PROVIDER_STALE',
+}
+
+
+/* alias because in many cases, we iterate over all possible events in code,
+so we have to do this on ClientProviderEvents to be exhaustive */
+export { ClientProviderEvents as AllProviderEvents };
+
+/**
+ * A type representing any possible ProviderEvent (server or client side).
+ * If you are implementing a hook or provider, you probably want to import `ProviderEvents` from the respective SDK.
+ */
+export type AnyProviderEvent = ServerProviderEvents | ClientProviderEvents;

--- a/packages/shared/src/events/events.ts
+++ b/packages/shared/src/events/events.ts
@@ -1,6 +1,6 @@
 // TODO: with TypeScript 5+, we can use computed string properties,
 // so we can extract all of these into a shared set of string consts and use that in both enums
-// for now we have to duplicated them.
+// for now we have duplicated them.
 
 /**
  * An enumeration of possible events for server-sdk providers.

--- a/packages/shared/src/events/generic-event-emitter.ts
+++ b/packages/shared/src/events/generic-event-emitter.ts
@@ -1,30 +1,31 @@
 import { Logger, ManageLogger, SafeLogger } from '../logger';
 import { EventContext, EventDetails, EventHandler } from './eventing';
-import { ProviderEvents } from './events';
+import { AnyProviderEvent } from './events';
 
 /**
  * The GenericEventEmitter should only be used within the SDK. It supports additional properties that can be included
  * in the event details.
  */
-export abstract class GenericEventEmitter<AdditionalContext extends Record<string, unknown> = Record<string, unknown>>
-  implements ManageLogger<GenericEventEmitter<AdditionalContext>>
+export abstract class GenericEventEmitter<E extends AnyProviderEvent, AdditionalContext extends Record<string, unknown> = Record<string, unknown>>
+  implements ManageLogger<GenericEventEmitter<E, AdditionalContext>>
 {
   protected abstract readonly eventEmitter: PlatformEventEmitter;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly _handlers = new WeakMap<EventHandler<any>, EventHandler<any>>();
+  private readonly _handlers = new WeakMap<EventHandler, EventHandler>();
   private _eventLogger?: Logger;
 
   constructor(private readonly globalLogger?: () => Logger) {}
 
-  emit<T extends ProviderEvents>(eventType: T, context?: EventContext<T, AdditionalContext>): void {
+  // here we use E, to restrict the events a provider can manually emit (PROVIDER_CONTEXT_CHANGED is emitted by the SDK)
+  emit(eventType: E, context?: EventContext): void {
     this.eventEmitter.emit(eventType, context);
   }
 
-  addHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void {
+  addHandler(eventType: AnyProviderEvent, handler: EventHandler): void {
     // The handlers have to be wrapped with an async function because if a synchronous functions throws an error,
     // the other handlers will not run.
-    const asyncHandler = async (details?: EventDetails<T>) => {
+    const asyncHandler = async (details?: EventDetails) => {
       await handler(details);    
     };
     // The async handler has to be written to the map, because we need to get the wrapper function when deleting a listener
@@ -32,9 +33,9 @@ export abstract class GenericEventEmitter<AdditionalContext extends Record<strin
     this.eventEmitter.on(eventType, asyncHandler);
   }
 
-  removeHandler<T extends ProviderEvents>(eventType: T, handler: EventHandler<T>): void {
+  removeHandler(eventType: AnyProviderEvent, handler: EventHandler): void {
     // Get the wrapper function for this handler, to delete it from the event emitter
-    const asyncHandler = this._handlers.get(handler) as EventHandler<T> | undefined;
+    const asyncHandler = this._handlers.get(handler) as EventHandler | undefined;
 
     if (!asyncHandler) {
       return;
@@ -43,7 +44,7 @@ export abstract class GenericEventEmitter<AdditionalContext extends Record<strin
     this.eventEmitter.removeListener(eventType, asyncHandler);
   }
 
-  removeAllHandlers(eventType?: ProviderEvents): void {
+  removeAllHandlers(eventType?: AnyProviderEvent): void {
     // If giving undefined, the listeners are not removed, so we have to check explicitly
     if (eventType) {
       this.eventEmitter.removeAllListeners(eventType);
@@ -52,8 +53,8 @@ export abstract class GenericEventEmitter<AdditionalContext extends Record<strin
     }
   }
 
-  getHandlers<T extends ProviderEvents>(eventType: T): EventHandler<T>[] {
-    return this.eventEmitter.listeners(eventType) as EventHandler<T>[];
+  getHandlers(eventType: AnyProviderEvent): EventHandler[] {
+    return this.eventEmitter.listeners(eventType) as EventHandler[];
   }
 
   setLogger(logger: Logger): this {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -1,9 +1,16 @@
 import { GeneralError } from './errors';
 import { EvaluationContext } from './evaluation';
-import { AllProviderEvents, AnyProviderEvent, EventDetails, EventHandler, Eventing, statusMatchesEvent } from './events';
-import { GenericEventEmitter } from './events';
+import {
+  AllProviderEvents,
+  AnyProviderEvent,
+  EventDetails,
+  EventHandler,
+  Eventing,
+  GenericEventEmitter,
+  statusMatchesEvent,
+} from './events';
 import { isDefined } from './filter';
-import { EvaluationLifeCycle, BaseHook } from './hooks';
+import { BaseHook, EvaluationLifeCycle } from './hooks';
 import { DefaultLogger, Logger, ManageLogger, SafeLogger } from './logger';
 import { CommonProvider, ProviderMetadata, ProviderStatus } from './provider';
 import { objectOrUndefined, stringOrUndefined } from './type-guards';
@@ -20,8 +27,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
   protected _context: EvaluationContext = {};
   protected _logger: Logger = new DefaultLogger();
 
-  private readonly _clientEventHandlers: Map<string | undefined, [AnyProviderEvent, EventHandler][]> =
-    new Map();
+  private readonly _clientEventHandlers: Map<string | undefined, [AnyProviderEvent, EventHandler][]> = new Map();
   protected _clientProviders: Map<string, P> = new Map();
   protected _clientEvents: Map<string | undefined, GenericEventEmitter<AnyProviderEvent>> = new Map();
   protected _runsOn: Paradigm;
@@ -212,9 +218,9 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
         })
         ?.catch((error) => {
           this.getAssociatedEventEmitters(clientName).forEach((emitter) => {
-            emitter?.emit(AllProviderEvents.Error, { clientName, providerName, message: error.message });
+            emitter?.emit(AllProviderEvents.Error, { clientName, providerName, message: error?.message });
           });
-          this._events?.emit(AllProviderEvents.Error, { clientName, providerName, message: error.message });
+          this._events?.emit(AllProviderEvents.Error, { clientName, providerName, message: error?.message });
           // rethrow after emitting error events, so that public methods can control error handling
           throw error;
         });
@@ -271,7 +277,6 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
     return newEmitter;
   }
 
-
   private getUnboundEmitters(): GenericEventEmitter<AnyProviderEvent>[] {
     const namedProviders = [...this._clientProviders.keys()];
     const eventEmitterNames = [...this._clientEvents.keys()].filter(isDefined);
@@ -299,9 +304,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
       ?.forEach((eventHandler) => oldProvider.events?.removeHandler(...eventHandler));
 
     // iterate over the event types
-    const newClientHandlers = Object.values(AllProviderEvents).map<
-      [AllProviderEvents, EventHandler]
-    >((eventType) => {
+    const newClientHandlers = Object.values(AllProviderEvents).map<[AllProviderEvents, EventHandler]>((eventType) => {
       const handler = async (details?: EventDetails) => {
         // on each event type, fire the associated handlers
         emitters.forEach((emitter) => {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -77,7 +77,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
    * Adds a handler for the given provider event type.
    * The handlers are called in the order they have been added.
    * API (global) events run for all providers.
-   * @param {ProviderEvents} eventType The provider event type to listen to
+   * @param {AnyProviderEvent} eventType The provider event type to listen to
    * @param {EventHandler} handler The handler to run on occurrence of the event type
    */
   addHandler<T extends AnyProviderEvent>(eventType: T, handler: EventHandler): void {
@@ -101,7 +101,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
 
   /**
    * Removes a handler for the given provider event type.
-   * @param {ProviderEvents} eventType The provider event type to remove the listener for
+   * @param {AnyProviderEvent} eventType The provider event type to remove the listener for
    * @param {EventHandler} handler The handler to remove for the provider event type
    */
   removeHandler<T extends AnyProviderEvent>(eventType: T, handler: EventHandler): void {
@@ -110,7 +110,7 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
 
   /**
    * Gets the current handlers for the given provider event type.
-   * @param {ProviderEvents} eventType The provider event type to get the current handlers for
+   * @param {AnyProviderEvent} eventType The provider event type to get the current handlers for
    * @returns {EventHandler[]} The handlers currently attached to the given provider event type
    */
   getHandlers<T extends AnyProviderEvent>(eventType: T): EventHandler[] {

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -1,5 +1,5 @@
 import { EvaluationContext } from '../evaluation';
-import { GenericEventEmitter } from '../events';
+import { AnyProviderEvent, GenericEventEmitter } from '../events';
 import { Metadata, Paradigm } from '../types';
 
 /**
@@ -57,7 +57,7 @@ export interface CommonProvider {
    * An event emitter for ProviderEvents.
    * @see ProviderEvents
    */
-  events?: GenericEventEmitter;
+  events?: GenericEventEmitter<AnyProviderEvent>;
 
   /**
    * A function used to shut down the provider.

--- a/packages/shared/test/events.spec.ts
+++ b/packages/shared/test/events.spec.ts
@@ -1,8 +1,8 @@
 import EventEmitter from 'events';
-import { GenericEventEmitter, Logger, ProviderEvents, ReadyEvent } from '../src';
+import { GenericEventEmitter, Logger, AllProviderEvents, ReadyEvent, AnyProviderEvent } from '../src';
 
 // create concrete class to test the abstract functionality.
-class TestEventEmitter extends GenericEventEmitter {
+class TestEventEmitter extends GenericEventEmitter<AnyProviderEvent> {
   protected readonly eventEmitter = new EventEmitter({ captureRejections: true });
 
   constructor() {
@@ -19,8 +19,8 @@ describe('GenericEventEmitter', () => {
       const emitter = new TestEventEmitter();
 
       const handler1 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.emit(ProviderEvents.Ready);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
     });
@@ -32,11 +32,11 @@ describe('GenericEventEmitter', () => {
       const handler2 = jest.fn();
       const handler3 = jest.fn();
 
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.addHandler(ProviderEvents.Ready, handler2);
-      emitter.addHandler(ProviderEvents.Error, handler3);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Ready, handler2);
+      emitter.addHandler(AllProviderEvents.Error, handler3);
 
-      emitter.emit(ProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
       expect(handler2).toHaveBeenCalledTimes(1);
@@ -56,18 +56,18 @@ describe('GenericEventEmitter', () => {
       const emitter = new TestEventEmitter();
       emitter.setLogger(logger);
 
-      emitter.addHandler(ProviderEvents.Ready, async () => {
+      emitter.addHandler(AllProviderEvents.Ready, async () => {
         throw Error();
       });
-      emitter.emit(ProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
     });
 
     it('trigger handler for event type', function () {
       const emitter = new TestEventEmitter();
 
       const handler1 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.emit(ProviderEvents.Ready);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
     });
@@ -77,8 +77,8 @@ describe('GenericEventEmitter', () => {
       const emitter = new TestEventEmitter();
 
       const handler1 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.emit(ProviderEvents.Ready, event);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.emit(AllProviderEvents.Ready, event);
 
       expect(handler1).toHaveBeenNthCalledWith(1, event);
     });
@@ -90,11 +90,11 @@ describe('GenericEventEmitter', () => {
       const handler2 = jest.fn();
       const handler3 = jest.fn();
 
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.addHandler(ProviderEvents.Ready, handler2);
-      emitter.addHandler(ProviderEvents.Error, handler3);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Ready, handler2);
+      emitter.addHandler(AllProviderEvents.Error, handler3);
 
-      emitter.emit(ProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
       expect(handler2).toHaveBeenCalledTimes(1);
@@ -107,11 +107,11 @@ describe('GenericEventEmitter', () => {
       const emitter = new TestEventEmitter();
 
       const handler1 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
 
-      emitter.emit(ProviderEvents.Ready);
-      emitter.removeHandler(ProviderEvents.Ready, handler1);
-      emitter.emit(ProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
+      emitter.removeHandler(AllProviderEvents.Ready, handler1);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
     });
@@ -123,12 +123,12 @@ describe('GenericEventEmitter', () => {
 
       const handler1 = jest.fn();
       const handler2 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.addHandler(ProviderEvents.Error, handler2);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Error, handler2);
 
-      emitter.removeAllHandlers(ProviderEvents.Ready);
-      emitter.emit(ProviderEvents.Ready);
-      emitter.emit(ProviderEvents.Error);
+      emitter.removeAllHandlers(AllProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Error);
 
       expect(handler1).toHaveBeenCalledTimes(0);
       expect(handler2).toHaveBeenCalledTimes(1);
@@ -139,12 +139,12 @@ describe('GenericEventEmitter', () => {
 
       const handler1 = jest.fn();
       const handler2 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.addHandler(ProviderEvents.Error, handler2);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Error, handler2);
 
-      emitter.emit(ProviderEvents.Ready);
-      emitter.removeAllHandlers(ProviderEvents.Ready);
-      emitter.emit(ProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
+      emitter.removeAllHandlers(AllProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Ready);
 
       expect(handler1).toHaveBeenCalledTimes(1);
       expect(handler2).toHaveBeenCalledTimes(0);
@@ -155,14 +155,14 @@ describe('GenericEventEmitter', () => {
 
       const handler1 = jest.fn();
       const handler2 = jest.fn();
-      emitter.addHandler(ProviderEvents.Ready, handler1);
-      emitter.addHandler(ProviderEvents.Error, handler2);
+      emitter.addHandler(AllProviderEvents.Ready, handler1);
+      emitter.addHandler(AllProviderEvents.Error, handler2);
 
-      emitter.emit(ProviderEvents.Ready);
-      emitter.emit(ProviderEvents.Error);
+      emitter.emit(AllProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Error);
       emitter.removeAllHandlers();
-      emitter.emit(ProviderEvents.Ready);
-      emitter.emit(ProviderEvents.Error);
+      emitter.emit(AllProviderEvents.Ready);
+      emitter.emit(AllProviderEvents.Error);
 
       expect(handler1).toHaveBeenCalledTimes(1);
       expect(handler2).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
This PR:

- adds `PROVIDER_CONTEXT_CHANGED` events, which, in the static paradigm, can be used to inform the SDK that the flags should be re-evaluated (important for UI repaints in React, for instance (note this event is only available in the web-sdk)
- runs the associated `PROVIDER_CONTEXT_CHANGED` handlers if the provider's context handler function ran successfully or `PROVIDER_ERROR` handlers otherwise.
- adds associated tests

A decent amount of this is just typing magic to reduce duplicated code while making the new event only available in the web-sdk.

See: [associated spec change](https://github.com/open-feature/spec/pull/200) 

Fixes: https://github.com/open-feature/js-sdk/issues/729