### PR TITLE
feat: suspend on RECONCILING, mem provider fixes

### DIFF
--- a/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/client/src/provider/in-memory-provider/in-memory-provider.ts
@@ -52,6 +52,7 @@ export class InMemoryProvider implements Provider {
       .map(([key]) => key);
 
     this._flagConfiguration = { ...flagConfiguration };
+
     try {
       await this.initialize(this._context);
       this.events.emit(ProviderEvents.ConfigurationChanged, { flagsChanged });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": ">=0.4.10",
+    "@openfeature/web-sdk": ">=0.4.14",
     "react": ">=16.8.0"
   },
   "devDependencies": {

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -5,7 +5,7 @@ import { useOpenFeatureClient } from './provider';
 type ReactFlagEvaluationOptions = {
   /**
    * Suspend flag evaluations while the provider is not ready.
-   * Set to false if you don't want to show suspense fallbacks util the provider is initialized.
+   * Set to false if you don't want to show suspense fallbacks until the provider is initialized.
    * Defaults to true.
    */
   suspendUntilReady?: boolean,

--- a/packages/react/src/use-feature-flag.ts
+++ b/packages/react/src/use-feature-flag.ts
@@ -14,7 +14,7 @@ type ReactFlagEvaluationOptions = {
    * Set to true if you want to show suspense fallbacks while flags are re-evaluated after context changes.
    * Defaults to false.
    */
-  suspendWhileStale?: boolean,
+  suspendWhileReconciling?: boolean,
   /**
    * Update the component if the provider emits a ConfigurationChanged event.
    * Set to false to prevent components from re-rendering when flag value changes
@@ -35,7 +35,7 @@ const DEFAULT_OPTIONS: ReactFlagEvaluationOptions = {
   updateOnContextChanged: true,
   updateOnConfigurationChanged: true,
   suspendUntilReady: true,
-  suspendWhileStale: false,
+  suspendWhileReconciling: false,
 };
 
 enum SuspendState {
@@ -177,15 +177,15 @@ function attachHandlersAndResolve<T extends FlagValue>(flagKey: string, defaultV
     if (defaultedOptions.updateOnContextChanged) {
       // update when the context changes
       client.addHandler(ProviderEvents.ContextChanged, forceUpdate);
-      if (defaultedOptions.suspendWhileStale) {
-        client.addHandler(ProviderEvents.Stale, suspendRef);
+      if (defaultedOptions.suspendWhileReconciling) {
+        client.addHandler(ProviderEvents.Reconciling, suspendRef);
       }
     }
     return () => {
       // cleanup the handlers
       client.removeHandler(ProviderEvents.Ready, forceUpdate);
       client.removeHandler(ProviderEvents.ContextChanged, forceUpdate);
-      client.removeHandler(ProviderEvents.Stale, suspendRef);
+      client.removeHandler(ProviderEvents.Reconciling, suspendRef);
     };
   }, []);
   


### PR DESCRIPTION
This PR adds "suspend on reconciling" to the React SDK, in a manner [consistent with this spec](https://openfeature.dev/specification/sections/events#event-handlers-and-context-reconciliation).

When the SDK emits a PROVIDER_RECONCILING event, loaders are displayed until the CONTEXT_CHANGED event is emitted.
