### PR TITLE
feat: allow constraint of booleans

### DIFF
--- a/packages/client/src/evaluation/evaluation.ts
+++ b/packages/client/src/evaluation/evaluation.ts
@@ -9,15 +9,19 @@ export interface Features {
   /**
    * Performs a flag evaluation that returns a boolean.
    * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @template {string} T A optional generic argument constraining the boolean
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {boolean} Flag evaluation response
    */
   getBooleanValue(flagKey: string, defaultValue: boolean, options?: FlagEvaluationOptions): boolean;
 
+  getBooleanValue<T extends boolean = boolean>(flagKey: string, defaultValue: T, options?: FlagEvaluationOptions): T;
+
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
    * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @template {boolean} T A optional generic argument constraining the boolean
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
    * @returns {EvaluationDetails<boolean>} Flag evaluation details response
@@ -27,6 +31,12 @@ export interface Features {
     defaultValue: boolean,
     options?: FlagEvaluationOptions,
   ): EvaluationDetails<boolean>;
+
+  getBooleanDetails<T extends boolean = boolean>(
+    flagKey: string,
+    defaultValue: boolean,
+    options?: FlagEvaluationOptions,
+  ): EvaluationDetails<T>;
 
   /**
    * Performs a flag evaluation that returns a string.

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -190,13 +190,26 @@ describe('OpenFeatureClient', () => {
 
     describe('flag evaluation', () => {
       describe('getBooleanValue', () => {
-        it('should return boolean, and call boolean resolver', () => {
-          const booleanFlag = 'my-boolean-flag';
-          const defaultBooleanValue = false;
-          const value = client.getBooleanValue(booleanFlag, defaultBooleanValue);
+        describe('with no generic arg (as boolean)', () => {
+          it('should return boolean, and call boolean resolver', () => {
+            const booleanFlag = 'my-boolean-flag';
+            const defaultBooleanValue = false;
+            const value = client.getBooleanValue(booleanFlag, defaultBooleanValue);
+  
+            expect(value).toEqual(BOOLEAN_VALUE);
+            expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+          });
+        });
 
-          expect(value).toEqual(BOOLEAN_VALUE);
-          expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+        describe('with generic arg', () => {
+          it('should return T, and call boolean resolver', () => {
+            const booleanFlag = 'my-boolean-flag';
+            const defaultBooleanValue = true;
+            const value = client.getBooleanValue<true>(booleanFlag, defaultBooleanValue);
+  
+            expect(value).toEqual(BOOLEAN_VALUE);
+            expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+          });
         });
       });
 

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -130,15 +130,16 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
     return (await this.getBooleanDetails(flagKey, defaultValue, context, options)).value;
   }
 
-  getBooleanDetails(
+  getBooleanDetails<T extends boolean = boolean>(
     flagKey: string,
-    defaultValue: boolean,
+    defaultValue: T,
     context?: EvaluationContext,
     options?: FlagEvaluationOptions,
-  ): Promise<EvaluationDetails<boolean>> {
-    return this.evaluate<boolean>(
+  ): Promise<EvaluationDetails<T>> {
+    return this.evaluate<T>(
       flagKey,
-      this._provider.resolveBooleanEvaluation,
+      // this isolates providers from our restricted boolean generic argument.
+      this._provider.resolveBooleanEvaluation as () => Promise<EvaluationDetails<T>>,
       defaultValue,
       'boolean',
       context,

--- a/packages/server/src/evaluation/evaluation.ts
+++ b/packages/server/src/evaluation/evaluation.ts
@@ -10,6 +10,7 @@ export interface Features {
   /**
    * Performs a flag evaluation that returns a boolean.
    * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @template {boolean} T A optional generic argument constraining the boolean
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
@@ -22,9 +23,17 @@ export interface Features {
     options?: FlagEvaluationOptions,
   ): Promise<boolean>;
 
+  getBooleanValue<T extends boolean = boolean>(
+    flagKey: string,
+    defaultValue: T,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions,
+  ): Promise<T>;
+
   /**
    * Performs a flag evaluation that a returns an evaluation details object.
    * @param {string} flagKey The flag key uniquely identifies a particular flag
+   * @template {boolean} T A optional generic argument constraining the boolean
    * @param {boolean} defaultValue The value returned if an error occurs
    * @param {EvaluationContext} context The evaluation context used on an individual flag evaluation
    * @param {FlagEvaluationOptions} options Additional flag evaluation options
@@ -36,6 +45,13 @@ export interface Features {
     context?: EvaluationContext,
     options?: FlagEvaluationOptions,
   ): Promise<EvaluationDetails<boolean>>;
+
+  getBooleanDetails<T extends boolean = boolean>(
+    flagKey: string,
+    defaultValue: T,
+    context?: EvaluationContext,
+    options?: FlagEvaluationOptions,
+  ): Promise<EvaluationDetails<T>>;
 
   /**
    * Performs a flag evaluation that returns a string.

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -181,13 +181,26 @@ describe('OpenFeatureClient', () => {
 
     describe('flag evaluation', () => {
       describe('getBooleanValue', () => {
-        it('should return boolean, and call boolean resolver', async () => {
-          const booleanFlag = 'my-boolean-flag';
-          const defaultBooleanValue = false;
-          const value = await client.getBooleanValue(booleanFlag, defaultBooleanValue);
+        describe('with no generic arg (as boolean)', () => {
+          it('should return boolean, and call boolean resolver', async () => {
+            const booleanFlag = 'my-boolean-flag';
+            const defaultBooleanValue = false;
+            const value = await client.getBooleanValue(booleanFlag, defaultBooleanValue);
+  
+            expect(value).toEqual(BOOLEAN_VALUE);
+            expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+          });
+        });
 
-          expect(value).toEqual(BOOLEAN_VALUE);
-          expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+        describe('with generic arg', () => {
+          it('should return T, and call boolean resolver', async () => {
+            const booleanFlag = 'my-boolean-flag';
+            const defaultBooleanValue = true;
+            const value = await client.getBooleanValue<true>(booleanFlag, defaultBooleanValue);
+  
+            expect(value).toEqual(BOOLEAN_VALUE);
+            expect(MOCK_PROVIDER.resolveBooleanEvaluation).toHaveBeenCalledWith(booleanFlag, defaultBooleanValue, {}, {});
+          });
         });
       });
 


### PR DESCRIPTION
Support constraining boolean evaluations. This probably seems weird, but it helps avoid a bunch of ugly and dangerous type assertions with some upcoming react SDK features, and it can't hurt anything.

Fully backwards compatible, new tests added.

We CAN avoid this if we want, but it makes things consistent and again, avoids some risky type assertions going forward.