### PR TITLE
fix: wrong context passed to named providers

### DIFF
--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -179,7 +179,7 @@ export class OpenFeatureClient implements Client {
     const allHooksReversed = [...allHooks].reverse();
 
     const context = {
-      ...OpenFeature.getContext(),
+      ...OpenFeature.getContext(this?.options?.name),
     };
 
     // this reference cannot change during the course of evaluation

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -106,7 +106,7 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
    * @param {string} clientName The name to identify the client
    * @returns {EvaluationContext} Evaluation context
    */
-  getContext(clientName: string): EvaluationContext;
+  getContext(clientName?: string): EvaluationContext;
   getContext(nameOrUndefined?: string): EvaluationContext {
     const clientName = stringOrUndefined(nameOrUndefined);
     if (clientName) {

--- a/packages/client/test/evaluation-context.spec.ts
+++ b/packages/client/test/evaluation-context.spec.ts
@@ -76,6 +76,28 @@ describe('Evaluation Context', () => {
         expect(OpenFeature.getContext(clientName)).toEqual(globalContext);
       });
 
+      it('should call onContextChange for appropriate provider with appropriate context', async () => {
+        const globalContext: EvaluationContext = { scope: 'global' };
+        const testContext: EvaluationContext = { scope: 'test' };
+        const clientName = 'test';
+        const defaultProvider = new MockProvider();
+        const provider1 = new MockProvider();
+
+        await OpenFeature.setProviderAndWait(defaultProvider);
+        await OpenFeature.setProviderAndWait(clientName, provider1);
+
+        // Spy on context changed handlers of both providers
+        const defaultProviderSpy = jest.spyOn(defaultProvider, 'onContextChange');
+        const provider1Spy = jest.spyOn(provider1, 'onContextChange');
+
+        await OpenFeature.setContext(globalContext);
+        await OpenFeature.setContext(clientName, testContext);
+
+        // provider one should get global and specific context calls
+        expect(defaultProviderSpy).toHaveBeenCalledWith({}, globalContext);
+        expect(provider1Spy).toHaveBeenCalledWith(globalContext, testContext);
+      });
+
       it('should only call a providers onContextChange once when clearing context', async () => {
         const globalContext: EvaluationContext = { scope: 'global' };
         const testContext: EvaluationContext = { scope: 'test' };

--- a/packages/client/test/evaluation-context.spec.ts
+++ b/packages/client/test/evaluation-context.spec.ts
@@ -12,10 +12,11 @@ class MockProvider implements Provider {
     return Promise.resolve();
   }
 
-  resolveBooleanEvaluation = jest.fn((flagKey: string, defaultValue: boolean, context: EvaluationContext ) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  resolveBooleanEvaluation = jest.fn((flagKey: string, defaultValue: boolean, context: EvaluationContext) => {
     return {
       value: true
-    }
+    };
   });
 
   resolveNumberEvaluation(): ResolutionDetails<number> {


### PR DESCRIPTION
Fixed an issue with implementations of https://github.com/open-feature/js-sdk/pull/704 where the wrong context was passed to namespaced providers.