### PR TITLE
fix(nest): add peer deps for nestjs-core and rxjs 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14470,7 +14470,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.23"
@@ -14481,7 +14481,7 @@
     },
     "packages/nest": {
       "name": "@openfeature/nestjs-sdk",
-      "version": "0.0.3-experimental",
+      "version": "0.0.4-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@nestjs/common": "^10.2.10",
@@ -14495,26 +14495,27 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@openfeature/server-sdk": ">=1.7.5",
-        "rxjs": "^6.0.0 || ^7.0.0"
+        "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0"
       }
     },
     "packages/react": {
       "name": "@openfeature/react-sdk",
-      "version": "0.0.5-experimental",
+      "version": "0.1.0-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "*",
         "@openfeature/web-sdk": "*"
       },
       "peerDependencies": {
-        "@openfeature/web-sdk": ">=0.4.0",
-        "react": ">=18.0.0"
+        "@openfeature/web-sdk": ">=0.4.10",
+        "react": ">=16.8.0"
       }
     },
     "packages/server": {
       "name": "@openfeature/server-sdk",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.23"

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -30,8 +30,7 @@
 </p>
 <!-- x-hide-in-docs-start -->
 
-[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API
-for feature flagging that works with your favorite feature flag management tool.
+[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.
 
 <!-- x-hide-in-docs-end -->
 

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -15,13 +15,17 @@
   <a href="https://github.com/open-feature/spec/releases/tag/v0.7.0">
     <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.7.0&color=yellow&style=for-the-badge" />
   </a>
-    <!-- x-release-please-start-version -->
-  <a href="https://github.com/open-feature/js-sdk/releases/tag/nestjs-sdk-v0.1.0">
-    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.1.0&color=blue&style=for-the-badge" />
+  <!-- x-release-please-start-version -->
+  <a href="https://github.com/open-feature/js-sdk/releases/tag/nestjs-sdk-v0.0.4-experimental">
+    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.0.4-experimental&color=blue&style=for-the-badge" />
   </a>
   <!-- x-release-please-end -->
+  <br/>
   <a href="https://codecov.io/gh/open-feature/js-sdk">
     <img alt="codecov" src="https://codecov.io/gh/open-feature/js-sdk/branch/main/graph/badge.svg?token=3DC5XOEHMY" />
+  </a>
+  <a href="https://www.npmjs.com/package/@openfeature/nestjs-sdk">
+    <img alt="NPM Download" src="https://img.shields.io/npm/dm/%40openfeature%2Fnestjs-sdk" />
   </a>
 </p>
 <!-- x-hide-in-docs-start -->
@@ -37,11 +41,11 @@ The OpenFeature NestJS SDK is a package that provides a NestJS wrapper for the [
 
 Capabilities include:
 
-- Provide a NestJS global module to simplify OpenFeature configuration and usage within NestJS;
-- Injecting feature flags directly into controller route handlers by using decorators;
-- Injecting transaction evaluation context for flag evaluations directly from [execution context](https://docs.nestjs.com/fundamentals/execution-context) (HTTP header values, client IPs, etc.);
-- Injecting OpenFeature clients into NestJS services and controllers by using decorators;
-- Setting up logging, event handling, hooks and providers directly when registering the module.
+- Provide a NestJS global module to simplify OpenFeature configuration and usage within NestJS
+- Setting up logging, event handling, hooks and providers directly when registering the module
+- Injecting feature flags directly into controller route handlers by using decorators
+- Injecting transaction evaluation context for flag evaluations directly from [execution context](https://docs.nestjs.com/fundamentals/execution-context) (HTTP header values, client IPs, etc.)
+- Injecting OpenFeature clients into NestJS services and controllers by using decorators
 
 ## 🚀 Quick start
 
@@ -146,10 +150,10 @@ export class OpenFeatureTestService {
 }
 ```
 
-## Module aditional information
+## Module additional information
 
 ### Flag evaluation context injection
 
-Whenever a flag evaluation occurs, context can be provided with information like user e-mail, role, targeting key, etc in order to trigger specific evaluation rules or logic. The `OpenFeatureModule` provides a way to configure context for each request using the `contextFactory` option.
-The `contextFactory` is ran in a NestJS interceptor scope to configure the evaluation context and than it is used in every flag evaluation related to this request.
+Whenever a flag evaluation occurs, context can be provided with information like user e-mail, role, targeting key, etc. in order to trigger specific evaluation rules or logic. The `OpenFeatureModule` provides a way to configure context for each request using the `contextFactory` option.
+The `contextFactory` is run in a NestJS interceptor scope to configure the evaluation context, and then it is used in every flag evaluation related to this request.
 By default, the interceptor is configured globally, but it can be changed by setting the `useGlobalInterceptor` to `false`. In this case, it is still possible to configure a `contextFactory` that can be injected into route, module or controller bound interceptors.

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -41,7 +41,7 @@ The OpenFeature NestJS SDK is a package that provides a NestJS wrapper for the [
 
 Capabilities include:
 
-- Provide a NestJS global module to simplify OpenFeature configuration and usage within NestJS
+- Providing a NestJS global module to simplify OpenFeature configuration and usage within NestJS
 - Setting up logging, event handling, hooks and providers directly when registering the module
 - Injecting feature flags directly into controller route handlers by using decorators
 - Injecting transaction evaluation context for flag evaluations directly from [execution context](https://docs.nestjs.com/fundamentals/execution-context) (HTTP header values, client IPs, etc.)

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -46,8 +46,9 @@
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-    "@openfeature/server-sdk": ">=1.7.5",
-    "rxjs": "^6.0.0 || ^7.0.0"
+    "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+    "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0",
+    "@openfeature/server-sdk": ">=1.7.5"
   },
   "devDependencies": {
     "@nestjs/common": "^10.2.10",


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Adds `@nestjs/core` and rxjs version 8 to peer deps of nestjs-sdk.
Also fixes typos in README.
