### PR TITLE
fix: some handlers fail to run

### DIFF
--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -18,7 +18,7 @@ type OpenFeatureGlobal = {
   [GLOBAL_OPENFEATURE_API_KEY]?: OpenFeatureAPI;
 };
 type NameProviderTuple = {
-  namespace?: string;
+  name?: string;
   provider: Provider;
 }
 
@@ -89,18 +89,18 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
       // collect all providers that are using the default context (not mapped to a name)
       const defaultContextNameProviders: NameProviderTuple[] = Array.from(this._clientProviders.entries())
         .filter(([name]) => !this._namedProviderContext.has(name))
-        .reduce<{ namespace: string; provider: Provider }[]>((acc, [name, provider]) => {
-          acc.push({ namespace: name, provider });
+        .reduce<NameProviderTuple[]>((acc, [name, provider]) => {
+          acc.push({ name: name, provider });
           return acc;
         }, []);
 
       const allProviders: NameProviderTuple[] = [
-        { namespace: undefined, provider: this._defaultProvider },
+        { name: undefined, provider: this._defaultProvider },
         ...defaultContextNameProviders,
       ];
       await Promise.all(
         allProviders.map((tuple) =>
-          this.runProviderContextChangeHandler(tuple.namespace, tuple.provider, oldContext, context),
+          this.runProviderContextChangeHandler(tuple.name, tuple.provider, oldContext, context),
         ),
       );
     }

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -90,11 +90,12 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
       const defaultContextNameProviders: NameProviderTuple[] = Array.from(this._clientProviders.entries())
         .filter(([name]) => !this._namedProviderContext.has(name))
         .reduce<NameProviderTuple[]>((acc, [name, provider]) => {
-          acc.push({ name: name, provider });
+          acc.push({ name, provider });
           return acc;
         }, []);
 
       const allProviders: NameProviderTuple[] = [
+        // add in the default (no name)
         { name: undefined, provider: this._defaultProvider },
         ...defaultContextNameProviders,
       ];

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -17,7 +17,7 @@ const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');
 type OpenFeatureGlobal = {
   [GLOBAL_OPENFEATURE_API_KEY]?: OpenFeatureAPI;
 };
-type NameProviderTuple = {
+type NameProviderRecord = {
   name?: string;
   provider: Provider;
 }
@@ -87,14 +87,14 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<Provider, Hook> impleme
       this._context = context;
 
       // collect all providers that are using the default context (not mapped to a name)
-      const defaultContextNameProviders: NameProviderTuple[] = Array.from(this._clientProviders.entries())
+      const defaultContextNameProviders: NameProviderRecord[] = Array.from(this._clientProviders.entries())
         .filter(([name]) => !this._namedProviderContext.has(name))
-        .reduce<NameProviderTuple[]>((acc, [name, provider]) => {
+        .reduce<NameProviderRecord[]>((acc, [name, provider]) => {
           acc.push({ name, provider });
           return acc;
         }, []);
 
-      const allProviders: NameProviderTuple[] = [
+      const allProviders: NameProviderRecord[] = [
         // add in the default (no name)
         { name: undefined, provider: this._defaultProvider },
         ...defaultContextNameProviders,

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -109,6 +109,13 @@ export abstract class OpenFeatureCommonAPI<P extends CommonProvider = CommonProv
   }
 
   /**
+   * Removes all event handlers.
+   */
+  clearHandlers(): void {
+    this._events.removeAllHandlers();
+  }
+
+  /**
    * Gets the current handlers for the given provider event type.
    * @param {AnyProviderEvent} eventType The provider event type to get the current handlers for
    * @returns {EventHandler[]} The handlers currently attached to the given provider event type


### PR DESCRIPTION
fixed an issue where some handlers would fail to run if the associated provider did not have a onContextChange method