### PR TITLE
feat: query-style, generic useFlag hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13721,7 +13721,7 @@
         "@openfeature/web-sdk": "*"
       },
       "peerDependencies": {
-        "@openfeature/web-sdk": ">=1.0.0",
+        "@openfeature/web-sdk": ">=1.1.0",
         "react": ">=16.8.0"
       }
     },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -126,11 +126,11 @@ function App() {
 
 function Page() {
   // Use the "query-style" flag evaluation hook.
-  const { value: newMessage } = useFlag('new-message', true);
+  const { value: newMessageFlagValue } = useFlag('new-message', true);
   return (
     <div className="App">
       <header className="App-header">
-        {newMessage ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
+        {newMessageFlagValue ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
       </header>
     </div>
   )
@@ -191,7 +191,7 @@ You can disable this feature in the hook options:
 
 ```tsx
 function Page() {
-  const newMessage = useBooleanFlagValue('new-message', false, { updateOnContextChanged: false });
+  const newMessageFlagValue = useBooleanFlagValue('new-message', false, { updateOnContextChanged: false });
   return (
     <MyComponents></MyComponents>
   )
@@ -208,7 +208,7 @@ You can disable this feature in the hook options:
 
 ```tsx
 function Page() {
-  const newMessage = useBooleanFlagValue('new-message', false, { updateOnConfigurationChanged: false });
+  const newMessageFlagValue = useBooleanFlagValue('new-message', false, { updateOnConfigurationChanged: false });
   return (
     <MyComponents></MyComponents>
   )
@@ -235,11 +235,11 @@ function Content() {
 
 function Message() {
   // component to render after READY.
-  const newMessage = useBooleanFlagValue('new-message', false);
+  const newMessageFlagValue = useBooleanFlagValue('new-message', false);
 
   return (
     <>
-      {newMessage ? (
+      {newMessageFlagValue ? (
         <p>Welcome to this OpenFeature-enabled React app!</p>
       ) : (
         <p>Welcome to this plain old React app!</p>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -138,7 +138,7 @@ function Page() {
 
 export default App;
 ```
-You use the strongly-typed flag value and flag evaluation details hooks as well, if you prefer.
+You can use the strongly-typed flag value and flag evaluation detail hooks as well, if you prefer.
 
 ```tsx
 import { useBooleanFlagValue } from '@openfeature/react-sdk';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -87,10 +87,12 @@ The following list contains the peer dependencies of `@openfeature/react-sdk` wi
 
 ### Usage
 
+The `OpenFeatureProvider` represents a scope for feature flag evaluations within a react application.
+It binds an OpenFeature client to all evaluations within child components, and allows the use of evaluation hooks.
 The example below shows how to use the `OpenFeatureProvider` with OpenFeature's `InMemoryProvider`.
 
 ```tsx
-import { EvaluationContext, OpenFeatureProvider, useBooleanFlagValue, useBooleanFlagDetails, OpenFeature, InMemoryProvider } from '@openfeature/react-sdk';
+import { EvaluationContext, OpenFeatureProvider, useFlag, OpenFeature, InMemoryProvider } from '@openfeature/react-sdk';
 
 const flagConfig = {
   'new-message': {
@@ -109,8 +111,11 @@ const flagConfig = {
   },
 };
 
+// Instantiate and set our provider (be sure this only happens once)!
+// Note: there's no need to await it's initialization, the React SDK handles re-rendering and suspense for you!
 OpenFeature.setProvider(new InMemoryProvider(flagConfig));
 
+// Enclose your content in the configured provider
 function App() {
   return (
     <OpenFeatureProvider>
@@ -120,7 +125,8 @@ function App() {
 }
 
 function Page() {
-  const newMessage = useBooleanFlagValue('new-message', false);
+  // Use the "query-style" flag evaluation hook.
+  const { value: newMessage } = useFlag('new-message', true);
   return (
     <div className="App">
       <header className="App-header">
@@ -132,12 +138,19 @@ function Page() {
 
 export default App;
 ```
+You use the strongly-typed flag value and flag evaluation details hooks as well, if you prefer.
 
-You use the detailed flag evaluation hooks to evaluate the flag and get additional information about the flag and the evaluation.
+```tsx
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
+
+// boolean flag evaluation
+const value = useBooleanFlagValue('new-message', false);
+```
 
 ```tsx
 import { useBooleanFlagDetails } from '@openfeature/react-sdk';
 
+// "detailed" boolean flag evaluation
 const {
   value,
   variant,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -87,7 +87,7 @@ The following list contains the peer dependencies of `@openfeature/react-sdk` wi
 
 ### Usage
 
-The `OpenFeatureProvider` represents a scope for feature flag evaluations within a react application.
+The `OpenFeatureProvider` represents a scope for feature flag evaluations within a React application.
 It binds an OpenFeature client to all evaluations within child components, and allows the use of evaluation hooks.
 The example below shows how to use the `OpenFeatureProvider` with OpenFeature's `InMemoryProvider`.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -112,7 +112,7 @@ const flagConfig = {
 };
 
 // Instantiate and set our provider (be sure this only happens once)!
-// Note: there's no need to await it's initialization, the React SDK handles re-rendering and suspense for you!
+// Note: there's no need to await its initialization, the React SDK handles re-rendering and suspense for you!
 OpenFeature.setProvider(new InMemoryProvider(flagConfig));
 
 // Enclose your content in the configured provider
@@ -126,11 +126,11 @@ function App() {
 
 function Page() {
   // Use the "query-style" flag evaluation hook.
-  const { value: newMessageFlagValue } = useFlag('new-message', true);
+  const { value: showNewMessage } = useFlag('new-message', true);
   return (
     <div className="App">
       <header className="App-header">
-        {newMessageFlagValue ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
+        {showNewMessage ? <p>Welcome to this OpenFeature-enabled React app!</p> : <p>Welcome to this React app.</p>}
       </header>
     </div>
   )
@@ -191,7 +191,7 @@ You can disable this feature in the hook options:
 
 ```tsx
 function Page() {
-  const newMessageFlagValue = useBooleanFlagValue('new-message', false, { updateOnContextChanged: false });
+  const showNewMessage = useBooleanFlagValue('new-message', false, { updateOnContextChanged: false });
   return (
     <MyComponents></MyComponents>
   )
@@ -208,7 +208,7 @@ You can disable this feature in the hook options:
 
 ```tsx
 function Page() {
-  const newMessageFlagValue = useBooleanFlagValue('new-message', false, { updateOnConfigurationChanged: false });
+  const showNewMessage = useBooleanFlagValue('new-message', false, { updateOnConfigurationChanged: false });
   return (
     <MyComponents></MyComponents>
   )
@@ -235,11 +235,11 @@ function Content() {
 
 function Message() {
   // component to render after READY.
-  const newMessageFlagValue = useBooleanFlagValue('new-message', false);
+  const showNewMessage = useBooleanFlagValue('new-message', false);
 
   return (
     <>
-      {newMessageFlagValue ? (
+      {showNewMessage ? (
         <p>Welcome to this OpenFeature-enabled React app!</p>
       ) : (
         <p>Welcome to this plain old React app!</p>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": ">=1.1.0",
+    "@openfeature/web-sdk": "^1.0.2",
     "react": ">=16.8.0"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": ">=1.0.0",
+    "@openfeature/web-sdk": ">=1.1.0",
     "react": ">=16.8.0"
   },
   "devDependencies": {

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -54,9 +54,9 @@ enum SuspendState {
   Error,
 }
 
-// just used for casting, etc, but don't use for return values because the name isn't as clear
-//
-// This type is a bit wild-looking, but I think we need it. We have to use the conditional, because otherwise useFlag('key', false) would return false, not boolean (too constrained).
+// This type is a bit wild-looking, but I think we need it.
+// We have to use the conditional, because otherwise useFlag('key', false) would return false, not boolean (too constrained).
+// We have a duplicate for the hook return below, this one is just used for casting because the name isn't as clear
 type ConstrainedFlagQuery<T> = FlagQuery<
   T extends boolean
     ? boolean

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -70,6 +70,7 @@ type ConstrainedFlagQuery<T> = FlagQuery<
 /**
  * Evaluates a feature flag generically, returning an react-flavored queryable object.
  * The resolver method to use is based on the type of the defaultValue.
+ * For type-specific hooks, use {@link useBooleanFlagValue}, {@link useBooleanFlagDetails} and equivalents.
  * By default, components will re-render when the flag value changes.
  * @param {string} flagKey the flag identifier
  * @template {FlagValue} T A optional generic argument constraining the default.
@@ -108,6 +109,7 @@ T extends boolean
 /**
  * Evaluates a feature flag, returning a boolean.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @param {boolean} defaultValue the default value
  * @param {ReactFlagEvaluationOptions} options options for this evaluation
@@ -124,6 +126,7 @@ export function useBooleanFlagValue(
 /**
  * Evaluates a feature flag, returning evaluation details.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @param {boolean} defaultValue the default value
  * @param {ReactFlagEvaluationOptions} options options for this evaluation
@@ -147,6 +150,7 @@ export function useBooleanFlagDetails(
 /**
  * Evaluates a feature flag, returning a string.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @template {string} [T=string] A optional generic argument constraining the string
  * @param {T} defaultValue the default value
@@ -164,6 +168,7 @@ export function useStringFlagValue<T extends string = string>(
 /**
  * Evaluates a feature flag, returning evaluation details.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @template {string} [T=string] A optional generic argument constraining the string
  * @param {T} defaultValue the default value
@@ -188,6 +193,7 @@ export function useStringFlagDetails<T extends string = string>(
 /**
  * Evaluates a feature flag, returning a number.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @template {number} [T=number] A optional generic argument constraining the number
  * @param {T} defaultValue the default value
@@ -205,6 +211,7 @@ export function useNumberFlagValue<T extends number = number>(
 /**
  * Evaluates a feature flag, returning evaluation details.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @template {number} [T=number] A optional generic argument constraining the number
  * @param {T} defaultValue the default value
@@ -229,6 +236,7 @@ export function useNumberFlagDetails<T extends number = number>(
 /**
  * Evaluates a feature flag, returning an object.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @template {JsonValue} [T=JsonValue] A optional generic argument describing the structure
  * @param {T} defaultValue the default value
@@ -246,6 +254,7 @@ export function useObjectFlagValue<T extends JsonValue = JsonValue>(
 /**
  * Evaluates a feature flag, returning evaluation details.
  * By default, components will re-render when the flag value changes.
+ * For a generic hook returning a queryable interface, see {@link useFlag}.
  * @param {string} flagKey the flag identifier
  * @param {T} defaultValue the default value
  * @template {JsonValue} [T=JsonValue] A optional generic argument describing the structure

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -429,7 +429,7 @@ class HookFlagQuery<T extends FlagValue = FlagValue> implements FlagQuery {
   get isAuthoritative() {
     return (
       !this.isError &&
-      this._details.reason != StandardResolutionReasons.CACHED &&
+      this._details.reason != StandardResolutionReasons.STALE &&
       this._details.reason != StandardResolutionReasons.DISABLED
     );
   }

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -77,7 +77,7 @@ type ConstrainedFlagQuery<T> = FlagQuery<
  * @param {string} flagKey the flag identifier
  * @template {FlagValue} T A optional generic argument constraining the default.
  * @param {T} defaultValue the default value; used to determine what resolved type should be used.
- * @param {ReactFlagEvaluationOptions} options options for this evaluation
+ * @param {ReactFlagEvaluationOptions} options for this evaluation
  * @returns { FlagQuery } a queryable object containing useful information about the flag.
  */
 export function useFlag<T extends FlagValue = FlagValue>(

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -6,9 +6,11 @@ import {
   JsonValue,
   ProviderEvents,
   ProviderStatus,
+  StandardResolutionReasons,
 } from '@openfeature/web-sdk';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useOpenFeatureClient } from '../provider';
+import { FlagQuery } from '../query';
 
 type ReactFlagEvaluationOptions = {
   /**
@@ -50,6 +52,57 @@ enum SuspendState {
   Pending,
   Success,
   Error,
+}
+
+// just used for casting, etc, but don't use for return values because the name isn't as clear
+type ConstrainedFlagQuery<T> = FlagQuery<
+  T extends boolean
+    ? boolean
+    : T extends number
+      ? number
+      : T extends string
+        ? string
+        : T extends JsonValue
+          ? T
+          : JsonValue
+>;
+
+/**
+ * Evaluates a feature flag generically, returning an react-flavored queryable object.
+ * The resolver method to use is based on the type of the defaultValue.
+ * By default, components will re-render when the flag value changes.
+ * @param {string} flagKey the flag identifier
+ * @template {FlagValue} T A optional generic argument constraining the default.
+ * @param {T} defaultValue the default value; used to determine what resolved type should be used.
+ * @param {ReactFlagEvaluationOptions} options options for this evaluation
+ * @returns { FlagQuery } a queryable object containing useful information about the flag.
+ */
+export function useFlag<T extends FlagValue = FlagValue>(
+  flagKey: string,
+  defaultValue: T,
+  options?: ReactFlagEvaluationOptions,
+): FlagQuery<
+T extends boolean
+  ? boolean
+  : T extends number
+    ? number
+    : T extends string
+      ? string
+      : T extends JsonValue
+        ? T
+        : JsonValue
+> {
+  // use the default value to determine the resolver to call
+  const query =
+    typeof defaultValue === 'boolean'
+      ? new HookFlagQuery<boolean>(useBooleanFlagDetails(flagKey, defaultValue, options))
+      : typeof defaultValue === 'number'
+        ? new HookFlagQuery<number>(useNumberFlagDetails(flagKey, defaultValue, options))
+        : typeof defaultValue === 'string'
+          ? new HookFlagQuery<string>(useStringFlagDetails(flagKey, defaultValue, options))
+          : new HookFlagQuery<JsonValue>(useObjectFlagDetails(flagKey, defaultValue, options));
+  // TS sees this as HookFlagQuery<JsonValue>, because the compiler isn't aware of the `typeof` checks above.
+  return query as unknown as ConstrainedFlagQuery<T>;
 }
 
 /**
@@ -104,7 +157,7 @@ export function useStringFlagValue<T extends string = string>(
   flagKey: string,
   defaultValue: T,
   options?: ReactFlagEvaluationOptions,
-): T {
+): string {
   return useStringFlagDetails(flagKey, defaultValue, options).value;
 }
 
@@ -121,7 +174,7 @@ export function useStringFlagDetails<T extends string = string>(
   flagKey: string,
   defaultValue: T,
   options?: ReactFlagEvaluationOptions,
-): EvaluationDetails<T> {
+): EvaluationDetails<string> {
   return attachHandlersAndResolve(
     flagKey,
     defaultValue,
@@ -145,7 +198,7 @@ export function useNumberFlagValue<T extends number = number>(
   flagKey: string,
   defaultValue: T,
   options?: ReactFlagEvaluationOptions,
-): T {
+): number {
   return useNumberFlagDetails(flagKey, defaultValue, options).value;
 }
 
@@ -162,7 +215,7 @@ export function useNumberFlagDetails<T extends number = number>(
   flagKey: string,
   defaultValue: T,
   options?: ReactFlagEvaluationOptions,
-): EvaluationDetails<T> {
+): EvaluationDetails<number> {
   return attachHandlersAndResolve(
     flagKey,
     defaultValue,
@@ -335,4 +388,53 @@ function suspenseWrapper<T>(promise: Promise<T>) {
         throw new Error('Suspending promise is in an unknown state.');
     }
   };
+}
+
+// FlagQuery implementation, do not export
+class HookFlagQuery<T extends FlagValue = FlagValue> implements FlagQuery {
+  constructor(private _details: EvaluationDetails<T>) {}
+
+  get details() {
+    return this._details;
+  }
+
+  get value() {
+    return this._details?.value;
+  }
+
+  get variant() {
+    return this._details.variant;
+  }
+
+  get flagMetadata() {
+    return this._details.flagMetadata;
+  }
+
+  get reason() {
+    return this._details.reason;
+  }
+
+  get isError() {
+    return !!this._details?.errorCode || this._details.reason == StandardResolutionReasons.ERROR;
+  }
+
+  get errorCode() {
+    return this._details?.errorCode;
+  }
+
+  get errorMessage() {
+    return this._details?.errorMessage;
+  }
+
+  get isAuthoritative() {
+    return (
+      !this.isError &&
+      this._details.reason != StandardResolutionReasons.CACHED &&
+      this._details.reason != StandardResolutionReasons.DISABLED
+    );
+  }
+
+  get type() {
+    return typeof this._details.value;
+  }
 }

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -55,6 +55,8 @@ enum SuspendState {
 }
 
 // just used for casting, etc, but don't use for return values because the name isn't as clear
+//
+// This type is a bit wild-looking, but I think we need it. We have to use the conditional, because otherwise useFlag('key', false) would return false, not boolean (too constrained).
 type ConstrainedFlagQuery<T> = FlagQuery<
   T extends boolean
     ? boolean

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export * from './evaluation';
+export * from './query';
 export * from './provider';
 // re-export the web-sdk so consumers can access that API from the react-sdk
 export * from '@openfeature/web-sdk';

--- a/packages/react/src/query/index.ts
+++ b/packages/react/src/query/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/packages/react/src/query/query.ts
+++ b/packages/react/src/query/query.ts
@@ -47,7 +47,7 @@ export interface FlagQuery<T extends FlagValue = FlagValue> {
 
   /**
    * Indicates this flag is up-to-date and in sync with the source of truth.
-   * Specifically, indicates the evaluation did not default due to error, and the reason is neither {@link StandardResolutionReasons.CACHED} or {@link StandardResolutionReasons.DISABLED}.
+   * Specifically, indicates the evaluation did not default due to error, and the reason is neither {@link StandardResolutionReasons.STALE} or {@link StandardResolutionReasons.DISABLED}.
    */
   readonly isAuthoritative: boolean;
 

--- a/packages/react/src/query/query.ts
+++ b/packages/react/src/query/query.ts
@@ -1,0 +1,58 @@
+import { ErrorCode, EvaluationDetails, FlagMetadata, FlagValue, StandardResolutionReasons } from '@openfeature/core';
+
+export interface FlagQuery<T extends FlagValue = FlagValue> {
+  /**
+   * A structure representing the result of the flag evaluation process
+   */
+  readonly details: EvaluationDetails<T>;
+
+  /**
+   * The flag value
+   */
+  readonly value: T;
+
+  /**
+   * A variant is a semantic identifier for a value.
+   * Not available from all providers.
+   */
+  readonly variant: string | undefined;
+
+  /**
+   * Arbitrary data associated with this flag or evaluation.
+   * Not available from all providers.
+   */
+  readonly flagMetadata: FlagMetadata;
+
+  /**
+   * The reason the evaluation resolved to the particular value.
+   * Not available from all providers.
+   */
+  readonly reason: typeof StandardResolutionReasons | string | undefined;
+
+  /**
+   * Indicates if this flag defaulted due to an error.
+   * Specifically, indicates reason equals {@link StandardResolutionReasons.ERROR} or the errorCode is set, this field is truthy.
+   */
+  readonly isError: boolean;
+
+  /**
+   * The error code, see {@link ErrorCode}.
+   */
+  readonly errorCode: ErrorCode | undefined;
+
+  /**
+   * A message associated with the error.
+   */
+  readonly errorMessage: string | undefined;
+
+  /**
+   * Indicates this flag is up-to-date and in sync with the source of truth.
+   * Specifically, indicates the evaluation did not default due to error, and the reason is neither {@link StandardResolutionReasons.CACHED} or {@link StandardResolutionReasons.DISABLED}.
+   */
+  readonly isAuthoritative: boolean;
+
+  /**
+   * The type of the value, as returned by "typeof" operator.
+   */
+  readonly type: 'string' | 'number' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'object' | 'function';
+}


### PR DESCRIPTION
This PR adds a new `useFlag` hook. This hook:

- returns an object supporting a react "query-style" API with relevant properties: `const { value: newMessage, isError, reason, errorCode, isAuthoritative, type } = useFlag('new-message', true);`
- supports ergonomic generics: 
```
const { value: boolVal }: FlagQuery<boolean> = useFlag('bool-flag', true);
const { value: stringVal }: FlagQuery<string> = useFlag('string-flag', 'string');
const { value: objVal }: FlagQuery<{greeting: string}> = useFlag('obj-flag', { greeting: 'hi' });
```
- supports all the same options and features as other hooks (suspense, etc)

This PR fixes some type bugs as well, and adds to the readme.

DEPENDS ON: https://github.com/open-feature/js-sdk/pull/898