### PR TITLE
feat: maintain state in SDK, add RECONCILING

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,7 @@ export default {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
@@ -174,7 +174,7 @@ export default {
   ],
 
   // Use this configuration option to add custom reporters to Jest
-  // reporters: [['github-actions', { silent: false }], 'summary'],
+  reporters: ['default', ['github-actions', { silent: false }], 'summary'],
 
   // Automatically reset mock state before every test
   // resetMocks: false,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,7 @@ export default {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  collectCoverage: true,
+  collectCoverage: false,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
@@ -174,7 +174,7 @@ export default {
   ],
 
   // Use this configuration option to add custom reporters to Jest
-  reporters: [['github-actions', { silent: false }], 'summary'],
+  // reporters: [['github-actions', { silent: false }], 'summary'],
 
   // Automatically reset mock state before every test
   // resetMocks: false,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "OpenFeature SDK for JavaScript",
   "scripts": {
-    "test": "jest --selectProjects=shared --selectProjects=server --selectProjects=client --verbose",
+    "test": "jest --selectProjects=shared --selectProjects=server --selectProjects=client",
     "e2e-server": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/server/e2e/features && jest --selectProjects=server-e2e --verbose",
     "e2e-client": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/client/e2e/features && jest --selectProjects=client-e2e --verbose",
     "e2e": "npm run e2e-server && npm run e2e-client",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "OpenFeature SDK for JavaScript",
   "scripts": {
-    "test": "jest --selectProjects=shared --selectProjects=server --selectProjects=client",
+    "test": "jest --selectProjects=shared --selectProjects=server --selectProjects=client --silent",
     "e2e-server": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/server/e2e/features && jest --selectProjects=server-e2e --verbose",
     "e2e-client": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/client/e2e/features && jest --selectProjects=client-e2e --verbose",
     "e2e": "npm run e2e-server && npm run e2e-client",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -279,7 +279,6 @@ import {
   Logger,
   Provider,
   ProviderEventEmitter,
-  ProviderStatus,
   ResolutionDetails
 } from '@openfeature/web-sdk';
 
@@ -308,8 +307,6 @@ class MyProvider implements Provider {
   onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> {
     // reconcile the provider's cached flags, if applicable
   }
-
-  status?: ProviderStatus | undefined;
 
   // implement with "new OpenFeatureEventEmitter()", and use "emit()" to emit events
   events?: ProviderEventEmitter<AnyProviderEvent> | undefined; 

--- a/packages/client/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/client/e2e/step-definitions/evaluation.spec.ts
@@ -1,13 +1,13 @@
-import { defineFeature, loadFeature } from 'jest-cucumber';
 import {
-  JsonValue,
-  JsonObject,
-  EvaluationDetails,
   EvaluationContext,
+  EvaluationDetails,
+  JsonObject,
+  JsonValue,
   ResolutionDetails,
   StandardResolutionReasons,
 } from '@openfeature/core';
-import { OpenFeature, ProviderEvents, InMemoryProvider } from '../../src';
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import { InMemoryProvider, OpenFeature } from '../../src';
 import flagConfiguration from './flags-config';
 // load the feature file.
 const feature = loadFeature('packages/client/e2e/features/evaluation.feature');
@@ -18,15 +18,12 @@ const client = OpenFeature.getClient();
 const givenAnOpenfeatureClientIsRegisteredWithCacheDisabled = (
   given: (stepMatcher: string, stepDefinitionCallback: () => void) => void
 ) => {
-  OpenFeature.setProvider(new InMemoryProvider(flagConfiguration));
   given('a provider is registered with cache disabled', () => undefined);
 };
 
 defineFeature(feature, (test) => {
-  beforeAll((done) => {
-    client.addHandler(ProviderEvents.Ready, async () => {
-      done();
-    });
+  beforeAll(async () => {
+    await OpenFeature.setProvider(new InMemoryProvider(flagConfiguration));
   });
 
   afterAll(async () => {

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1,5 +1,6 @@
-import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger, ProviderStatus } from '@openfeature/core';
+import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger } from '@openfeature/core';
 import { Features } from '../evaluation';
+import { ProviderStatus } from '../provider';
 
 export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing {
   readonly metadata: ClientMetadata;

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -10,7 +10,7 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
-  ProviderStatus,
+  ProviderFatalError,
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
@@ -21,8 +21,9 @@ import { ProviderEvents } from '../events';
 import { InternalEventEmitter } from '../events/internal/internal-event-emitter';
 import { Hook } from '../hooks';
 import { OpenFeature } from '../open-feature';
-import { Provider } from '../provider';
+import { Provider, ProviderStatus } from '../provider';
 import { Client } from './client';
+import { ProviderNotReadyError } from '@openfeature/core';
 
 type OpenFeatureClientOptions = {
   /**
@@ -41,6 +42,7 @@ export class OpenFeatureClient implements Client {
     // functions are passed here to make sure that these values are always up to date,
     // and so we don't have to make these public properties on the API class.
     private readonly providerAccessor: () => Provider,
+    private readonly providerStatusAccessor: () => ProviderStatus,
     private readonly emitterAccessor: () => InternalEventEmitter,
     private readonly globalLogger: () => Logger,
     private readonly options: OpenFeatureClientOptions,
@@ -57,12 +59,12 @@ export class OpenFeatureClient implements Client {
   }
 
   get providerStatus(): ProviderStatus {
-    return this.providerAccessor()?.status || ProviderStatus.READY;
+    return this.providerStatusAccessor();
   }
 
   addHandler(eventType: ProviderEvents, handler: EventHandler): void {
     this.emitterAccessor().addHandler(eventType, handler);
-    const shouldRunNow = statusMatchesEvent(eventType, this._provider.status);
+    const shouldRunNow = statusMatchesEvent(eventType, this.providerStatus);
 
     if (shouldRunNow) {
       // run immediately, we're in the matching state
@@ -206,6 +208,13 @@ export class OpenFeatureClient implements Client {
 
     try {
       this.beforeHooks(allHooks, hookContext, options);
+      
+      // short circuit evaluation entirely if provider is in a bad state
+      if (this.providerStatus === ProviderStatus.NOT_READY) {
+        throw new ProviderNotReadyError('provider has not yet initialized');
+      } else if (this.providerStatus === ProviderStatus.FATAL) {
+        throw new ProviderFatalError('provider is in an irrecoverable error state');
+      }
 
       // run the referenced resolver, binding the provider.
       const resolution = resolver.call(this._provider, flagKey, defaultValue, context, this._logger);

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -53,12 +53,12 @@ export class OpenFeatureAPI extends OpenFeatureCommonAPI<ClientProviderStatus, P
     return instance;
   }
 
-  private getProviderStatus(name?: string): ProviderStatus {
-    if (!name) {
+  private getProviderStatus(domain?: string): ProviderStatus {
+    if (!domain) {
       return this._defaultProvider.status;
     }
 
-    return this._domainScopedProviders.get(name)?.status ?? this._defaultProvider.status;
+    return this._domainScopedProviders.get(domain)?.status ?? this._defaultProvider.status;
   }
 
   /**

--- a/packages/client/src/provider/no-op-provider.ts
+++ b/packages/client/src/provider/no-op-provider.ts
@@ -1,4 +1,4 @@
-import { JsonValue, ProviderStatus, ResolutionDetails } from '@openfeature/core';
+import { JsonValue, ResolutionDetails } from '@openfeature/core';
 import { Provider } from './provider';
 
 const REASON_NO_OP = 'No-op';
@@ -10,16 +10,6 @@ class NoopFeatureProvider implements Provider {
   readonly metadata = {
     name: 'No-op Provider',
   } as const;
-
-  get status(): ProviderStatus {
-    /**
-     * This is due to the NoopProvider not being a real provider.
-     * We do not want it to trigger the Ready event handlers, so we never set this to ready.
-     * With the NoopProvider assigned, the client can be assumed to be uninitialized.
-     * https://github.com/open-feature/js-sdk/pull/429#discussion_r1202642654
-     */
-    return ProviderStatus.NOT_READY;
-  }
 
   resolveBooleanEvaluation(_: string, defaultValue: boolean): ResolutionDetails<boolean> {
     return this.noOp(defaultValue);

--- a/packages/client/src/provider/provider.ts
+++ b/packages/client/src/provider/provider.ts
@@ -1,5 +1,7 @@
-import { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/core';
+import { ClientProviderStatus, CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/core';
 import { Hook } from '../hooks';
+
+export { ClientProviderStatus as ProviderStatus };
 
 /**
  * Interface that providers must implement to resolve flag values for their particular
@@ -7,7 +9,7 @@ import { Hook } from '../hooks';
  *
  * Implementation for resolving all the required flag types must be defined.
  */
-export interface Provider extends CommonProvider {
+export interface Provider extends CommonProvider<ClientProviderStatus> {
   /**
    * A provider hook exposes a mechanism for provider authors to register hooks
    * to tap into various stages of the flag evaluation lifecycle. These hooks can

--- a/packages/client/test/in-memory-provider.spec.ts
+++ b/packages/client/test/in-memory-provider.spec.ts
@@ -1,10 +1,10 @@
-import { FlagNotFoundError, GeneralError, InMemoryProvider, ProviderEvents, ProviderStatus, StandardResolutionReasons, TypeMismatchError } from '../src';
+import { FlagNotFoundError, GeneralError, InMemoryProvider, ProviderEvents, StandardResolutionReasons, TypeMismatchError } from '../src';
 import { FlagConfiguration } from '../src/provider/in-memory-provider/flag-configuration';
 import { VariantNotFoundError } from '../src/provider/in-memory-provider/variant-not-found-error';
 
 describe('in-memory provider', () => {
   describe('initialize', () => {
-    it('Should have provider status as NOT_READY after instantiation and emit READY and have READY state after initialuzation', async () => {
+    it('Should not throw for valid flags', async () => {
       const booleanFlagSpec = {
         'a-boolean-flag': {
           variants: {
@@ -16,13 +16,10 @@ describe('in-memory provider', () => {
         },
       };
       const provider = new InMemoryProvider(booleanFlagSpec);
-      expect(provider.status).toBe(ProviderStatus.NOT_READY);
-
       await provider.initialize();
-      expect(provider.status).toBe(ProviderStatus.READY);
     });
 
-    it('Should have provider status as ERROR after instantiation, emit ERROR and have ERROR state if initialization throws', async () => {
+    it('Should throw on invalid flags', async () => {
       const throwingFlagSpec: FlagConfiguration = {
         'a-boolean-flag': {
           variants: {
@@ -37,12 +34,8 @@ describe('in-memory provider', () => {
         },
       };
       const provider = new InMemoryProvider(throwingFlagSpec);
-
-      expect(provider.status).toBe(ProviderStatus.NOT_READY);
       const someContext = {};
-
       await expect(provider.initialize(someContext)).rejects.toThrow();
-      expect(provider.status).toBe(ProviderStatus.ERROR);
     });
   });
 
@@ -511,9 +504,6 @@ describe('in-memory provider', () => {
       const configChangedSpy = jest.fn();
       provider.events.addHandler(ProviderEvents.ConfigurationChanged, configChangedSpy);
 
-      const readySpy = jest.fn();
-      provider.events.addHandler(ProviderEvents.Ready, readySpy);
-
       const newFlagSpec = {
         'some-flag': {
           variants: {
@@ -526,8 +516,6 @@ describe('in-memory provider', () => {
       await provider.putConfiguration(newFlagSpec);
 
       expect(configChangedSpy).toHaveBeenCalledWith({ flagsChanged: ['some-flag'] });
-      expect(readySpy).toHaveBeenCalled();
-      expect(provider.status).toBe(ProviderStatus.READY);
     });
   });
 

--- a/packages/client/test/open-feature.spec.ts
+++ b/packages/client/test/open-feature.spec.ts
@@ -56,13 +56,6 @@ describe('OpenFeature', () => {
         expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
         expect(provider.initialize).toHaveBeenCalled();
       });
-
-      it('should not invoke initialize function if the provider is not in state NOT_READY', () => {
-        const provider = mockProvider({ initialStatus: ProviderStatus.READY });
-        OpenFeature.setProvider(provider);
-        expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
-        expect(provider.initialize).not.toHaveBeenCalled();
-      });
     });
 
     describe('Requirement 1.1.2.3', () => {
@@ -123,13 +116,13 @@ describe('OpenFeature', () => {
     it('should not close provider if it is used by another client', async () => {
       const provider1 = { ...mockProvider(), onClose: jest.fn() };
 
-      OpenFeature.setProvider('domain1', provider1);
-      OpenFeature.setProvider('domain2', provider1);
+      await OpenFeature.setProviderAndWait('domain1', provider1);
+      await OpenFeature.setProviderAndWait('domain2', provider1);
 
-      OpenFeature.setProvider('domain1', { ...provider1 });
+      await OpenFeature.setProviderAndWait('domain1', { ...provider1 });
       expect(provider1.onClose).not.toHaveBeenCalled();
 
-      OpenFeature.setProvider('domain2', { ...provider1 });
+      await OpenFeature.setProviderAndWait('domain2', { ...provider1 });
       expect(provider1.onClose).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -59,7 +59,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */

--- a/packages/nest/src/feature.decorator.ts
+++ b/packages/nest/src/feature.decorator.ts
@@ -56,7 +56,7 @@ interface FeatureProps<T extends FlagValue> {
 
 /**
  * Returns a domain scoped or the default OpenFeature client with the given context.
- * @param {string} clientDomain The domain of the OpenFeature client.
+ * @param {string} domain The domain of the OpenFeature client.
  * @param {EvaluationContext} context The evaluation context of the client.
  * @returns {Client} The OpenFeature client.
  */

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -64,7 +64,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -61,7 +61,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -279,7 +279,6 @@ import {
   Logger,
   Provider,
   ProviderEventEmitter,
-  ProviderStatus,
   ResolutionDetails
 } from '@openfeature/server-sdk';
 
@@ -304,8 +303,6 @@ class MyProvider implements Provider {
   resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext, logger: Logger): Promise<ResolutionDetails<T>> {
     // code to evaluate an object
   }
-
-  status?: ProviderStatus | undefined;
 
   // implement with "new OpenFeatureEventEmitter()", and use "emit()" to emit events
   events?: ProviderEventEmitter<AnyProviderEvent> | undefined; 

--- a/packages/server/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/server/e2e/step-definitions/evaluation.spec.ts
@@ -7,7 +7,7 @@ import {
   StandardResolutionReasons,
 } from '@openfeature/core';
 import { defineFeature, loadFeature } from 'jest-cucumber';
-import { InMemoryProvider, OpenFeature, ProviderEvents } from '../../src';
+import { InMemoryProvider, OpenFeature } from '../../src';
 import flagConfiguration from './flags-config';
 
 // load the feature file.
@@ -19,17 +19,12 @@ const client = OpenFeature.getClient();
 const givenAnOpenfeatureClientIsRegisteredWithCacheDisabled = (
   given: (stepMatcher: string, stepDefinitionCallback: () => void) => void,
 ) => {
-  OpenFeature.setProvider(
-    new InMemoryProvider(flagConfiguration),
-  );
   given('a provider is registered with cache disabled', () => undefined);
 };
 
 defineFeature(feature, (test) => {
-  beforeAll((done) => {
-    client.addHandler(ProviderEvents.Ready, async () => {
-      done();
-    });
+  beforeAll(async () => {
+    await OpenFeature.setProvider(new InMemoryProvider(flagConfiguration));
   });
 
   afterAll(async () => {

--- a/packages/server/src/client/client.ts
+++ b/packages/server/src/client/client.ts
@@ -1,5 +1,12 @@
-import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageContext, ManageLogger } from '@openfeature/core';
+import {
+  ClientMetadata,
+  EvaluationLifeCycle,
+  Eventing,
+  ManageContext,
+  ManageLogger,
+} from '@openfeature/core';
 import { Features } from '../evaluation';
+import { ProviderStatus } from '../provider';
 
 export interface Client
   extends EvaluationLifeCycle<Client>,
@@ -8,4 +15,8 @@ export interface Client
     ManageLogger<Client>,
     Eventing {
   readonly metadata: ClientMetadata;
+  /**
+   * Returns the status of the associated provider.
+   */
+  readonly providerStatus: ProviderStatus;
 }

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -31,7 +31,7 @@ export class OpenFeatureAPI
   implements ManageContext<OpenFeatureAPI>, ManageTransactionContextPropagator<OpenFeatureCommonAPI<ServerProviderStatus, Provider>>
 {
   protected _statusEnumType: typeof ProviderStatus = ProviderStatus;
-  protected _events = new OpenFeatureEventEmitter();
+  protected _apiEmitter = new OpenFeatureEventEmitter();
   protected _defaultProvider: ProviderWrapper<Provider, ServerProviderStatus> = new ProviderWrapper(NOOP_PROVIDER, ProviderStatus.NOT_READY, this._statusEnumType);
   protected _domainScopedProviders: Map<string, ProviderWrapper<Provider, ServerProviderStatus>> = new Map();
   protected _createEventEmitter = () => new OpenFeatureEventEmitter();

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -58,12 +58,12 @@ export class OpenFeatureAPI
     return instance;
   }
 
-  private getProviderStatus(name?: string): ProviderStatus {
-    if (!name) {
+  private getProviderStatus(domain?: string): ProviderStatus {
+    if (!domain) {
       return this._defaultProvider.status;
     }
 
-    return this._domainScopedProviders.get(name)?.status ?? this._defaultProvider.status;
+    return this._domainScopedProviders.get(domain)?.status ?? this._defaultProvider.status;
   }
 
   setContext(context: EvaluationContext): this {

--- a/packages/server/src/provider/no-op-provider.ts
+++ b/packages/server/src/provider/no-op-provider.ts
@@ -1,4 +1,4 @@
-import { ResolutionDetails, JsonValue, ProviderStatus } from '@openfeature/core';
+import { JsonValue, ResolutionDetails } from '@openfeature/core';
 import { Provider } from './provider';
 
 const REASON_NO_OP = 'No-op';
@@ -10,16 +10,6 @@ class NoopFeatureProvider implements Provider {
   readonly metadata = {
     name: 'No-op Provider',
   } as const;
-
-  get status(): ProviderStatus {
-    /**
-     * This is due to the NoopProvider not being a real provider.
-     * We do not want it to trigger the Ready event handlers, so we never set this to ready.
-     * With the NoopProvider assigned, the client can be assumed to be uninitialized.
-     * https://github.com/open-feature/js-sdk/pull/429#discussion_r1202642654
-     */
-    return ProviderStatus.NOT_READY;
-  }
 
   resolveBooleanEvaluation(_: string, defaultValue: boolean): Promise<ResolutionDetails<boolean>> {
     return this.noOp(defaultValue);

--- a/packages/server/src/provider/provider.ts
+++ b/packages/server/src/provider/provider.ts
@@ -1,5 +1,7 @@
-import { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/core';
+import { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails, ServerProviderStatus } from '@openfeature/core';
 import { Hook } from '../hooks';
+
+export { ServerProviderStatus as ProviderStatus };
 
 /**
  * Interface that providers must implement to resolve flag values for their particular
@@ -7,7 +9,7 @@ import { Hook } from '../hooks';
  *
  * Implementation for resolving all the required flag types must be defined.
  */
-export interface Provider extends CommonProvider {
+export interface Provider extends CommonProvider<ServerProviderStatus> {
   /**
    * A provider hook exposes a mechanism for provider authors to register hooks
    * to tap into various stages of the flag evaluation lifecycle. These hooks can

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -1,3 +1,4 @@
+import { GeneralError } from '@openfeature/core';
 import {
   Client,
   ErrorCode,
@@ -10,6 +11,7 @@ import {
   OpenFeature,
   OpenFeatureClient,
   Provider,
+  ProviderFatalError,
   ProviderStatus,
   ResolutionDetails,
   StandardResolutionReasons,
@@ -542,6 +544,83 @@ describe('OpenFeatureClient', () => {
           {}
         );
       });
+    });
+  });
+
+  describe('Requirement 1.7.1, 1.7.3', () => {
+    const initProvider = {
+      metadata: {
+        name: 'initProvider',
+      },
+      initialize: () => {
+        return Promise.resolve();
+      }
+    } as unknown as Provider;
+    it('status must be READY if init resolves', async () => {
+      await OpenFeature.setProviderAndWait('1.7.1, 1.7.3', initProvider);
+      const client = OpenFeature.getClient('1.7.1, 1.7.3');
+      expect(client.providerStatus).toEqual(ProviderStatus.READY);
+    });
+  });
+
+  describe('Requirement 1.7.4', () => {
+    const errorProvider = {
+      metadata: {
+        name: 'errorProvider',
+      },
+      initialize: async () => {
+        return Promise.reject(new GeneralError());
+      }
+    } as unknown as Provider;
+    it('status must be ERROR if init rejects', async () => {
+      await expect(OpenFeature.setProviderAndWait('1.7.4', errorProvider)).rejects.toThrow();
+      const client = OpenFeature.getClient('1.7.4');
+      expect(client.providerStatus).toEqual(ProviderStatus.ERROR);
+    });
+  });
+
+  describe('Requirement 1.7.5, 1.7.6, 1.7.8', () => {
+    const fatalProvider = {
+      metadata: {
+        name: 'fatalProvider',
+      },
+      initialize: () => {
+        return Promise.reject(new ProviderFatalError());
+      }
+    } as unknown as Provider;
+    it('must short circuit and return PROVIDER_FATAL code if provider FATAL', async () => {
+      await expect(OpenFeature.setProviderAndWait('1.7.5, 1.7.6, 1.7.8', fatalProvider)).rejects.toThrow();
+      const client = OpenFeature.getClient('1.7.5, 1.7.6, 1.7.8');
+      expect(client.providerStatus).toEqual(ProviderStatus.FATAL);
+
+      const defaultVal = 'default';
+      const details = await client.getStringDetails('some-flag', defaultVal);
+      expect(details.value).toEqual(defaultVal);
+      expect(details.errorCode).toEqual(ErrorCode.PROVIDER_FATAL);
+    });
+  });
+
+  describe('Requirement 1.7.7', () => {
+    const neverReadyProvider = {
+      metadata: {
+        name: 'fatalProvider',
+      },
+      initialize: () => {
+        return new Promise(() => {
+          return; // promise never resolves
+        });
+      }
+    } as unknown as Provider;
+    it('must short circuit and return PROVIDER_NOT_READY code if provider NOT_READY', async () => {
+      OpenFeature.setProviderAndWait('1.7.7', neverReadyProvider).catch(() => {
+        // do nothing
+      });
+      const defaultVal = 'default';
+      const client = OpenFeature.getClient('1.7.7');
+      expect(client.providerStatus).toEqual(ProviderStatus.NOT_READY);
+      const details = await client.getStringDetails('some-flag', defaultVal);
+      expect(details.value).toEqual(defaultVal);
+      expect(details.errorCode).toEqual(ErrorCode.PROVIDER_NOT_READY);
     });
   });
 

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -7,7 +7,6 @@ const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradi
       name: 'mock-events-success',
     },
     runsOn: config?.runsOn || 'server',
-    status: config?.initialStatus || ProviderStatus.NOT_READY,
     initialize: jest.fn(() => {
       return Promise.resolve('started');
     }),
@@ -55,13 +54,6 @@ describe('OpenFeature', () => {
         OpenFeature.setProvider(provider);
         expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
         expect(provider.initialize).toHaveBeenCalled();
-      });
-
-      it('should not invoke initialize function if the provider is not in state NOT_READY', () => {
-        const provider = mockProvider({ initialStatus: ProviderStatus.READY });
-        OpenFeature.setProvider(provider);
-        expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
-        expect(provider.initialize).not.toHaveBeenCalled();
       });
     });
 
@@ -123,13 +115,13 @@ describe('OpenFeature', () => {
     it('should not close provider if it is used by another client', async () => {
       const provider1 = { ...mockProvider(), onClose: jest.fn() };
 
-      OpenFeature.setProvider('domain1', provider1);
-      OpenFeature.setProvider('domain2', provider1);
+      await OpenFeature.setProviderAndWait('domain1', provider1);
+      await OpenFeature.setProviderAndWait('domain2', provider1);
 
-      OpenFeature.setProvider('domain1', { ...provider1 });
+      await OpenFeature.setProviderAndWait('domain1', { ...provider1 });
       expect(provider1.onClose).not.toHaveBeenCalled();
 
-      OpenFeature.setProvider('domain2', { ...provider1 });
+      await OpenFeature.setProviderAndWait('domain2', { ...provider1 });
       expect(provider1.onClose).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -58,7 +58,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -6,3 +6,4 @@ export * from './targeting-key-missing-error';
 export * from './invalid-context-error';
 export * from './open-feature-error-abstract';
 export * from './provider-not-ready-error';
+export * from './provider-fatal-error';

--- a/packages/shared/src/errors/provider-fatal-error.ts
+++ b/packages/shared/src/errors/provider-fatal-error.ts
@@ -1,0 +1,12 @@
+import { OpenFeatureError } from './open-feature-error-abstract';
+import { ErrorCode } from '../evaluation';
+
+export class ProviderFatalError extends OpenFeatureError {
+  code: ErrorCode;
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    Object.setPrototypeOf(this, ProviderFatalError.prototype);
+    this.name = 'ProviderFatalError';
+    this.code = ErrorCode.PROVIDER_FATAL;
+  }
+}

--- a/packages/shared/src/evaluation/evaluation.ts
+++ b/packages/shared/src/evaluation/evaluation.ts
@@ -88,6 +88,11 @@ export enum ErrorCode {
   PROVIDER_NOT_READY = 'PROVIDER_NOT_READY',
 
   /**
+   * The provider has entered an irrecoverable error state.
+   */
+  PROVIDER_FATAL = 'PROVIDER_FATAL',
+
+  /**
    * The flag could not be found.
    */
   FLAG_NOT_FOUND = 'FLAG_NOT_FOUND',

--- a/packages/shared/src/events/event-utils.ts
+++ b/packages/shared/src/events/event-utils.ts
@@ -1,20 +1,22 @@
-import { ProviderStatus } from '../provider';
+import { AllProviderStatus, ClientProviderStatus, ServerProviderStatus } from '../provider';
 import { AllProviderEvents, AnyProviderEvent } from './events';
 
 const eventStatusMap = {
-    [ProviderStatus.READY]: AllProviderEvents.Ready,
-    [ProviderStatus.ERROR]: AllProviderEvents.Error,
-    [ProviderStatus.STALE]: AllProviderEvents.Stale,
-    [ProviderStatus.NOT_READY]: undefined,
+    [AllProviderStatus.READY]: AllProviderEvents.Ready,
+    [AllProviderStatus.ERROR]: AllProviderEvents.Error,
+    [AllProviderStatus.FATAL]: AllProviderEvents.Error,
+    [AllProviderStatus.STALE]: AllProviderEvents.Stale,
+    [AllProviderStatus.RECONCILING]: AllProviderEvents.Reconciling,
+    [AllProviderStatus.NOT_READY]: undefined,
 };
 
 /**
  * Returns true if the provider's status corresponds to the event.
  * If the provider's status is not defined, it matches READY.
  * @param {AnyProviderEvent} event event to match
- * @param {ProviderStatus} status  status of provider
+ * @param {ClientProviderStatus | ServerProviderStatus} status  status of provider
  * @returns {boolean} boolean indicating if the provider status corresponds to the event.
  */
-export const statusMatchesEvent = <T extends AnyProviderEvent>(event: T, status?: ProviderStatus): boolean => {
+export const statusMatchesEvent = <T extends AnyProviderEvent>(event: T, status?: ClientProviderStatus | ServerProviderStatus): boolean => {
     return (!status && event === AllProviderEvents.Ready) || eventStatusMap[status!] === event;
 };

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -1,3 +1,4 @@
+import { ErrorCode } from '../evaluation';
 import { AllProviderEvents, AnyProviderEvent } from './events';
 
 export type EventMetadata = {
@@ -18,9 +19,11 @@ type CommonEventProps = {
   metadata?: EventMetadata;
 };
 
+
 export type ReadyEvent = CommonEventProps;
 export type ErrorEvent = CommonEventProps;
 export type StaleEvent = CommonEventProps;
+export type ReconcilingEvent = CommonEventProps & { errorCode: ErrorCode };
 export type ConfigChangeEvent = CommonEventProps & { flagsChanged?: string[] };
 
 type EventMap = {
@@ -29,6 +32,7 @@ type EventMap = {
   [AllProviderEvents.Stale]: StaleEvent;
   [AllProviderEvents.ContextChanged]: CommonEventProps;
   [AllProviderEvents.ConfigurationChanged]: ConfigChangeEvent;
+  [AllProviderEvents.Reconciling]: ReconcilingEvent;
 };
 
 export type EventContext<  U extends Record<string, unknown> = Record<string, unknown>

--- a/packages/shared/src/events/events.ts
+++ b/packages/shared/src/events/events.ts
@@ -52,6 +52,11 @@ export enum ClientProviderEvents {
   ContextChanged = 'PROVIDER_CONTEXT_CHANGED',
 
   /**
+   * The context associated with the provider has changed, and the provider has not yet reconciled its associated state.
+   */
+  Reconciling = 'PROVIDER_RECONCILING',
+
+  /**
    * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
    */
   Stale = 'PROVIDER_STALE',

--- a/packages/shared/src/events/events.ts
+++ b/packages/shared/src/events/events.ts
@@ -69,6 +69,6 @@ export { ClientProviderEvents as AllProviderEvents };
 
 /**
  * A type representing any possible ProviderEvent (server or client side).
- * If you are implementing a hook or provider, you probably want to import `ProviderEvents` from the respective SDK.
+ * In most cases, you probably want to import `ProviderEvents` from the respective SDK.
  */
 export type AnyProviderEvent = ServerProviderEvents | ClientProviderEvents;

--- a/packages/shared/src/events/generic-event-emitter.ts
+++ b/packages/shared/src/events/generic-event-emitter.ts
@@ -18,6 +18,7 @@ export abstract class GenericEventEmitter<E extends AnyProviderEvent, Additional
     [AllProviderEvents.Ready]: new WeakMap<EventHandler, EventHandler[]>(),
     [AllProviderEvents.Error]: new WeakMap<EventHandler, EventHandler[]>(),
     [AllProviderEvents.Stale]: new WeakMap<EventHandler, EventHandler[]>(),
+    [AllProviderEvents.Reconciling]: new WeakMap<EventHandler, EventHandler[]>(),
   };
   private _eventLogger?: Logger;
 

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -331,12 +331,12 @@ export abstract class OpenFeatureCommonAPI<S extends AnyProviderStatus, P extend
     return initializationPromise;
   }
 
-  protected getProviderForClient(name?: string): P {
-    if (!name) {
+  protected getProviderForClient(domain?: string): P {
+    if (!domain) {
       return this._defaultProvider.provider;
     }
 
-    return this._domainScopedProviders.get(name)?.provider ?? this._defaultProvider.provider;
+    return this._domainScopedProviders.get(domain)?.provider ?? this._defaultProvider.provider;
   }
 
   protected buildAndCacheEventEmitterForClient(domain?: string): GenericEventEmitter<AnyProviderEvent> {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -322,7 +322,7 @@ export abstract class OpenFeatureCommonAPI<S extends AnyProviderStatus, P extend
     // Do not close a provider that is bound to any client
     if (!this.allProviders.includes(oldProvider)) {
       oldProvider?.onClose?.()?.catch((err: Error | undefined) => {
-        this._logger.error(`error closing provider: ${err?.message}, ${err?.stack}`)
+        this._logger.error(`error closing provider: ${err?.message}, ${err?.stack}`);
       });
     }
 

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -76,7 +76,8 @@ export class ProviderWrapper<P extends CommonProvider<AnyProviderStatus>, S exte
 export abstract class OpenFeatureCommonAPI<S extends AnyProviderStatus, P extends CommonProvider<S> = CommonProvider<S>, H extends BaseHook = BaseHook>
   implements Eventing, EvaluationLifeCycle<OpenFeatureCommonAPI<S, P>>, ManageLogger<OpenFeatureCommonAPI<S, P>>
 {
-  protected abstract readonly _statusEnumType: typeof ClientProviderStatus | typeof ServerProviderStatus; // an accessor 
+  // accessor for the type of the ProviderStatus enum (client or server)
+  protected abstract readonly _statusEnumType: typeof ClientProviderStatus | typeof ServerProviderStatus;
   protected abstract _createEventEmitter(): GenericEventEmitter<AnyProviderEvent>;
   protected abstract _defaultProvider: ProviderWrapper<P, AnyProviderStatus>;
   protected abstract _domainScopedProviders: Map<string, ProviderWrapper<P, AnyProviderStatus>>;

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -2,10 +2,15 @@ import { EvaluationContext } from '../evaluation';
 import { AnyProviderEvent, ProviderEventEmitter } from '../events';
 import { Metadata, Paradigm } from '../types';
 
+// TODO: with TypeScript 5+, we can use computed string properties,
+// so we can extract all of these into a shared set of string consts and use that in both enums
+// for now we have duplicated them.
+
 /**
  * The state of the provider.
+ * Note that the provider's state is handled by the SDK.
  */
-export enum ProviderStatus {
+export enum ServerProviderStatus {
   /**
    * The provider has not been initialized and cannot yet evaluate flags.
    */
@@ -25,7 +30,50 @@ export enum ProviderStatus {
    * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
    */
   STALE = 'STALE',
+
+  /**
+   * The provider has entered an irrecoverable error state.
+   */
+  FATAL = 'FATAL',
 }
+
+/**
+ * The state of the provider.
+ * Note that the provider's state is handled by the SDK.
+ */
+export enum ClientProviderStatus {
+  /**
+   * The provider has not been initialized and cannot yet evaluate flags.
+   */
+  NOT_READY = 'NOT_READY',
+
+  /**
+   * The provider is ready to resolve flags.
+   */
+  READY = 'READY',
+
+  /**
+   * The provider is in an error state and unable to evaluate flags.
+   */
+  ERROR = 'ERROR',
+
+  /**
+   * The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
+   */
+  STALE = 'STALE',
+
+  /**
+   * The provider has entered an irrecoverable error state.
+   */
+  FATAL = 'FATAL',
+
+  /**
+   * The provider is reconciling its state with a context change.
+   */
+  RECONCILING = 'RECONCILING',
+}
+
+export { ClientProviderStatus as AllProviderStatus };
 
 /**
  * Static data about the provider.
@@ -34,7 +82,7 @@ export interface ProviderMetadata extends Metadata {
   readonly name: string;
 }
 
-export interface CommonProvider {
+export interface CommonProvider<E extends ClientProviderStatus | ServerProviderStatus> {
   readonly metadata: ProviderMetadata;
 
   /**
@@ -43,15 +91,14 @@ export interface CommonProvider {
    */
   readonly runsOn?: Paradigm;
 
+  // TODO: in the future we could make this a never to force provider to remove it.
   /**
+   * @deprecated the SDK now maintains the provider's state; there's no need for providers to implement this field.
    * Returns a representation of the current readiness of the provider.
-   * If the provider needs to be initialized, it should return {@link ProviderStatus.READY}.
-   * If the provider is in an error state, it should return {@link ProviderStatus.ERROR}.
-   * If the provider is functioning normally, it should return {@link ProviderStatus.NOT_READY}.
    * 
    * _Providers which do not implement this method are assumed to be ready immediately._
    */
-  readonly status?: ProviderStatus;
+  readonly status?: E;
 
   /**
    * An event emitter for ProviderEvents.
@@ -67,7 +114,7 @@ export interface CommonProvider {
 
   /**
    * A function used to setup the provider.
-   * Called by the SDK after the provider is set if the provider's status is {@link ProviderStatus.NOT_READY}.
+   * Called by the SDK after the provider is set if the provider's status is NOT_READY.
    * When the returned promise resolves, the SDK fires the ProviderEvents.Ready event.
    * If the returned promise rejects, the SDK fires the ProviderEvents.Error event.
    * Use this function to perform any context-dependent setup within the provider.

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -73,6 +73,10 @@ export enum ClientProviderStatus {
   RECONCILING = 'RECONCILING',
 }
 
+/**
+ * A type representing any possible ProviderStatus (server or client side).
+ * In most cases, you probably want to import `ProviderStatus` from the respective SDK.
+ */
 export { ClientProviderStatus as AllProviderStatus };
 
 /**
@@ -82,7 +86,7 @@ export interface ProviderMetadata extends Metadata {
   readonly name: string;
 }
 
-export interface CommonProvider<E extends ClientProviderStatus | ServerProviderStatus> {
+export interface CommonProvider<S extends ClientProviderStatus | ServerProviderStatus> {
   readonly metadata: ProviderMetadata;
 
   /**
@@ -98,7 +102,7 @@ export interface CommonProvider<E extends ClientProviderStatus | ServerProviderS
    * 
    * _Providers which do not implement this method are assumed to be ready immediately._
    */
-  readonly status?: E;
+  readonly status?: S;
 
   /**
    * An event emitter for ProviderEvents.

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -56,7 +56,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,7 +59,7 @@
     // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
     // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    "stripInternal": true,                               /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */


### PR DESCRIPTION
Implements the newest spec changes [here](https://github.com/open-feature/spec/pull/241).

- Provider state is deprecated (state is now maintained in the SDK itself). This is non-breaking, we just ignore the provider's own state now
- add RECONCILING events and state, fire related events with provider's `on context change`
- add FATAL state

The new tests should help you understand the impact of the changes.