### PR TITLE
feat: add optout global context interceptors

### DIFF
--- a/packages/nest/test/fixtures.ts
+++ b/packages/nest/test/fixtures.ts
@@ -1,0 +1,75 @@
+import { InMemoryProvider } from '@openfeature/server-sdk';
+import { ExecutionContext } from '@nestjs/common';
+import { OpenFeatureModule } from '../src';
+
+export const defaultProvider = new InMemoryProvider({
+  testBooleanFlag: {
+    defaultVariant: 'default',
+    variants: { default: true },
+    disabled: false,
+  },
+  testStringFlag: {
+    defaultVariant: 'default',
+    variants: { default: 'expected-string-value-default' },
+    disabled: false,
+  },
+  testNumberFlag: {
+    defaultVariant: 'default',
+    variants: { default: 10 },
+    disabled: false,
+  },
+  testObjectFlag: {
+    defaultVariant: 'default',
+    variants: { default: { client: 'default' } },
+    disabled: false,
+  },
+});
+
+
+export const providers = {
+  namedClient: new InMemoryProvider({
+    testBooleanFlag: {
+      defaultVariant: 'default',
+      variants: { default: true },
+      disabled: false,
+    },
+    testStringFlag: {
+      defaultVariant: 'default',
+      variants: { default: 'expected-string-value-named' },
+      disabled: false,
+    },
+    testNumberFlag: {
+      defaultVariant: 'default',
+      variants: { default: 10 },
+      disabled: false,
+    },
+    testObjectFlag: {
+      defaultVariant: 'default',
+      variants: { default: { client: 'named' } },
+      disabled: false,
+    },
+  }),
+};
+
+
+export const exampleContextFactory = async (context: ExecutionContext) => {
+  const request = await context.switchToHttp().getRequest();
+
+  const userId = request.header('x-user-id');
+
+  if (userId) {
+    return {
+      targetingKey: userId,
+    };
+  }
+
+  return undefined;
+};
+
+export const getOpenFeatureDefaultTestModule = () => {
+  return OpenFeatureModule.forRoot({
+    contextFactory: exampleContextFactory,
+    defaultProvider,
+    providers
+  });
+};

--- a/packages/nest/test/open-feature-sdk.spec.ts
+++ b/packages/nest/test/open-feature-sdk.spec.ts
@@ -1,176 +1,181 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import supertest from 'supertest';
-import { exampleContextFactory, OpenFeatureController, OpenFeatureTestService } from './test-app';
+import { OpenFeatureController, OpenFeatureControllerContextScopedController, OpenFeatureTestService } from './test-app';
+import { exampleContextFactory, getOpenFeatureDefaultTestModule } from './fixtures';
 import { OpenFeatureModule } from '../src';
-import { InMemoryProvider } from '@openfeature/server-sdk';
+import { defaultProvider, providers } from './fixtures';
 
 describe('OpenFeature SDK', () => {
-  let moduleRef: TestingModule;
-  let app: INestApplication;
-  let defaultProvider: InMemoryProvider;
-  let namedProvider: InMemoryProvider;
 
-  beforeAll(async () => {
-    defaultProvider = new InMemoryProvider({
-      testBooleanFlag: {
-        defaultVariant: 'default',
-        variants: { default: true },
-        disabled: false,
-      },
-      testStringFlag: {
-        defaultVariant: 'default',
-        variants: { default: 'expected-string-value-default' },
-        disabled: false,
-      },
-      testNumberFlag: {
-        defaultVariant: 'default',
-        variants: { default: 10 },
-        disabled: false,
-      },
-      testObjectFlag: {
-        defaultVariant: 'default',
-        variants: { default: { client: 'default' } },
-        disabled: false,
-      },
+  describe('With global context interceptor', () => {
+    let moduleRef: TestingModule;
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      moduleRef = await Test.createTestingModule({
+        imports: [
+          getOpenFeatureDefaultTestModule()
+        ],
+        providers: [OpenFeatureTestService],
+        controllers: [OpenFeatureController],
+      }).compile();
+      app = moduleRef.createNestApplication();
+      app = await app.init();
     });
 
-    namedProvider = new InMemoryProvider({
-      testBooleanFlag: {
-        defaultVariant: 'default',
-        variants: { default: true },
-        disabled: false,
-      },
-      testStringFlag: {
-        defaultVariant: 'default',
-        variants: { default: 'expected-string-value-named' },
-        disabled: false,
-      },
-      testNumberFlag: {
-        defaultVariant: 'default',
-        variants: { default: 10 },
-        disabled: false,
-      },
-      testObjectFlag: {
-        defaultVariant: 'default',
-        variants: { default: { client: 'named' } },
-        disabled: false,
-      },
+    afterAll(async () => {
+      await moduleRef.close();
     });
 
-    moduleRef = await Test.createTestingModule({
-      imports: [
-        OpenFeatureModule.forRoot({
-          contextFactory: exampleContextFactory,
-          defaultProvider: defaultProvider,
-          providers: {
-            namedClient: namedProvider,
-          },
-        }),
-      ],
-      providers: [OpenFeatureTestService],
-      controllers: [OpenFeatureController],
-    }).compile();
-    app = moduleRef.createNestApplication();
-    app = await app.init();
+    describe('openfeature client decorator', () => {
+      it('should inject the correct open feature clients', async () => {
+        const testService = moduleRef.get(OpenFeatureTestService);
+        expect(testService.defaultClient).toBeDefined();
+        expect(await testService.defaultClient.getStringValue('testStringFlag', 'wrong-value')).toEqual(
+          'expected-string-value-default',
+        );
+
+        expect(testService.namedClient).toBeDefined();
+        expect(await testService.namedClient.getStringValue('testStringFlag', 'wrong-value')).toEqual(
+          'expected-string-value-named',
+        );
+      });
+    });
+
+    describe('feature flag decorators', () => {
+      it('should inject the correct boolean feature flag evaluation details', async () => {
+        const testService = app.get(OpenFeatureTestService);
+        const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
+
+        await supertest(app.getHttpServer()).get('/boolean').expect(200).expect('true');
+
+        expect(testServiceSpy).toHaveBeenCalledWith({
+          flagKey: 'testBooleanFlag',
+          flagMetadata: {},
+          reason: 'STATIC',
+          value: true,
+          variant: 'default',
+        });
+      });
+
+      it('should inject the correct string feature flag evaluation details', async () => {
+        const testService = app.get(OpenFeatureTestService);
+        const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
+
+        await supertest(app.getHttpServer()).get('/string').expect(200).expect('expected-string-value-default');
+
+        expect(testServiceSpy).toHaveBeenCalledWith({
+          flagKey: 'testStringFlag',
+          flagMetadata: {},
+          reason: 'STATIC',
+          value: 'expected-string-value-default',
+          variant: 'default',
+        });
+      });
+
+      it('should inject the correct number feature flag evaluation details', async () => {
+        const testService = app.get(OpenFeatureTestService);
+        const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
+
+        await supertest(app.getHttpServer()).get('/number').expect(200).expect('10');
+
+        expect(testServiceSpy).toHaveBeenCalledWith({
+          flagKey: 'testNumberFlag',
+          flagMetadata: {},
+          reason: 'STATIC',
+          value: 10,
+          variant: 'default',
+        });
+      });
+
+      it('should inject the correct object feature flag evaluation details', async () => {
+        const testService = app.get(OpenFeatureTestService);
+        const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
+
+        await supertest(app.getHttpServer()).get('/object').expect(200).expect({ client: 'default' });
+
+        expect(testServiceSpy).toHaveBeenCalledWith({
+          flagKey: 'testObjectFlag',
+          flagMetadata: {},
+          reason: 'STATIC',
+          value: { client: 'default' },
+          variant: 'default',
+        });
+      });
+
+      it('should use the execution context from contextFactory', async () => {
+        const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
+        await supertest(app.getHttpServer()).get('/dynamic-context').set('x-user-id', '123').expect(200).expect('true');
+        expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, { targetingKey: '123' }, {});
+      });
+    });
+
+    describe('evaluation context service should', () => {
+      it('inject the evaluation context from contex factory', async function() {
+        const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
+        await supertest(app.getHttpServer())
+          .get('/dynamic-context-in-service')
+          .set('x-user-id', 'dynamic-user')
+          .expect(200)
+          .expect('true');
+        expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, { targetingKey: 'dynamic-user' }, {});
+      });
+    });
   });
 
-  afterAll(async () => {
-    await moduleRef.close();
-  });
+  describe('Without global context interceptor', () => {
 
-  describe('openfeature client decorator', () => {
-    it('should inject the correct open feature clients', async () => {
-      const testService = moduleRef.get(OpenFeatureTestService);
-      expect(testService.defaultClient).toBeDefined();
-      expect(await testService.defaultClient.getStringValue('testStringFlag', 'wrong-value')).toEqual(
-        'expected-string-value-default',
-      );
+    let moduleRef: TestingModule;
+    let app: INestApplication;
 
-      expect(testService.namedClient).toBeDefined();
-      expect(await testService.namedClient.getStringValue('testStringFlag', 'wrong-value')).toEqual(
-        'expected-string-value-named',
-      );
-    });
-  });
+    beforeAll(async () => {
 
-  describe('feature flag decorators', () => {
-    it('should inject the correct boolean feature flag evaluation details', async () => {
-      const testService = app.get(OpenFeatureTestService);
-      const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
-
-      await supertest(app.getHttpServer()).get('/boolean').expect(200).expect('true');
-
-      expect(testServiceSpy).toHaveBeenCalledWith({
-        flagKey: 'testBooleanFlag',
-        flagMetadata: {},
-        reason: 'STATIC',
-        value: true,
-        variant: 'default',
-      });
+      moduleRef = await Test.createTestingModule({
+        imports: [
+          OpenFeatureModule.forRoot({
+            contextFactory: exampleContextFactory,
+            defaultProvider,
+            providers,
+            useGlobalInterceptor: false
+          }),
+        ],
+        providers: [OpenFeatureTestService],
+        controllers: [OpenFeatureController, OpenFeatureControllerContextScopedController],
+      }).compile();
+      app = moduleRef.createNestApplication();
+      app = await app.init();
     });
 
-    it('should inject the correct string feature flag evaluation details', async () => {
-      const testService = app.get(OpenFeatureTestService);
-      const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
-
-      await supertest(app.getHttpServer()).get('/string').expect(200).expect('expected-string-value-default');
-
-      expect(testServiceSpy).toHaveBeenCalledWith({
-        flagKey: 'testStringFlag',
-        flagMetadata: {},
-        reason: 'STATIC',
-        value: 'expected-string-value-default',
-        variant: 'default',
-      });
+    afterAll(async () => {
+      await moduleRef.close();
     });
 
-    it('should inject the correct number feature flag evaluation details', async () => {
-      const testService = app.get(OpenFeatureTestService);
-      const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
-
-      await supertest(app.getHttpServer()).get('/number').expect(200).expect('10');
-
-      expect(testServiceSpy).toHaveBeenCalledWith({
-        flagKey: 'testNumberFlag',
-        flagMetadata: {},
-        reason: 'STATIC',
-        value: 10,
-        variant: 'default',
-      });
-    });
-
-    it('should inject the correct object feature flag evaluation details', async () => {
-      const testService = app.get(OpenFeatureTestService);
-      const testServiceSpy = jest.spyOn(testService, 'serviceMethod');
-
-      await supertest(app.getHttpServer()).get('/object').expect(200).expect({ client: 'default' });
-
-      expect(testServiceSpy).toHaveBeenCalledWith({
-        flagKey: 'testObjectFlag',
-        flagMetadata: {},
-        reason: 'STATIC',
-        value: { client: 'default' },
-        variant: 'default',
-      });
-    });
-
-    it('should use the execution context from contextFactory', async () => {
+    it('should not use context if global context interceptor is not configured', async () => {
       const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
       await supertest(app.getHttpServer()).get('/dynamic-context').set('x-user-id', '123').expect(200).expect('true');
-      expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, { targetingKey: '123' }, {});
+      expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, {}, {});
     });
-  });
 
-  describe('evaluation context service should', () => {
-    it('inject the evaluation context from contex factory', async function () {
-      const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
-      await supertest(app.getHttpServer())
-        .get('/dynamic-context-in-service')
-        .set('x-user-id', 'dynamic-user')
-        .expect(200)
-        .expect('true');
-      expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, { targetingKey: 'dynamic-user' }, {});
+    describe('evaluation context service should', () => {
+      it('inject empty context if no context interceptor is configured', async function() {
+        const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
+        await supertest(app.getHttpServer())
+          .get('/dynamic-context-in-service')
+          .set('x-user-id', 'dynamic-user')
+          .expect(200)
+          .expect('true');
+        expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, {}, {});
+      });
+    });
+
+    describe('With Controller bound Context interceptor', () => {
+
+      it('should not use context if global context interceptor is not configured', async () => {
+        const evaluationSpy = jest.spyOn(defaultProvider, 'resolveBooleanEvaluation');
+        await supertest(app.getHttpServer()).get('/controller-context').set('x-user-id', '123').expect(200).expect('true');
+        expect(evaluationSpy).toHaveBeenCalledWith('testBooleanFlag', false, { targetingKey: '123' }, {});
+      });
     });
   });
 });

--- a/packages/nest/test/open-feature.module.spec.ts
+++ b/packages/nest/test/open-feature.module.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getOpenFeatureClientToken, OpenFeatureModule } from '../src';
 import { OpenFeatureClient } from '@openfeature/server-sdk';
-import { getOpenFeatureTestModule } from './test-app';
+import { getOpenFeatureDefaultTestModule } from './fixtures';
 
 describe('OpenFeatureModule', () => {
   let moduleRef: TestingModule;
@@ -9,7 +9,7 @@ describe('OpenFeatureModule', () => {
   describe('client injection', () => {
     beforeAll(async () => {
       moduleRef = await Test.createTestingModule({
-        imports: [getOpenFeatureTestModule()],
+        imports: [getOpenFeatureDefaultTestModule()],
       }).compile();
     });
 


### PR DESCRIPTION
## This PR

- Makes it possible to deactivate the global OF context interceptor

### Notes

It currently supports passing a default context factory that is injected whenever the interceptor class is passed to `UseInterceptors`.
