### PR TITLE
fix: removed duped core types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       "devDependencies": {
         "@openfeature/flagd-provider": "^0.10.2",
         "@openfeature/flagd-web-provider": "^0.4.0",
-        "@rollup/plugin-alias": "^5.0.0",
         "@rollup/plugin-typescript": "^11.0.0",
         "@types/events": "^3.0.0",
         "@types/jest": "^29.0.0",
@@ -1765,38 +1764,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@rollup/plugin-alias": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.0.1.tgz",
-      "integrity": "sha512-JObvbWdOHoMy9W7SU0lvGhDtWq9PllP5mjpAy+TUslZG/WzOId9u80Hsqq1vCUn9pFJ0cxpdcnAv+QzU2zFH3Q==",
-      "dev": true,
-      "dependencies": {
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-alias/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@rollup/plugin-typescript": {
       "version": "11.1.5",
@@ -14480,7 +14447,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.24"
@@ -14525,7 +14492,7 @@
     },
     "packages/server": {
       "name": "@openfeature/server-sdk",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.24"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@openfeature/flagd-provider": "^0.10.2",
     "@openfeature/flagd-web-provider": "^0.4.0",
-    "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/events": "^3.0.0",
     "@types/jest": "^29.0.0",

--- a/packages/client/tsconfig.rollup.json
+++ b/packages/client/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/nest/tsconfig.rollup.json
+++ b/packages/nest/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/react/tsconfig.rollup.json
+++ b/packages/react/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/server/tsconfig.rollup.json
+++ b/packages/server/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/packages/shared/tsconfig.rollup.json
+++ b/packages/shared/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,6 @@
 // this config rolls up all the types in the project to a single declaration (d.ts) file.
 // we do NOT use rollup to build (we use esbuild for that)
 
-import alias from '@rollup/plugin-alias';
 import dts from 'rollup-plugin-dts';
 
 export default {
@@ -18,6 +17,7 @@ export default {
     }
   ],
   plugins: [
-    dts({tsconfig: './tsconfig.json'}),
+    // use the rollup override tsconfig (applies equivalent in each sub-packages as well)
+    dts({tsconfig: './tsconfig.rollup.json'}),
   ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "@openfeature/core": [ "./packages/shared/src" ]
-    },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    },                                                   /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/tsconfig.rollup.json
+++ b/tsconfig.rollup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {}
+  }
+}


### PR DESCRIPTION
A while back I added:

```json
    "paths": {
      "@openfeature/core": [ "./packages/shared/src" ]
    },      
```

To the tsconfigs, which helped with local dev by always resolving `src/*` files from sibling packages instead of anything in their `dist/`.

It also had the nasty side-effect of causing our type bundling to include types from this package in it's output, causing duplicated artifacts and possible compiler issues. I've overridden this with a custom `tsconfig.rollup.json`.

Before this fix, the web/server SDK dists contained dupes of the stuff in shared:

```ts
import EventEmitter from 'events';

type FlagValueType = 'boolean' | 'string' | 'number' | 'object';
type PrimitiveValue = null | boolean | string | number;
type JsonObject = {
    [key: string]: JsonValue;
};
type JsonArray = JsonValue[];
/**
 * Represents a JSON node value.
 */
```

After this fix, they import them:

```ts
import { BaseHook, HookHints, EvaluationDetails, JsonValue, EvaluationLifeCycle, ManageLogger, Eventing, ClientMetadata, ProviderStatus, ClientProviderEvents, GenericEventEmitter, CommonEventDetails, FlagValue, CommonProvider, EvaluationContext, Logger, ResolutionDetails, EventHandler, OpenFeatureCommonAPI, ManageContext } from '@openfeature/core';
export * from '@openfeature/core';
```