### PR TITLE
feat: use EvenEmitter3 for web-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       ],
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",
-        "@types/events": "^3.0.3",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.16",
         "@types/react": "^18.2.55",
@@ -2152,12 +2151,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
-    },
-    "node_modules/@types/events": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
       "dev": true
     },
     "node_modules/@types/glob": {
@@ -13772,7 +13765,7 @@
     },
     "packages/react": {
       "name": "@openfeature/react-sdk",
-      "version": "0.2.0-experimental",
+      "version": "0.2.1-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^27.6.3",
         "eslint-plugin-jsdoc": "^48.0.6",
-        "events": "^3.3.0",
+        "eventemitter3": "^5.0.1",
         "jest": "^29.7.0",
         "jest-config": "^29.7.0",
         "jest-cucumber": "^3.0.1",
@@ -4787,14 +4787,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
     },
     "node_modules/exec-sh": {
       "version": "0.3.6",
@@ -13743,7 +13740,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.27"
@@ -13754,7 +13751,7 @@
     },
     "packages/nest": {
       "name": "@openfeature/nestjs-sdk",
-      "version": "0.1.0-experimental",
+      "version": "0.1.1-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@nestjs/common": "^10.2.10",
@@ -13788,7 +13785,7 @@
     },
     "packages/server": {
       "name": "@openfeature/server-sdk",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "0.0.27"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.6.3",
     "eslint-plugin-jsdoc": "^48.0.6",
-    "events": "^3.3.0",
+    "eventemitter3": "^5.0.1",
     "jest": "^29.7.0",
     "jest-config": "^29.7.0",
     "jest-cucumber": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
-    "@types/events": "^3.0.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.16",
     "@types/react": "^18.2.55",

--- a/packages/client/src/events/open-feature-event-emitter.ts
+++ b/packages/client/src/events/open-feature-event-emitter.ts
@@ -1,6 +1,7 @@
 import { GenericEventEmitter } from '@openfeature/core';
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 import { ProviderEmittableEvents } from './events';
+
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit
  * events at various parts of the provider lifecycle.
@@ -9,12 +10,9 @@ import { ProviderEmittableEvents } from './events';
  * the result of the initialize method.
  */
 export class OpenFeatureEventEmitter extends GenericEventEmitter<ProviderEmittableEvents> {
-  protected readonly eventEmitter = new EventEmitter({ captureRejections: true });
+  protected readonly eventEmitter = new EventEmitter();
 
   constructor() {
     super();
-    this.eventEmitter.on('error', (err) => {
-      this._logger?.error('Error running event handler:', err);
-    });
   }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes an issue where the `events` node polyfill does not comply to the `node:events` types.
When trying to use the web OpenFeatureEventEmitter the following error message comes up, describing that the `events` polyfill's EventEmitter is incompatible to `node:events` EventEmitter.

```
✘ [ERROR] TS2416: Property 'eventEmitter' in type 'OpenFeatureEventEmitter' is not assignable to the same property in base type 'GenericEventEmitter<ProviderEmittableEvents, Record<string, unknown>>'.
  Type 'EventEmitter' is not assignable to type 'PlatformEventEmitter'.
    Types of property 'addListener' are incompatible.
      Type '(type: string | number, listener: Listener) => EventEmitter' is not assignable to type '(eventName: string | symbol, listener: (...args: any[]) => void) => PlatformEventEmitter'.
        Types of parameters 'type' and 'eventName' are incompatible.
          Type 'string | symbol' is not assignable to type 'string | number'.
            Type 'symbol' is not assignable to type 'string | number'.
```

This PR fixes that issue by not using the `events` anymore and instead using https://www.npmjs.com/package/eventemitter3

cc @toddbaert 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #845 

