### PR TITLE
fix: allow iteration over all event types

### DIFF
--- a/packages/client/test/events.spec.ts
+++ b/packages/client/test/events.spec.ts
@@ -519,6 +519,16 @@ describe('Events', () => {
       // emit a change event from the mock provider
       provider.events?.emit(ProviderEvents.ConfigurationChanged, { flagsChanged: [changedFlag] });
     });
+
+    it('It allows iteration over all event types', () => {
+      // just a typings test; it should be possible to iterate over a collection of ProviderEvents,
+      const client = OpenFeature.getClient(domain);
+      const providerEvents: ProviderEvents[] = [];
+
+      providerEvents.forEach((e) => {
+        client.addHandler(e, () => {});
+      });
+    });
   });
 
   describe('Requirement 5.3.3', () => {

--- a/packages/server/test/events.spec.ts
+++ b/packages/server/test/events.spec.ts
@@ -499,6 +499,16 @@ describe('Events', () => {
       // emit a change event from the mock provider
       provider.events?.emit(ProviderEvents.ConfigurationChanged, { flagsChanged: [changedFlag] });
     });
+
+    it('It allows iteration over all event types', () => {
+      // just a typings test; it should be possible to iterate over a collection of ProviderEvents,
+      const client = OpenFeature.getClient(domain);
+      const providerEvents: ProviderEvents[] = [];
+
+      providerEvents.forEach((e) => {
+        client.addHandler(e, () => {});
+      });
+    });
   });
   
   describe('Requirement 5.3.3', () => {

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -87,6 +87,10 @@ export interface Eventing<T extends ServerProviderEvents | ClientProviderEvents>
     eventType: T extends ClientProviderEvents ? ClientNotChangeEvents : ServerNotChangeEvents,
     handler: EventHandler<T extends ClientProviderEvents ? ClientNotChangeEvents : ServerNotChangeEvents>,
   ): void;
+  addHandler(
+    eventType: T extends ClientProviderEvents ? ClientProviderEvents : ServerProviderEvents,
+    handler: EventHandler<T extends ClientProviderEvents ? ClientProviderEvents : ServerProviderEvents>,
+  ): void;
 
   /**
    * Removes a handler for the given provider event type.


### PR DESCRIPTION
This is an addendum to https://github.com/open-feature/js-sdk/pull/816.

Since the `addHandler` overloads for the event types (`ProviderEvents.ConfigurationChanged` and `NotChangeEvents`) are mutually exclusive, it was impossible to iterate over them and pass the same function...

I had to add one more "base" overload that tolerated both. This doesn't reduce any of the nice type safety added in https://github.com/open-feature/js-sdk/pull/816, but allows users to iterate over `ProviderEvents` collections as seen in the new tests.