### PR TITLE
fix: improve event handler types

### DIFF
--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1,8 +1,9 @@
 import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger } from '@openfeature/core';
 import { Features } from '../evaluation';
 import { ProviderStatus } from '../provider';
+import { ProviderEvents } from '../events';
 
-export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing {
+export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing<ProviderEvents> {
   readonly metadata: ClientMetadata;
   /**
    * Returns the status of the associated provider.

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -11,6 +11,7 @@ import {
   Logger,
   OpenFeatureError,
   ProviderFatalError,
+  ProviderNotReadyError,
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
@@ -23,7 +24,6 @@ import { Hook } from '../hooks';
 import { OpenFeature } from '../open-feature';
 import { Provider, ProviderStatus } from '../provider';
 import { Client } from './client';
-import { ProviderNotReadyError } from '@openfeature/core';
 
 type OpenFeatureClientOptions = {
   /**

--- a/packages/client/test/events.spec.ts
+++ b/packages/client/test/events.spec.ts
@@ -507,14 +507,17 @@ describe('Events', () => {
     it('It defines a mechanism for signalling `PROVIDER_CONFIGURATION_CHANGED`', (done) => {
       const provider = new MockProvider();
       const client = OpenFeature.getClient(domain);
+      const changedFlag = 'fake-flag';
 
-      client.addHandler(ProviderEvents.ConfigurationChanged, () => {
+      client.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
+        expect(details?.flagsChanged?.length).toEqual(1);
+        expect(details?.flagsChanged).toEqual([changedFlag]);
         done();
       });
 
       OpenFeature.setProvider(domain, provider);
       // emit a change event from the mock provider
-      provider.events?.emit(ProviderEvents.ConfigurationChanged);
+      provider.events?.emit(ProviderEvents.ConfigurationChanged, { flagsChanged: [changedFlag] });
     });
   });
 

--- a/packages/server/src/client/client.ts
+++ b/packages/server/src/client/client.ts
@@ -7,13 +7,14 @@ import {
 } from '@openfeature/core';
 import { Features } from '../evaluation';
 import { ProviderStatus } from '../provider';
+import { ProviderEvents } from '../events';
 
 export interface Client
   extends EvaluationLifeCycle<Client>,
     Features,
     ManageContext<Client>,
     ManageLogger<Client>,
-    Eventing {
+    Eventing<ProviderEvents> {
   readonly metadata: ClientMetadata;
   /**
    * Returns the status of the associated provider.

--- a/packages/server/test/events.spec.ts
+++ b/packages/server/test/events.spec.ts
@@ -487,14 +487,17 @@ describe('Events', () => {
     it('It defines a mechanism for signalling `PROVIDER_CONFIGURATION_CHANGED`', (done) => {
       const provider = new MockProvider();
       const client = OpenFeature.getClient(domain);
+      const changedFlag = 'fake-flag';
 
-      client.addHandler(ProviderEvents.ConfigurationChanged, () => {
+      client.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
+        expect(details?.flagsChanged?.length).toEqual(1);
+        expect(details?.flagsChanged).toEqual([changedFlag]);
         done();
       });
 
       OpenFeature.setProvider(domain, provider);
       // emit a change event from the mock provider
-      provider.events?.emit(ProviderEvents.ConfigurationChanged);
+      provider.events?.emit(ProviderEvents.ConfigurationChanged, { flagsChanged: [changedFlag] });
     });
   });
   

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -7,7 +7,7 @@ import {
   EventHandler,
   Eventing,
   GenericEventEmitter,
-  statusMatchesEvent,
+  statusMatchesEvent
 } from './events';
 import { isDefined } from './filter';
 import { BaseHook, EvaluationLifeCycle } from './hooks';
@@ -74,7 +74,7 @@ export class ProviderWrapper<P extends CommonProvider<AnyProviderStatus>, S exte
 }
 
 export abstract class OpenFeatureCommonAPI<S extends AnyProviderStatus, P extends CommonProvider<S> = CommonProvider<S>, H extends BaseHook = BaseHook>
-  implements Eventing, EvaluationLifeCycle<OpenFeatureCommonAPI<S, P>>, ManageLogger<OpenFeatureCommonAPI<S, P>>
+  implements Eventing<AnyProviderEvent>, EvaluationLifeCycle<OpenFeatureCommonAPI<S, P>>, ManageLogger<OpenFeatureCommonAPI<S, P>>
 {
   // accessor for the type of the ProviderStatus enum (client or server)
   protected abstract readonly _statusEnumType: typeof ClientProviderStatus | typeof ServerProviderStatus;


### PR DESCRIPTION
Before this change the `flagsChanged` prop on `EventDetails` was of type unknown for all event types, and a cast was needed.

After this change, `flagsChanged` is ONLY defined on `ProviderEvents.ConfigurationChanged`, where it should be, as (`string[] | undefined`) . In other words:

```typescript
client.addHandler(ProviderEvents.Ready, (details) => {
  expect(details?.flagsChanged?.length).toEqual(1);  // does not compile
});
```

```typescript
client.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
  expect(details?.flagsChanged?.length).toEqual(1);  // DOES compile
});
```

Additionally, `flagsChanged` does not autocomplete for events handlers other than `ProviderEvents.ConfigurationChanged`.