### PR TITLE
fix(types): conflicts with peer types

### DIFF
--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -61,6 +61,19 @@ Capabilities include:
 npm install --save @openfeature/nestjs-sdk
 ```
 
+#### npm
+
+```sh
+npm install --save @openfeature/nestjs-sdk
+```
+
+#### yarn
+
+```sh
+# yarn requires manual installation of the peer dependencies (see below)
+yarn add @openfeature/nestjs-sdk @openfeature/server-sdk @openfeature/core
+```
+
 #### Required peer dependencies
 
 The following list contains the peer dependencies of `@openfeature/nestjs-sdk` with its expected and compatible versions:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -42,10 +42,19 @@ The OpenFeature React SDK adds React-specific functionality to the [OpenFeature 
 
 In addition to the feature provided by the [web sdk](https://openfeature.dev/docs/reference/technologies/client/web), capabilities include:
 
-- [Multiple Providers and domains](#multiple-providers-and-domains)
-- [Re-rendering with Context Changes](#re-rendering-with-context-changes)
-- [Re-rendering with Flag Configuration Changes](#re-rendering-with-flag-configuration-changes)
-- [Suspense Support](#suspense-support)
+- [Overview](#overview)
+- [🚀 Quick start](#-quick-start)
+  - [Requirements](#requirements)
+  - [Install](#install)
+    - [npm](#npm)
+    - [yarn](#yarn)
+    - [Required peer dependencies](#required-peer-dependencies)
+  - [Usage](#usage)
+  - [Multiple Providers and Domains](#multiple-providers-and-domains)
+  - [Re-rendering with Context Changes](#re-rendering-with-context-changes)
+  - [Re-rendering with Flag Configuration Changes](#re-rendering-with-flag-configuration-changes)
+  - [Suspense Support](#suspense-support)
+- [Resources](#resources)
 
 ## 🚀 Quick start
 
@@ -62,11 +71,18 @@ In addition to the feature provided by the [web sdk](https://openfeature.dev/doc
 npm install --save @openfeature/react-sdk
 ```
 
+#### yarn
+
+```sh
+# yarn requires manual installation of the peer dependencies (see below)
+yarn add @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
+```
+
 #### Required peer dependencies
 
 The following list contains the peer dependencies of `@openfeature/react-sdk` with its expected and compatible versions:
 
-* `@openfeature/web-sdk`: >=0.4.10
+* `@openfeature/web-sdk`: >=0.4.14
 * `react`: >=16.8.0
 
 ### Usage

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,8 +11,11 @@ export default {
   },
   // function indicating which deps should be considered external: external deps will NOT have their types bundled
   external: (id) => {
-    // bundle everything but '@openfeature/core', which is a peer
-    return id === '@openfeature/core';
+    // bundle everything except peer deps (@openfeature/*, @nest/*,  react. rxjs)
+    return id.startsWith('@openfeature') ||
+      id.startsWith('@nest') ||
+      id === 'rxjs' ||
+      id === 'react';
   },
   plugins: [
     // use the rollup override tsconfig (applies equivalent in each sub-packages as well)


### PR DESCRIPTION
With our recent changes in bundling, there's a new problem with the framework-specific SDKs (react + nestjs). These have peers, and the external function was bundling those peers as well. This change prevents us from bundling any peers (which is what we want, so we avoid conflicts with the consumers installed peers).

This has no runtime impact, and there was not changes to core, web, or server SDK dists. See image below for the difference in the react SDK:

![image](https://github.com/open-feature/js-sdk/assets/25272906/0bdd16d6-d1c0-4118-9bf4-93659c164090)
