### PR TITLE
chore: remove pre-release, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This repository contains both the server-side JS and web-browser SDKs.
 For details, including API documentation, see the respective README files.
 
 - [Server SDK](./packages/server/README.md), for use in Node.js and similar runtimes.
+  - [NestJS SDK](./packages/nest/README.md), a distribution of the Server SDK with built-in NestJS-specific features.
 - [Client SDK](./packages/client/README.md), for use in the web browser.
+  - [React SDK](./packages/react//README.md), a distribution of the Client SDK with built-in React-specific features.
 
 Each have slightly different APIs, but share many underlying types and components.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,8 +12,8 @@
 <!-- x-hide-in-docs-end -->
 <!-- The 'github-badges' class is used in the docs -->
 <p align="center" class="github-badges">
-  <a href="https://github.com/open-feature/spec/releases/tag/v0.7.0">
-    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.7.0&color=yellow&style=for-the-badge" />
+  <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.8.0&color=yellow&style=for-the-badge" />
   </a>
   <!-- x-release-please-start-version -->
   <a href="https://github.com/open-feature/js-sdk/releases/tag/react-sdk-v0.3.2-experimental">

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -34,8 +34,6 @@
 
 <!-- x-hide-in-docs-end -->
 
-🧪 This SDK is experimental.
-
 ## Overview
 
 The OpenFeature React SDK adds React-specific functionality to the [OpenFeature Web SDK](https://openfeature.dev/docs/reference/technologies/client/web).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -295,6 +295,12 @@ To scope an OpenFeatureProvider to a particular provider/context set the `domain
 </OpenFeatureProvider>
 ```
 
+> I can import things form the `@openfeature/react-sdk`, `@openfeature/web-sdk`, and `@openfeature/core`; which should I use?
+
+The `@openfeature/react-sdk` re-exports everything from its peers (`@openfeature/web-sdk` and `@openfeature/core`), and adds the React-specific features.
+You can import everything from the `@openfeature/react-sdk` directly.
+Avoid importing anything from `@openfeature/web-sdk` or `@openfeature/core`.
+
 ## Resources
 
  - [Example repo](https://github.com/open-feature/react-test-app)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,10 +83,11 @@ yarn add @openfeature/react-sdk @openfeature/web-sdk @openfeature/core
 
 #### Required peer dependencies
 
-The following list contains the peer dependencies of `@openfeature/react-sdk` with its expected and compatible versions:
+The following list contains the peer dependencies of `@openfeature/react-sdk`.
+See the [package.json](./package.json) for the required versions.
 
-* `@openfeature/web-sdk`: >=1.0.0
-* `react`: >=16.8.0
+* `@openfeature/web-sdk`
+* `react`
 
 ### Usage
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,9 @@
       "versioning": "default"
     },
     "packages/react": {
+      "release-as": "0.3.2",
       "release-type": "node",
-      "prerelease": true,
+      "prerelease": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["README.md"],


### PR DESCRIPTION
- prompts a release of a non-experimental react-sdk
- updates README to point to React and NestJS SDKs
- removes version of peer deps from README (too brittle, point users to `package.json`)
- adds an FAQ question