### PR TITLE
fix(deps): resolve CVE-2024-29041 with nest update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1720,9 +1720,15 @@
       }
     },
     "node_modules/@nestjs/common": {
+<<<<<<< Updated upstream
       "version": "10.3.3",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.3.tgz",
       "integrity": "sha512-LAkTe8/CF0uNWM0ecuDwUNTHCi1lVSITmmR4FQ6Ftz1E7ujQCnJ5pMRzd8JRN14vdBkxZZ8VbVF0BDUKoKNxMQ==",
+=======
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.6.tgz",
+      "integrity": "sha512-ExWGwjKs8L3sAm6SMRIV/N2HzVol4VFO3EbDhKL/HV1FQXAqj7otjXv/SzGBlI+/ax1nQfEdGgZbSMeZeeR6VA==",
+>>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
@@ -1755,9 +1761,15 @@
       "dev": true
     },
     "node_modules/@nestjs/core": {
+<<<<<<< Updated upstream
       "version": "10.3.3",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.3.tgz",
       "integrity": "sha512-kxJWggQAPX3RuZx9JVec69eSLaYLNIox2emkZJpfBJ5Qq7cAq7edQIt1r4LGjTKq6kFubNTPsqhWf5y7yFRBPw==",
+=======
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.6.tgz",
+      "integrity": "sha512-06RFGSFGwDiMRdWFm1Rofp9A1G+1+W7dH2U07S6mE2XtABx5UBwA5kGBZL8z9osdNnBg+6WMpSpkNvQ35f60EA==",
+>>>>>>> Stashed changes
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1799,14 +1811,24 @@
       "dev": true
     },
     "node_modules/@nestjs/platform-express": {
+<<<<<<< Updated upstream
       "version": "10.3.3",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.3.tgz",
       "integrity": "sha512-GGKSEU48Os7nYFIsUM0nutuFUGn5AbeP8gzFBiBCAtiuJWrXZXpZ58pMBYxAbMf7IrcOZFInHEukjHGAQU0OZw==",
+=======
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.6.tgz",
+      "integrity": "sha512-yNHuBn/ktjssl+hJd3RXNyMjqL7jXOCDHhnc0JvAmRf3L54/RBgKyDcDLZ6Mv/KYOrmfId5PNeAAjd9IPmcyBw==",
+>>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
+<<<<<<< Updated upstream
         "express": "4.18.2",
+=======
+        "express": "4.19.2",
+>>>>>>> Stashed changes
         "multer": "1.4.4-lts.1",
         "tslib": "2.6.2"
       },
@@ -1826,9 +1848,15 @@
       "dev": true
     },
     "node_modules/@nestjs/testing": {
+<<<<<<< Updated upstream
       "version": "10.3.3",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.3.tgz",
       "integrity": "sha512-kX20GfjAImL5grd/i69uD/x7sc00BaqGcP2dRG3ilqshQUuy5DOmspLCr3a2C8xmVU7kzK4spT0oTxhe6WcCAA==",
+=======
+      "version": "10.3.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.6.tgz",
+      "integrity": "sha512-9atg+aGqhg3ZhwTz2oHMa3hg3JJ6XQfQcRhkiIsOegCIiV/esqBH7R71kAJC6ppOlKtT3XHngFvlIxo4tODKfw==",
+>>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "tslib": "2.6.2"
@@ -3610,9 +3638,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4920,9 +4948,15 @@
       }
     },
     "node_modules/express": {
+<<<<<<< Updated upstream
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
       "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+=======
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+>>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -4930,7 +4964,7 @@
         "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -13747,10 +13781,17 @@
       "version": "0.1.2-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
+<<<<<<< Updated upstream
         "@nestjs/common": "^10.2.10",
         "@nestjs/core": "^10.2.10",
         "@nestjs/platform-express": "^10.2.10",
         "@nestjs/testing": "^10.2.10",
+=======
+        "@nestjs/common": "^10.3.6",
+        "@nestjs/core": "^10.3.6",
+        "@nestjs/platform-express": "^10.3.6",
+        "@nestjs/testing": "^10.3.6",
+>>>>>>> Stashed changes
         "@openfeature/core": "*",
         "@openfeature/server-sdk": "*",
         "@types/supertest": "^6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1720,15 +1720,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-<<<<<<< Updated upstream
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.3.tgz",
-      "integrity": "sha512-LAkTe8/CF0uNWM0ecuDwUNTHCi1lVSITmmR4FQ6Ftz1E7ujQCnJ5pMRzd8JRN14vdBkxZZ8VbVF0BDUKoKNxMQ==",
-=======
       "version": "10.3.6",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.3.6.tgz",
       "integrity": "sha512-ExWGwjKs8L3sAm6SMRIV/N2HzVol4VFO3EbDhKL/HV1FQXAqj7otjXv/SzGBlI+/ax1nQfEdGgZbSMeZeeR6VA==",
->>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
@@ -1761,15 +1755,9 @@
       "dev": true
     },
     "node_modules/@nestjs/core": {
-<<<<<<< Updated upstream
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.3.tgz",
-      "integrity": "sha512-kxJWggQAPX3RuZx9JVec69eSLaYLNIox2emkZJpfBJ5Qq7cAq7edQIt1r4LGjTKq6kFubNTPsqhWf5y7yFRBPw==",
-=======
       "version": "10.3.6",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.6.tgz",
       "integrity": "sha512-06RFGSFGwDiMRdWFm1Rofp9A1G+1+W7dH2U07S6mE2XtABx5UBwA5kGBZL8z9osdNnBg+6WMpSpkNvQ35f60EA==",
->>>>>>> Stashed changes
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1811,24 +1799,14 @@
       "dev": true
     },
     "node_modules/@nestjs/platform-express": {
-<<<<<<< Updated upstream
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.3.tgz",
-      "integrity": "sha512-GGKSEU48Os7nYFIsUM0nutuFUGn5AbeP8gzFBiBCAtiuJWrXZXpZ58pMBYxAbMf7IrcOZFInHEukjHGAQU0OZw==",
-=======
       "version": "10.3.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.6.tgz",
       "integrity": "sha512-yNHuBn/ktjssl+hJd3RXNyMjqL7jXOCDHhnc0JvAmRf3L54/RBgKyDcDLZ6Mv/KYOrmfId5PNeAAjd9IPmcyBw==",
->>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
-<<<<<<< Updated upstream
-        "express": "4.18.2",
-=======
         "express": "4.19.2",
->>>>>>> Stashed changes
         "multer": "1.4.4-lts.1",
         "tslib": "2.6.2"
       },
@@ -1848,15 +1826,9 @@
       "dev": true
     },
     "node_modules/@nestjs/testing": {
-<<<<<<< Updated upstream
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.3.tgz",
-      "integrity": "sha512-kX20GfjAImL5grd/i69uD/x7sc00BaqGcP2dRG3ilqshQUuy5DOmspLCr3a2C8xmVU7kzK4spT0oTxhe6WcCAA==",
-=======
       "version": "10.3.6",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.3.6.tgz",
       "integrity": "sha512-9atg+aGqhg3ZhwTz2oHMa3hg3JJ6XQfQcRhkiIsOegCIiV/esqBH7R71kAJC6ppOlKtT3XHngFvlIxo4tODKfw==",
->>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "tslib": "2.6.2"
@@ -4948,20 +4920,14 @@
       }
     },
     "node_modules/express": {
-<<<<<<< Updated upstream
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
-=======
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
       "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
->>>>>>> Stashed changes
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
@@ -4995,30 +4961,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5026,18 +4968,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/express/node_modules/ms": {
@@ -5051,21 +4981,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
@@ -13767,7 +13682,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "0.4.15",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "1.0.0"
@@ -13781,17 +13696,10 @@
       "version": "0.1.2-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
-<<<<<<< Updated upstream
-        "@nestjs/common": "^10.2.10",
-        "@nestjs/core": "^10.2.10",
-        "@nestjs/platform-express": "^10.2.10",
-        "@nestjs/testing": "^10.2.10",
-=======
         "@nestjs/common": "^10.3.6",
         "@nestjs/core": "^10.3.6",
         "@nestjs/platform-express": "^10.3.6",
         "@nestjs/testing": "^10.3.6",
->>>>>>> Stashed changes
         "@openfeature/core": "*",
         "@openfeature/server-sdk": "*",
         "@types/supertest": "^6.0.0",
@@ -13806,20 +13714,20 @@
     },
     "packages/react": {
       "name": "@openfeature/react-sdk",
-      "version": "0.2.2-experimental",
+      "version": "0.2.3-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "*",
         "@openfeature/web-sdk": "*"
       },
       "peerDependencies": {
-        "@openfeature/web-sdk": ">=0.4.14",
+        "@openfeature/web-sdk": ">=1.0.0",
         "react": ">=16.8.0"
       }
     },
     "packages/server": {
       "name": "@openfeature/server-sdk",
-      "version": "1.13.1",
+      "version": "1.13.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "1.0.0"

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -51,10 +51,10 @@
     "@openfeature/server-sdk": ">=1.7.5"
   },
   "devDependencies": {
-    "@nestjs/common": "^10.2.10",
-    "@nestjs/core": "^10.2.10",
-    "@nestjs/platform-express": "^10.2.10",
-    "@nestjs/testing": "^10.2.10",
+    "@nestjs/common": "^10.3.6",
+    "@nestjs/core": "^10.3.6",
+    "@nestjs/platform-express": "^10.3.6",
+    "@nestjs/testing": "^10.3.6",
     "@openfeature/core": "*",
     "@openfeature/server-sdk": "*",
     "@types/supertest": "^6.0.0",


### PR DESCRIPTION
Fixes CVE in transitive express dep with nest update.

see: https://nvd.nist.gov/vuln/detail/CVE-2024-29041