### PR TITLE
fix: default options (re-renders not firing by default)

### DIFF
--- a/packages/react/src/common/options.ts
+++ b/packages/react/src/common/options.ts
@@ -64,14 +64,19 @@ export const DEFAULT_OPTIONS: ReactFlagEvaluationOptions = {
  */
 export const normalizeOptions: (options?: ReactFlagEvaluationOptions) => NormalizedOptions = (options?: ReactFlagEvaluationOptions) => {
   const defaultOptionsIfMissing = !options ? {} : options;
-  // fall-back the suspense options
+
+  const updateOnContextChanged = defaultOptionsIfMissing.suspendWhileReconciling;
+  const updateOnConfigurationChanged = defaultOptionsIfMissing.updateOnConfigurationChanged;
+
+  // fall-back the suspense options to the catch-all `suspend` property 
   const suspendUntilReady = 'suspendUntilReady' in defaultOptionsIfMissing ? defaultOptionsIfMissing.suspendUntilReady : defaultOptionsIfMissing.suspend;
   const suspendWhileReconciling = 'suspendWhileReconciling' in defaultOptionsIfMissing ? defaultOptionsIfMissing.suspendWhileReconciling : defaultOptionsIfMissing.suspend;
+
   return {
-    updateOnContextChanged: defaultOptionsIfMissing.updateOnContextChanged,
-    updateOnConfigurationChanged: defaultOptionsIfMissing.updateOnConfigurationChanged,
     // only return these if properly set (no undefined to allow overriding with spread)
     ...(typeof suspendUntilReady === 'boolean' && {suspendUntilReady}),
     ...(typeof suspendWhileReconciling === 'boolean' && {suspendWhileReconciling}),
+    ...(typeof updateOnContextChanged === 'boolean' && {updateOnContextChanged}),
+    ...(typeof updateOnConfigurationChanged === 'boolean' && {updateOnConfigurationChanged}),
   };
 };

--- a/packages/react/src/common/options.ts
+++ b/packages/react/src/common/options.ts
@@ -62,15 +62,13 @@ export const DEFAULT_OPTIONS: ReactFlagEvaluationOptions = {
  * @param {ReactFlagEvaluationOptions} options  options to normalize
  * @returns {NormalizedOptions} normalized options
  */
-export const normalizeOptions: (options?: ReactFlagEvaluationOptions) => NormalizedOptions = (options?: ReactFlagEvaluationOptions) => {
-  const defaultOptionsIfMissing = !options ? {} : options;
-
-  const updateOnContextChanged = defaultOptionsIfMissing.suspendWhileReconciling;
-  const updateOnConfigurationChanged = defaultOptionsIfMissing.updateOnConfigurationChanged;
+export const normalizeOptions: (options?: ReactFlagEvaluationOptions) => NormalizedOptions = (options: ReactFlagEvaluationOptions = {}) => {
+  const updateOnContextChanged = options.updateOnContextChanged;
+  const updateOnConfigurationChanged = options.updateOnConfigurationChanged;
 
   // fall-back the suspense options to the catch-all `suspend` property 
-  const suspendUntilReady = 'suspendUntilReady' in defaultOptionsIfMissing ? defaultOptionsIfMissing.suspendUntilReady : defaultOptionsIfMissing.suspend;
-  const suspendWhileReconciling = 'suspendWhileReconciling' in defaultOptionsIfMissing ? defaultOptionsIfMissing.suspendWhileReconciling : defaultOptionsIfMissing.suspend;
+  const suspendUntilReady = 'suspendUntilReady' in options ? options.suspendUntilReady : options.suspend;
+  const suspendWhileReconciling = 'suspendWhileReconciling' in options ? options.suspendWhileReconciling : options.suspend;
 
   return {
     // only return these if properly set (no undefined to allow overriding with spread)


### PR DESCRIPTION
When I was adding the general `suspend` option as @lukas-reining suggested (a way to enable/disable all suspense features) I broke the default options. I found this writing tests in a different branch.

Tests for the entire SDK including this are incoming shortly (today), but this is a fix for the issue.