### PR TITLE
fix: correct rollup to bundle all but core

### DIFF
--- a/packages/client/src/events/open-feature-event-emitter.ts
+++ b/packages/client/src/events/open-feature-event-emitter.ts
@@ -1,5 +1,5 @@
 import { GenericEventEmitter } from '@openfeature/core';
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { ProviderEmittableEvents } from './events';
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit

--- a/packages/server/src/events/open-feature-event-emitter.ts
+++ b/packages/server/src/events/open-feature-event-emitter.ts
@@ -1,5 +1,5 @@
 import { GenericEventEmitter } from '@openfeature/core';
-import EventEmitter from 'events';
+import { EventEmitter } from 'node:events';
 import { ProviderEvents } from './events';
 
 /**

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,17 +7,15 @@ export default {
   input: "./src/index.ts",
   output: {
     file: './dist/types.d.ts',
-    format: 'es', // module format doesn't really matter here since output i
+    format: 'es', // module format doesn't really matter here since output is types
   },
-  external: [
-    // function indicating which deps should be considered external: non-external deps will have their types bundled
-    (id) => {
-      // bundle 'events' types
-      return id !== 'events';
-    }
-  ],
+  // function indicating which deps should be considered external: external deps will NOT have their types bundled
+  external: (id) => {
+    // bundle everything but '@openfeature/core', which is a peer
+    return id === '@openfeature/core';
+  },
   plugins: [
     // use the rollup override tsconfig (applies equivalent in each sub-packages as well)
-    dts({tsconfig: './tsconfig.rollup.json'}),
+    dts({tsconfig: './tsconfig.rollup.json', respectExternal: true }),
   ],
 };


### PR DESCRIPTION
My rollup config was invalid, but clumsily working until a recent change in how we defined the event emitter type. The impact was the the bundled types for the web imported `from 'events'` instead of bundling it.

This PR fixes the mis-configuration (see comments).

Here is a screenshot showing the bundled types in the dist now (notice the import is gone and the emitter is in-lined, no other changes are present): 

![image](https://github.com/open-feature/js-sdk/assets/25272906/8728911d-7c72-4d53-8dc2-d748837a616e)

In server, this type is available from node, so we DON'T need to bundle it, and in fact, SHOULD import it. This is easily done by importing it like `from 'node:events'`. I don't think it would be a problem if we bundled it anyway, but this is more correct.

Fixes: https://github.com/open-feature/js-sdk/issues/845