### PR TITLE
fix: return metadata for the bound provider in hookContext

### DIFF
--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -201,7 +201,7 @@ export class OpenFeatureClient implements Client {
       defaultValue,
       flagValueType: flagType,
       clientMetadata: this.metadata,
-      providerMetadata: OpenFeature.providerMetadata,
+      providerMetadata: this._provider.metadata,
       context,
       logger: this._logger,
     };

--- a/packages/client/test/hooks.spec.ts
+++ b/packages/client/test/hooks.spec.ts
@@ -77,6 +77,39 @@ describe('Hooks', () => {
         ],
       });
     });
+    it('client metadata and provider metadata must match the client and provider used to resolve the flag', (done) => {
+      const provider: Provider = {
+        metadata: {
+          name: 'mock-my-domain-provider',
+        },
+        resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
+          return Promise.resolve({
+            value: BOOLEAN_VALUE,
+            variant: BOOLEAN_VARIANT,
+            reason: REASON,
+          });
+        }),
+      } as unknown as Provider;
+
+      OpenFeature.setProvider('my-domain', provider);
+      const client = OpenFeature.getClient('my-domain');
+
+      client.getBooleanValue(FLAG_KEY, false, {
+        hooks: [
+          {
+            before: (hookContext) => {
+              try {
+                expect(hookContext.providerMetadata).toEqual(provider.metadata);
+                expect(hookContext.clientMetadata).toEqual(client.metadata);
+                done();
+              } catch (err) {
+                done(err);
+              }
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('Requirement 4.1.3', () => {

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -254,7 +254,7 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
       defaultValue,
       flagValueType: flagType,
       clientMetadata: this.metadata,
-      providerMetadata: OpenFeature.providerMetadata,
+      providerMetadata: this._provider.metadata,
       context: mergedContext,
       logger: this._logger,
     };

--- a/packages/server/test/hooks.spec.ts
+++ b/packages/server/test/hooks.spec.ts
@@ -73,6 +73,39 @@ describe('Hooks', () => {
         ],
       });
     });
+    it('client metadata and provider metadata must match the client and provider used to resolve the flag', (done) => {
+      const provider: Provider = {
+        metadata: {
+          name: 'mock-my-domain-provider',
+        },
+        resolveBooleanEvaluation: jest.fn((): Promise<ResolutionDetails<boolean>> => {
+          return Promise.resolve({
+            value: BOOLEAN_VALUE,
+            variant: BOOLEAN_VARIANT,
+            reason: REASON,
+          });
+        }),
+      } as unknown as Provider;
+
+      OpenFeature.setProvider('my-domain', provider);
+      const client = OpenFeature.getClient('my-domain');
+
+      client.getBooleanValue(FLAG_KEY, false, undefined, {
+        hooks: [
+          {
+            before: (hookContext) => {
+              try {
+                expect(hookContext.providerMetadata).toEqual(provider.metadata);
+                expect(hookContext.clientMetadata).toEqual(client.metadata);
+                done();
+              } catch (err) {
+                done(err);
+              }
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('Requirement 4.1.3', () => {


### PR DESCRIPTION
Clients were incorrectly populating the hook context provider metadata field with metadata from the default provider instead of the one bound to the client.
