### PR TITLE
chore: release/use 1.0 core

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,5 @@
   "packages/react": "0.2.2-experimental",
   "packages/client": "0.4.15",
   "packages/server": "1.13.1",
-  "packages/shared": "0.0.28"
+  "packages/shared": "1.0.0"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,9 +46,9 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/core": "0.0.28"
+    "@openfeature/core": "1.0.0"
   },
   "devDependencies": {
-    "@openfeature/core": "0.0.28"
+    "@openfeature/core": "1.0.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,9 +48,9 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "@openfeature/core": "0.0.28"
+    "@openfeature/core": "1.0.0"
   },
   "devDependencies": {
-    "@openfeature/core": "0.0.28"
+    "@openfeature/core": "1.0.0"
   }
 }

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.0](https://github.com/open-feature/js-sdk/compare/core-v0.0.28...core-v1.0.0) (2024-03-11)
+
+### No changes
+
 ## [0.0.28](https://github.com/open-feature/js-sdk/compare/core-v0.0.27...core-v0.0.28) (2024-03-05)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfeature/core",
-  "version": "0.0.28",
+  "version": "1.0.0",
   "description": "Shared OpenFeature JS components (server and web)",
   "main": "./dist/cjs/index.js",
   "files": [


### PR DESCRIPTION
Releasing a 1.0 `@openfeature/core` version for better versioning/peer-dep management for consumers.