### PR TITLE
fix: remove export of OpenFeatureClient

### DIFF
--- a/packages/client/src/client/internal/open-feature-client.ts
+++ b/packages/client/src/client/internal/open-feature-client.ts
@@ -35,6 +35,11 @@ type OpenFeatureClientOptions = {
   version?: string;
 };
 
+/**
+ * This implementation of the {@link Client} is meant to only be instantiated by the SDK.
+ * It should not be used outside the SDK and so should not be exported.
+ * @internal
+ */
 export class OpenFeatureClient implements Client {
   private _hooks: Hook[] = [];
   private _clientLogger?: Logger;

--- a/packages/client/src/client/internal/open-feature-client.ts
+++ b/packages/client/src/client/internal/open-feature-client.ts
@@ -18,13 +18,13 @@ import {
   instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
-import { FlagEvaluationOptions } from '../evaluation';
-import { ProviderEvents } from '../events';
-import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
-import { Hook } from '../hooks';
-import { OpenFeature } from '../open-feature';
-import { Provider, ProviderStatus } from '../provider';
-import { Client } from './client';
+import { FlagEvaluationOptions } from '../../evaluation';
+import { ProviderEvents } from '../../events';
+import { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
+import { Hook } from '../../hooks';
+import { OpenFeature } from '../../open-feature';
+import { Provider, ProviderStatus } from '../../provider';
+import { Client } from './../client';
 
 type OpenFeatureClientOptions = {
   /**

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -9,10 +9,10 @@ import {
   stringOrUndefined,
 } from '@openfeature/core';
 import { Client } from './client';
+import { OpenFeatureClient } from './client/internal/open-feature-client';
 import { OpenFeatureEventEmitter, ProviderEvents } from './events';
 import { Hook } from './hooks';
 import { NOOP_PROVIDER, Provider, ProviderStatus } from './provider';
-import { OpenFeatureClient } from './client/open-feature-client';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -14,7 +14,7 @@ import {
   ResolutionDetails,
   StandardResolutionReasons,
 } from '../src';
-import { OpenFeatureClient } from '../src/client/open-feature-client';
+import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const BOOLEAN_VALUE = true;
 const STRING_VALUE = 'val';
@@ -130,12 +130,15 @@ describe('OpenFeatureClient', () => {
       resolveBooleanEvaluation(): ResolutionDetails<boolean> {
         throw new Error('Method not implemented.');
       }
+
       resolveStringEvaluation(): ResolutionDetails<string> {
         throw new Error('Method not implemented.');
       }
+
       resolveNumberEvaluation(): ResolutionDetails<number> {
         throw new Error('Method not implemented.');
       }
+
       resolveObjectEvaluation<T extends JsonValue>(): ResolutionDetails<T> {
         throw new Error('Method not implemented.');
       }
@@ -236,7 +239,7 @@ describe('OpenFeatureClient', () => {
                 numberFlag,
                 defaultNumberValue,
                 {},
-                {}
+                {},
               );
             });
           });
@@ -248,7 +251,7 @@ describe('OpenFeatureClient', () => {
               const defaultNumberValue = 4096;
               const value: MyRestrictedNumber = client.getNumberValue<MyRestrictedNumber>(
                 numberFlag,
-                defaultNumberValue
+                defaultNumberValue,
               );
 
               expect(value).toEqual(NUMBER_VALUE);
@@ -256,7 +259,7 @@ describe('OpenFeatureClient', () => {
                 numberFlag,
                 defaultNumberValue,
                 {},
-                {}
+                {},
               );
             });
           });
@@ -333,7 +336,7 @@ describe('OpenFeatureClient', () => {
               booleanFlag,
               defaultBooleanValue,
               {},
-              {}
+              {},
             );
           });
         });
@@ -634,4 +637,3 @@ describe('OpenFeatureClient', () => {
     });
   });
 });
-

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
 import { Paradigm } from '@openfeature/core';
 import { OpenFeature, OpenFeatureAPI, Provider, ProviderStatus } from '../src';
-import { OpenFeatureClient } from '../src/client/open-feature-client';
+import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
   return {

--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -9,7 +9,6 @@ import {
   HookContext,
   JsonValue,
   Logger,
-  ManageContext,
   OpenFeatureError,
   ProviderFatalError,
   ProviderNotReadyError,
@@ -19,13 +18,13 @@ import {
   instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
-import { FlagEvaluationOptions } from '../evaluation';
-import { ProviderEvents } from '../events';
-import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
-import { Hook } from '../hooks';
-import { OpenFeature } from '../open-feature';
-import { Provider, ProviderStatus } from '../provider';
-import { Client } from './client';
+import { FlagEvaluationOptions } from '../../evaluation';
+import { ProviderEvents } from '../../events';
+import { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
+import { Hook } from '../../hooks';
+import { OpenFeature } from '../../open-feature';
+import { Provider, ProviderStatus } from '../../provider';
+import { Client } from './../client';
 
 type OpenFeatureClientOptions = {
   /**
@@ -36,7 +35,7 @@ type OpenFeatureClientOptions = {
   version?: string;
 };
 
-export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClient> {
+export class OpenFeatureClient implements Client {
   private _context: EvaluationContext;
   private _hooks: Hook[] = [];
   private _clientLogger?: Logger;

--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -35,6 +35,11 @@ type OpenFeatureClientOptions = {
   version?: string;
 };
 
+/**
+ * This implementation of the {@link Client} is meant to only be instantiated by the SDK.
+ * It should not be used outside the SDK and so should not be exported.
+ * @internal
+ */
 export class OpenFeatureClient implements Client {
   private _context: EvaluationContext;
   private _hooks: Hook[] = [];

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -3,10 +3,12 @@ import {
   ManageContext,
   OpenFeatureCommonAPI,
   ProviderWrapper,
+  ServerProviderStatus,
   objectOrUndefined,
   stringOrUndefined,
 } from '@openfeature/core';
 import { Client } from './client';
+import { OpenFeatureClient } from './client/internal/open-feature-client';
 import { OpenFeatureEventEmitter } from './events';
 import { Hook } from './hooks';
 import { NOOP_PROVIDER, Provider, ProviderStatus } from './provider';
@@ -16,8 +18,6 @@ import {
   TransactionContext,
   TransactionContextPropagator,
 } from './transaction-context';
-import { ServerProviderStatus } from '@openfeature/core';
-import { OpenFeatureClient } from './client/open-feature-client';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/js-sdk/api');

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -17,7 +17,7 @@ import {
   TransactionContext,
   TransactionContextPropagator,
 } from '../src';
-import { OpenFeatureClient } from '../src/client/open-feature-client';
+import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const BOOLEAN_VALUE = true;
 const STRING_VALUE = 'val';

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
 import { Paradigm } from '@openfeature/core';
 import { OpenFeature, OpenFeatureAPI, Provider, ProviderStatus } from '../src';
-import { OpenFeatureClient } from '../src/client/open-feature-client';
+import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
   return {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
As discussed here https://github.com/open-feature/js-sdk/pull/750#discussion_r1450896230, we should not export `OpenFeatureClient` from the server and web SDK. The type used outside the SDK should be `Client`, which is also used in the public APIs like `OpenFeatureApi`.

The question is, if we should mark this as breaking. 
Technically it will break code that imports `OpenFeatureClient` instead of `Client`, but as @toddbaert said code using it  could also be seen as "used wrong" while being technically fine.

I am still leaning towards marking it as breaking, to be sure we are not breaking something that is technically fine, just because it is unintended use. But I could also live with non-beaking.