### PR TITLE
feat: set context during provider registration

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -116,7 +116,7 @@ To register a provider and ensure it is ready before further actions are taken, 
 
 ```ts
 await OpenFeature.setProviderAndWait(new MyProvider());
-```  
+```
 
 #### Synchronous
 
@@ -154,13 +154,21 @@ In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specific
 If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
 
 ```ts
+// Sets global context during provider registration
+await OpenFeature.setProvider(new MyProvider(), { origin: document.location.host })
+```
+
+Change context after the provider has been registered using `setContext`.
+
+```ts
 // Set a value to the global context
-await OpenFeature.setContext({ origin: document.location.host });
+await OpenFeature.setContext({ targetingKey: localStorage.getItem("targetingKey") });
 ```
 
 Context is global and setting it is `async`.
 Providers may implement an `onContextChanged` method that receives the old context and the newer one.
-This method is used internally by the provider to detect if, given the context change, the flags values cached on client side are invalid. If needed a request will be made to the provider with the new context in order to get the correct flags values.
+This method is used internally by the provider to detect if, given the context change, the flags values cached on client side are invalid.
+If needed a request will be made to the provider with the new context in order to get the correct flags values.
 
 ### Hooks
 
@@ -223,6 +231,24 @@ const clientWithDefault = OpenFeature.getClient();
 // A Client backed by NewCachedProvider
 const clientForCache = OpenFeature.getClient("clientForCache");
 ```
+
+#### Manage evaluation context for named clients
+
+By default, named clients use the global context.
+This can be overridden by explicitly setting context during initialization or by references the name used during provider registration.
+
+```ts
+OpenFeature.setProvider("clientForCache", new NewCachedProvider(), { isCache: true});
+```
+
+Change context after the provider has been registered by using `setContext` with a name.
+
+```ts
+OpenFeature.setContext("clientForCache", { targetingKey: localStorage.getItem("targetingKey") })
+```
+
+Once context has been defined for a named client, it will override the global context for all clients using the associated provider.
+Context can be cleared using for a named provider using `OpenFeature.clearContext("clientForCache")` or call `OpenFeature.clearContexts` to reset all context.
 
 ### Eventing
 

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -146,7 +146,7 @@ describe('OpenFeatureClient', () => {
       expect(provider.status).toBe(ProviderStatus.NOT_READY);
       await OpenFeature.setProviderAndWait(provider);
       expect(provider.status).toBe(ProviderStatus.READY);
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should wait for the provider to fail during initialization', async () => {
@@ -156,7 +156,7 @@ describe('OpenFeatureClient', () => {
       expect(provider.status).toBe(ProviderStatus.NOT_READY);
       await expect(OpenFeature.setProviderAndWait(provider)).rejects.toThrow();
       expect(provider.status).toBe(ProviderStatus.ERROR);
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -135,6 +135,9 @@ In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specific
 If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
 
 ```ts
+// set global context during provider registration
+OpenFeature.setProvider(new MyProvider(), { host: 'localhost' })
+
 // set a value to the global context
 OpenFeature.setContext({ region: "us-east-1" });
 
@@ -151,6 +154,9 @@ const requestContext = {
 
 const boolValue = await client.getBooleanValue('some-flag', false, requestContext);
 ```
+
+Context is merged by the SDK before performing a flag evaluation.
+The merge is order is defined [here](https://openfeature.dev/specification/sections/evaluation-context#requirement-323) in the OpenFeature specification.
 
 ### Hooks
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -54,6 +54,119 @@ export class OpenFeatureAPI
     return instance;
   }
 
+  /**
+   * Sets the default provider for flag evaluations and returns a promise that resolves when the provider is ready.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
+   * Setting a provider supersedes the current provider used in new and existing clients without a name.
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {Promise<void>}
+   * @throws Uncaught exceptions thrown by the provider during initialization.
+   */
+  setProviderAndWait(provider: Provider): Promise<void>;
+  /**
+   * Sets the default provider and evaluation context for flag evaluations and returns a promise that resolves when the provider is ready.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
+   * Setting a provider supersedes the current provider used in new and existing clients without a name.
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @param {EvaluationContext} context The evaluation context to use for flag evaluations.
+   * @returns {Promise<void>}
+   * @throws Uncaught exceptions thrown by the provider during initialization.
+   */
+  setProviderAndWait(provider: Provider, context: EvaluationContext): Promise<void>;
+  /**
+   * Sets the provider that OpenFeature will use for flag evaluations of providers with the given name.
+   * A promise is returned that resolves when the provider is ready.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   * @param {string} clientName The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {Promise<void>}
+   * @throws Uncaught exceptions thrown by the provider during initialization.
+   */
+  setProviderAndWait(clientName: string, provider: Provider): Promise<void>;
+  /**
+   * Sets the provider and evaluation context for flag evaluations of providers with the given name.
+   * A promise is returned that resolves when the provider is ready.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   * @param {string} clientName The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @param {EvaluationContext} context The evaluation context to use for flag evaluations.
+   * @returns {Promise<void>}
+   * @throws Uncaught exceptions thrown by the provider during initialization.
+   */
+  setProviderAndWait(clientName: string, provider: Provider, context: EvaluationContext): Promise<void>;
+  async setProviderAndWait(
+    clientOrProvider?: string | Provider,
+    providerContextOrUndefined?: Provider | EvaluationContext,
+    contextOrUndefined?: EvaluationContext,
+  ): Promise<void> {
+    const clientName = stringOrUndefined(clientOrProvider);
+    const provider = clientName
+      ? objectOrUndefined<Provider>(providerContextOrUndefined)
+      : objectOrUndefined<Provider>(clientOrProvider);
+    const context = clientName
+      ? objectOrUndefined<EvaluationContext>(contextOrUndefined)
+      : objectOrUndefined<EvaluationContext>(providerContextOrUndefined);
+    if (context) {
+      this.setContext(context);
+    }
+    await this.setAwaitableProvider(clientName, provider, this.getContext());
+  }
+
+  /**
+   * Sets the default provider for flag evaluations.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
+   * Setting a provider supersedes the current provider used in new and existing clients without a name.
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {this} OpenFeature API
+   */
+  setProvider(provider: Provider): this;
+  /**
+   * Sets the default provider and evaluation context for flag evaluations.
+   * This provider will be used by unnamed clients and named clients to which no provider is bound.
+   * Settings a provider supersedes the current provider used in new and existing clients without a name.
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @param context {EvaluationContext} The evaluation context to use for flag evaluations.
+   * @returns {this} OpenFeature API
+   */
+  setProvider(provider: Provider, context: EvaluationContext): this;
+  /**
+   * Sets the provider for flag evaluations of providers with the given name.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   * @param {string} clientName The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @returns {this} OpenFeature API
+   */
+  setProvider(clientName: string, provider: Provider): this;
+  /**
+   * Sets the provider and evaluation context flag evaluations of providers with the given name.
+   * Setting a provider supersedes the current provider used in new and existing clients with that name.
+   * @param {string} clientName The name to identify the client
+   * @param {Provider} provider The provider responsible for flag evaluations.
+   * @param context {EvaluationContext} The evaluation context to use for flag evaluations.
+   * @returns {this} OpenFeature API
+   */
+  setProvider(clientName: string, provider: Provider, context: EvaluationContext): this;
+  setProvider(
+    clientOrProvider?: string | Provider,
+    providerContextOrUndefined?: Provider | EvaluationContext,
+    contextOrUndefined?: EvaluationContext,
+  ): this {
+    const clientName = stringOrUndefined(clientOrProvider);
+    const provider = clientName
+      ? objectOrUndefined<Provider>(providerContextOrUndefined)
+      : objectOrUndefined<Provider>(clientOrProvider);
+    const context = clientName
+      ? objectOrUndefined<EvaluationContext>(contextOrUndefined)
+      : objectOrUndefined<EvaluationContext>(providerContextOrUndefined);
+
+    if (context) {
+      this.setContext(context);
+    }
+
+    this.catchPromiseErrors(this.setAwaitableProvider(clientName, provider, this.getContext()));
+    return this;
+  }
+
   setContext(context: EvaluationContext): this {
     this._context = context;
     return this;

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -137,7 +137,7 @@ describe('OpenFeatureClient', () => {
       expect(provider.status).toBe(ProviderStatus.NOT_READY);
       await OpenFeature.setProviderAndWait(provider);
       expect(provider.status).toBe(ProviderStatus.READY);
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
     });
 
     it('should wait for the provider to fail during initialization', async () => {
@@ -147,7 +147,7 @@ describe('OpenFeatureClient', () => {
       expect(provider.status).toBe(ProviderStatus.NOT_READY);
       await expect(OpenFeature.setProviderAndWait(provider)).rejects.toThrow();
       expect(provider.status).toBe(ProviderStatus.ERROR);
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/packages/server/test/evaluation-context.spec.ts
+++ b/packages/server/test/evaluation-context.spec.ts
@@ -1,0 +1,89 @@
+import {
+  EvaluationContext,
+  JsonValue,
+  OpenFeature,
+  Provider,
+  ProviderMetadata,
+  ProviderStatus,
+  ResolutionDetails,
+} from '../src';
+
+const initializeMock = jest.fn();
+
+class MockProvider implements Provider {
+  readonly metadata: ProviderMetadata;
+  status = ProviderStatus.NOT_READY;
+
+  constructor(options?: { name?: string }) {
+    this.metadata = { name: options?.name ?? 'mock-provider' };
+  }
+
+  initialize = initializeMock;
+
+  resolveBooleanEvaluation(): Promise<ResolutionDetails<boolean>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveStringEvaluation(): Promise<ResolutionDetails<string>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveNumberEvaluation(): Promise<ResolutionDetails<number>> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(): Promise<ResolutionDetails<T>> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe('Evaluation Context', () => {
+  afterEach(async () => {
+    OpenFeature.setContext({});
+    jest.clearAllMocks();
+  });
+
+  describe('Requirement 3.2.2', () => {
+    it('the API MUST have a method for setting the global evaluation context', () => {
+      const context: EvaluationContext = { property1: false };
+      OpenFeature.setContext(context);
+      expect(OpenFeature.getContext()).toEqual(context);
+    });
+
+    it('the API MUST have a method for setting evaluation context for a named client', () => {
+      const context: EvaluationContext = { property1: false };
+      OpenFeature.setContext(context);
+      expect(OpenFeature.getContext()).toEqual(context);
+    });
+
+    describe('Set context during provider registration', () => {
+      it('should set the context for the default provider', () => {
+        const context: EvaluationContext = { property1: false };
+        const provider = new MockProvider();
+        OpenFeature.setProvider(provider, context);
+        expect(OpenFeature.getContext()).toEqual(context);
+      });
+
+      it('should set the context for the default provider prior to initialization', async () => {
+        const context: EvaluationContext = { property1: false };
+        const provider = new MockProvider();
+        await OpenFeature.setProviderAndWait(provider, context);
+        expect(initializeMock).toHaveBeenCalledWith(context);
+        expect(OpenFeature.getContext()).toEqual(context);
+      });
+
+      it('should set the context for a named provider prior to initialization', async () => {
+        const context: EvaluationContext = { property1: false };
+        const clientName = 'test';
+        const provider = new MockProvider({ name: clientName });
+        await OpenFeature.setProviderAndWait(clientName, provider, context);
+        expect(initializeMock).toHaveBeenCalledWith(context);
+        expect(OpenFeature.getContext()).toEqual(context);
+      });
+    });
+  });
+
+  describe.skip('Requirement 3.2.4', () => {
+    // Only applies to the static-context paradigm
+  });
+});


### PR DESCRIPTION
## This PR

- overloads the set provider methods to support defining context
- updates to the server and client readmes

### Related Issues

Fixes #748

### Notes

I had to move the logic outside of the abstract class because the client supports named client context, which isn't available in the abstract. I also have to define the overloads on each implementation (web, server) in order for intellisense to work properly.
