### PR TITLE
fix: make domain/client optional

### DIFF
--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -7,14 +7,14 @@ type ClientOrDomain =
        * An identifier which logically binds clients with providers
        * @see OpenFeature.setProvider() and overloads.
        */
-      domain: string;
+      domain?: string;
       client?: never;
     }
   | {
       /**
        * OpenFeature client to use.
        */
-      client: Client;
+      client?: Client;
       domain?: never;
     };
 


### PR DESCRIPTION
Fixes a typing bug that makes domain/client required; these should be optional, consistent with other SDKs and the spec.