### PR TITLE
fix: delayed suspense causes "flicker"

### DIFF
--- a/packages/react/src/common/suspend.ts
+++ b/packages/react/src/common/suspend.ts
@@ -1,75 +1,20 @@
 import { Client, ProviderEvents } from '@openfeature/web-sdk';
-import { Dispatch, SetStateAction } from 'react';
-
-enum SuspendState {
-  Pending,
-  Success,
-  Error,
-}
 
 /**
- * Suspend function. If this runs, components using the calling hook will be suspended.
- * DO NOT EXPORT PUBLICLY 
- * @internal
- * @param {Client} client the OpenFeature client
- * @param {Function} updateState the state update function
- * @param {ProviderEvents[]} resumeEvents list of events which will resume the suspend
- */
-export function suspend(
-  client: Client,
-  updateState: Dispatch<SetStateAction<object | undefined>>,
-  ...resumeEvents: ProviderEvents[]
-) {
-  let suspendResolver: () => void;
-
-  const suspendPromise = new Promise<void>((resolve) => {
-    suspendResolver = () => {
-      resolve();
-      resumeEvents.forEach((e) => {
-        client.removeHandler(e, suspendResolver); // remove handlers once they've run
-      });
-      client.removeHandler(ProviderEvents.Error, suspendResolver);
-    };
-    resumeEvents.forEach((e) => {
-      client.addHandler(e, suspendResolver);
-    });
-    client.addHandler(ProviderEvents.Error, suspendResolver); // we never want to throw, resolve with errors - we may make this configurable later
-  });
-  updateState(suspenseWrapper(suspendPromise));
-}
-
-/**
- * Promise wrapper that throws unresolved promises to support React suspense.
+ * Suspends until the client is ready to evaluate feature flags.
  * DO NOT EXPORT PUBLICLY
- * @internal
- * @param {Promise<T>} promise to wrap
- * @template T flag type
- * @returns {Function} suspense-compliant lambda
+ * @param client
  */
-export function suspenseWrapper<T>(promise: Promise<T>) {
-  let status: SuspendState = SuspendState.Pending;
-  let result: T;
-
-  const suspended = promise
-    .then((value) => {
-      status = SuspendState.Success;
-      result = value;
-    })
-    .catch((error) => {
-      status = SuspendState.Error;
-      result = error;
-    });
-
-  return () => {
-    switch (status) {
-      case SuspendState.Pending:
-        throw suspended;
-      case SuspendState.Success:
-        return result;
-      case SuspendState.Error:
-        throw result;
-      default:
-        throw new Error('Suspending promise is in an unknown state.');
-    }
-  };
+export function suspendUntilReady(client: Client): Promise<void> {
+  let resolve: (value: unknown) => void;
+  let reject: () => void;
+  throw new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+    client.addHandler(ProviderEvents.Ready, resolve);
+    client.addHandler(ProviderEvents.Error, reject);
+  }).finally(() => {
+    client.removeHandler(ProviderEvents.Ready, resolve);
+    client.removeHandler(ProviderEvents.Ready, reject);
+  });
 }

--- a/packages/react/src/common/suspense.ts
+++ b/packages/react/src/common/suspense.ts
@@ -3,7 +3,7 @@ import { Client, ProviderEvents } from '@openfeature/web-sdk';
 /**
  * Suspends until the client is ready to evaluate feature flags.
  * DO NOT EXPORT PUBLICLY
- * @param client
+ * @param {Client} client OpenFeature client
  */
 export function suspendUntilReady(client: Client): Promise<void> {
   let resolve: (value: unknown) => void;

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -10,7 +10,7 @@ import {
 } from '@openfeature/web-sdk';
 import { useEffect, useState } from 'react';
 import { DEFAULT_OPTIONS, ReactFlagEvaluationOptions, normalizeOptions } from '../common/options';
-import { suspendUntilReady } from '../common/suspend';
+import { suspendUntilReady } from '../common/suspense';
 import { useProviderOptions } from '../provider/context';
 import { useOpenFeatureClient } from '../provider/use-open-feature-client';
 import { useOpenFeatureClientStatus } from '../provider/use-open-feature-client-status';
@@ -247,17 +247,17 @@ function attachHandlersAndResolve<T extends FlagValue>(
   options?: ReactFlagEvaluationOptions,
 ): EvaluationDetails<T> {
   // highest priority > evaluation hook options > provider options > default options > lowest priority
-  const defaultedOptions = { ...DEFAULT_OPTIONS, ...useProviderOptions(), ...normalizeOptions(options)};
+  const defaultedOptions = { ...DEFAULT_OPTIONS, ...useProviderOptions(), ...normalizeOptions(options) };
   const client = useOpenFeatureClient();
   const status = useOpenFeatureClientStatus();
 
   // suspense
   if (defaultedOptions.suspendUntilReady && status === ProviderStatus.NOT_READY) {
-    throw suspendUntilReady(client);
+    suspendUntilReady(client);
   }
 
   if (defaultedOptions.suspendWhileReconciling && status === ProviderStatus.RECONCILING) {
-    throw suspendUntilReady(client);
+    suspendUntilReady(client);
   }
 
   const [evalutationDetails, setEvaluationDetails] = useState<EvaluationDetails<T>>(

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -10,9 +10,10 @@ import {
 } from '@openfeature/web-sdk';
 import { useEffect, useState } from 'react';
 import { DEFAULT_OPTIONS, ReactFlagEvaluationOptions, normalizeOptions } from '../common/options';
-import { suspend } from '../common/suspend';
+import { suspendUntilReady } from '../common/suspend';
 import { useProviderOptions } from '../provider/context';
 import { useOpenFeatureClient } from '../provider/use-open-feature-client';
+import { useOpenFeatureClientStatus } from '../provider/use-open-feature-client-status';
 import { FlagQuery } from '../query';
 
 // This type is a bit wild-looking, but I think we need it.
@@ -247,57 +248,55 @@ function attachHandlersAndResolve<T extends FlagValue>(
 ): EvaluationDetails<T> {
   // highest priority > evaluation hook options > provider options > default options > lowest priority
   const defaultedOptions = { ...DEFAULT_OPTIONS, ...useProviderOptions(), ...normalizeOptions(options)};
-  const [, updateState] = useState<object | undefined>();
   const client = useOpenFeatureClient();
-  const forceUpdate = () => {
-    updateState({});
-  };
-  const suspendRef = () => {
-    suspend(
-      client,
-      updateState,
-      ProviderEvents.ContextChanged,
-      ProviderEvents.ConfigurationChanged,
-      ProviderEvents.Ready,
-    );
+  const status = useOpenFeatureClientStatus();
+
+  // suspense
+  if (defaultedOptions.suspendUntilReady && status === ProviderStatus.NOT_READY) {
+    throw suspendUntilReady(client);
+  }
+
+  if (defaultedOptions.suspendWhileReconciling && status === ProviderStatus.RECONCILING) {
+    throw suspendUntilReady(client);
+  }
+
+  const [evalutationDetails, setEvaluationDetails] = useState<EvaluationDetails<T>>(
+    resolver(client).call(client, flagKey, defaultValue, options),
+  );
+
+  const updateEvaluationDetailsRef = () => {
+    setEvaluationDetails(resolver(client).call(client, flagKey, defaultValue, options));
   };
 
   useEffect(() => {
-    if (client.providerStatus === ProviderStatus.NOT_READY) {
+    if (status === ProviderStatus.NOT_READY) {
       // update when the provider is ready
-      client.addHandler(ProviderEvents.Ready, forceUpdate);
-      if (defaultedOptions.suspendUntilReady) {
-        suspend(client, updateState, ProviderEvents.Ready);
-      }
+      client.addHandler(ProviderEvents.Ready, updateEvaluationDetailsRef);
     }
 
     if (defaultedOptions.updateOnContextChanged) {
       // update when the context changes
-      client.addHandler(ProviderEvents.ContextChanged, forceUpdate);
-      if (defaultedOptions.suspendWhileReconciling) {
-        client.addHandler(ProviderEvents.Reconciling, suspendRef);
-      }
+      client.addHandler(ProviderEvents.ContextChanged, updateEvaluationDetailsRef);
     }
     return () => {
       // cleanup the handlers
-      client.removeHandler(ProviderEvents.Ready, forceUpdate);
-      client.removeHandler(ProviderEvents.ContextChanged, forceUpdate);
-      client.removeHandler(ProviderEvents.Reconciling, suspendRef);
+      client.removeHandler(ProviderEvents.Ready, updateEvaluationDetailsRef);
+      client.removeHandler(ProviderEvents.ContextChanged, updateEvaluationDetailsRef);
     };
   }, []);
 
   useEffect(() => {
     if (defaultedOptions.updateOnConfigurationChanged) {
       // update when the provider configuration changes
-      client.addHandler(ProviderEvents.ConfigurationChanged, forceUpdate);
+      client.addHandler(ProviderEvents.ConfigurationChanged, updateEvaluationDetailsRef);
     }
     return () => {
       // cleanup the handlers
-      client.removeHandler(ProviderEvents.ConfigurationChanged, forceUpdate);
+      client.removeHandler(ProviderEvents.ConfigurationChanged, updateEvaluationDetailsRef);
     };
   }, []);
 
-  return resolver(client).call(client, flagKey, defaultValue, options);
+  return evalutationDetails;
 }
 
 // FlagQuery implementation, do not export

--- a/packages/react/src/provider/use-open-feature-client-status.ts
+++ b/packages/react/src/provider/use-open-feature-client-status.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useOpenFeatureClient } from './use-open-feature-client';
+import { ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+
+/**
+ * Get the {@link ProviderStatus} for the OpenFeatureClient.
+ * @returns {ProviderStatus} status of the client for this scope
+ */
+export function useOpenFeatureClientStatus(): ProviderStatus {
+  const client = useOpenFeatureClient();
+  const [status, setStatus] = useState(client.providerStatus);
+
+  useEffect(() => {
+    const updateStatus = () => setStatus(client.providerStatus);
+    client.addHandler(ProviderEvents.ConfigurationChanged, updateStatus);
+    client.addHandler(ProviderEvents.ContextChanged, updateStatus);
+    client.addHandler(ProviderEvents.Error, updateStatus);
+    client.addHandler(ProviderEvents.Ready, updateStatus);
+    client.addHandler(ProviderEvents.Stale, updateStatus);
+    client.addHandler(ProviderEvents.Reconciling, updateStatus);
+    return () => {
+      client.removeHandler(ProviderEvents.ConfigurationChanged, updateStatus);
+      client.removeHandler(ProviderEvents.ContextChanged, updateStatus);
+      client.removeHandler(ProviderEvents.Error, updateStatus);
+      client.removeHandler(ProviderEvents.Ready, updateStatus);
+      client.removeHandler(ProviderEvents.Stale, updateStatus);
+      client.removeHandler(ProviderEvents.Reconciling, updateStatus);
+    };
+  }, [client]);
+
+  return status;
+}

--- a/packages/react/src/provider/use-when-provider-ready.ts
+++ b/packages/react/src/provider/use-when-provider-ready.ts
@@ -3,7 +3,7 @@ import { DEFAULT_OPTIONS, ReactFlagEvaluationOptions, normalizeOptions } from '.
 import { useProviderOptions } from './context';
 import { useOpenFeatureClient } from './use-open-feature-client';
 import { useOpenFeatureClientStatus } from './use-open-feature-client-status';
-import { suspendUntilReady } from '../common/suspend';
+import { suspendUntilReady } from '../common/suspense';
 
 type Options = Pick<ReactFlagEvaluationOptions, 'suspendUntilReady'>;
 
@@ -22,7 +22,7 @@ export function useWhenProviderReady(options?: Options): boolean {
 
   // suspense
   if (defaultedOptions.suspendUntilReady && status === ProviderStatus.NOT_READY) {
-    throw suspendUntilReady(client);
+    suspendUntilReady(client);
   }
 
   return status === ProviderStatus.READY;

--- a/packages/react/test/evaluation.spec.tsx
+++ b/packages/react/test/evaluation.spec.tsx
@@ -21,6 +21,7 @@ import {
   useStringFlagValue,
 } from '../src/';
 import { TestingProvider } from './test.utils';
+import { startTransition, useState } from 'react';
 
 describe('evaluation', () => {
   const EVALUATION = 'evaluation';
@@ -40,6 +41,7 @@ describe('evaluation', () => {
   const REASON_ATTR = 'data-reason';
   const REASON_ATTR_VALUE = StandardResolutionReasons.STATIC;
   const TYPE_ATTR = 'data-type';
+  const BUTTON_TEXT = 'button';
 
   const makeProvider = () => {
     return new InMemoryProvider({
@@ -331,17 +333,69 @@ describe('evaluation', () => {
       it('should suspend until ready and then render', async () => {
         OpenFeature.setProvider(SUSPENSE_ON, suspendingProvider());
 
+        let renderedDefaultValue = false;
+
+        function Component() {
+          const { value } = useFlag(SUSPENSE_FLAG_KEY, DEFAULT);
+
+          if (value === DEFAULT) {
+            renderedDefaultValue = true;
+          }
+
+          return <div>{value}</div>;
+        }
+
         render(
           <OpenFeatureProvider domain={SUSPENSE_ON}>
             <React.Suspense fallback={<div>{FALLBACK}</div>}>
-              <TestComponent></TestComponent>
+              <Component></Component>
             </React.Suspense>
           </OpenFeatureProvider>,
         );
 
         // should see fallback initially
+        expect(renderedDefaultValue).toBe(false);
         expect(screen.queryByText(STATIC_FLAG_VALUE_A)).toBeNull();
         expect(screen.queryByText(FALLBACK)).toBeInTheDocument();
+        // eventually we should see the value
+        await waitFor(() => expect(screen.queryByText(STATIC_FLAG_VALUE_A)).toBeInTheDocument(), {
+          timeout: DELAY * 2,
+        });
+      });
+
+      it('should show the previous UI during a transition', async () => {
+        OpenFeature.setProvider(SUSPENSE_ON, suspendingProvider());
+
+        function ParentComponent() {
+          const [show, setShow] = useState(false);
+
+          if (show) {
+            return <TestComponent></TestComponent>;
+          } else {
+            return <button onClick={() => startTransition(() => setShow(true))}>{BUTTON_TEXT}</button>;
+          }
+        }
+
+        render(
+          <OpenFeatureProvider domain={SUSPENSE_ON}>
+            <React.Suspense fallback={<div>{FALLBACK}</div>}>
+              <ParentComponent></ParentComponent>
+            </React.Suspense>
+          </OpenFeatureProvider>,
+        );
+
+        // should see button initially
+        const button = screen.getByText(BUTTON_TEXT);
+        expect(button).toBeInTheDocument();
+
+        // click the button
+        act(() => {
+          button.click();
+        });
+
+        // because this is a transition update, we still see the button
+        expect(button).toBeInTheDocument();
+
         // eventually we should see the value
         await waitFor(() => expect(screen.queryByText(STATIC_FLAG_VALUE_A)).toBeInTheDocument(), {
           timeout: DELAY * 2,
@@ -354,11 +408,23 @@ describe('evaluation', () => {
         await OpenFeature.setContext(SUSPENSE_OFF, {});
         OpenFeature.setProvider(SUSPENSE_ON, suspendingProvider());
 
+        let renderedDefaultValue;
+
+        function Component() {
+          const { value } = useFlag(SUSPENSE_FLAG_KEY, DEFAULT);
+
+          if (value === DEFAULT) {
+            renderedDefaultValue = true;
+          }
+
+          return <div>{value}</div>;
+        }
+
         render(
           // disable suspendUntilReady, we are only testing reconcile suspense.
           <OpenFeatureProvider domain={SUSPENSE_ON} suspendUntilReady={false}>
             <React.Suspense fallback={<div>{FALLBACK}</div>}>
-              <TestComponent></TestComponent>
+              <Component></Component>
             </React.Suspense>
           </OpenFeatureProvider>,
         );
@@ -366,10 +432,16 @@ describe('evaluation', () => {
         // initially should be default, because suspendUntilReady={false}
         expect(screen.queryByText(DEFAULT)).toBeInTheDocument();
 
+        // after the initial render, we should never see the default value anymore, because suspendWhileReconciling={true}
+        renderedDefaultValue = false;
+
         // update the context without awaiting
         act(() => {
           OpenFeature.setContext(SUSPENSE_ON, { user: TARGETED_USER });
         });
+
+        // the default value should not be rendered again, since we are suspending while reconciling
+        expect(renderedDefaultValue).toBe(false);
 
         // expect to see fallback while we are reconciling
         await waitFor(() => expect(screen.queryByText(FALLBACK)).toBeInTheDocument(), { timeout: DELAY / 2 });
@@ -378,6 +450,38 @@ describe('evaluation', () => {
         await waitFor(() => expect(screen.queryByText(TARGETED_FLAG_VALUE)).toBeInTheDocument(), {
           timeout: DELAY * 2,
         });
+      });
+    });
+
+    it('should show the previous UI while reconciling during a transition', async () => {
+      await OpenFeature.setContext(SUSPENSE_OFF, {});
+      OpenFeature.setProvider(SUSPENSE_ON, suspendingProvider());
+
+      render(
+        // disable suspendUntilReady, we are only testing reconcile suspense.
+        <OpenFeatureProvider domain={SUSPENSE_ON} suspendUntilReady={false}>
+          <React.Suspense fallback={<div>{FALLBACK}</div>}>
+            <TestComponent></TestComponent>
+          </React.Suspense>
+        </OpenFeatureProvider>,
+      );
+
+      // initially should be default, because suspendUntilReady={false}
+      expect(screen.queryByText(DEFAULT)).toBeInTheDocument();
+
+      // update the context without awaiting
+      act(() => {
+        startTransition(() => {
+          OpenFeature.setContext(SUSPENSE_ON, { user: TARGETED_USER });
+        });
+      });
+
+      // we should still see the same UI, because this is a transition update
+      expect(screen.queryByText(DEFAULT)).toBeInTheDocument();
+
+      // make sure we updated after reconciling
+      await waitFor(() => expect(screen.queryByText(TARGETED_FLAG_VALUE)).toBeInTheDocument(), {
+        timeout: DELAY * 2,
       });
     });
 

--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -73,17 +73,24 @@ describe('provider', () => {
 
   describe('useWhenProviderReady', () => {
     describe('suspendUntilReady=true (default)', () => {
-      function TestComponent() {
-        const isReady = useWhenProviderReady();
-        return (
-          <>
-            <div>{isReady ? '👍' : '👎'}</div>
-          </>
-        );
-      }
-
       it('should suspend until ready and then return provider status', async () => {
         OpenFeature.setProvider(SUSPENSE_ON, suspendingProvider());
+
+        let renderedWhileNotReady = false;
+
+        function TestComponent() {
+          const isReady = useWhenProviderReady();
+
+          if (!isReady) {
+            renderedWhileNotReady = true;
+          }
+
+          return (
+            <>
+              <div>{isReady ? '👍' : '👎'}</div>
+            </>
+          );
+        }
 
         render(
           <OpenFeatureProvider domain={SUSPENSE_ON}>
@@ -94,7 +101,8 @@ describe('provider', () => {
         );
 
         // should see fallback initially
-        expect(screen.queryByText('👎')).not.toBeVisible();
+        expect(renderedWhileNotReady).toBe(false);
+        expect(screen.queryByText('👎')).not.toBeInTheDocument();
         expect(screen.queryByText(FALLBACK)).toBeInTheDocument();
         // eventually we should the value
         await waitFor(() => expect(screen.queryByText('👍')).toBeVisible(), { timeout: DELAY * 2 });


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Add an internal `useOpenFeatureClientStatus()` function to make it slightly easier to keep track of the state of the current Client, and know when to suspend or not.

- Replaces the `suspend()` function with a `suspendUntilReady()` function. The `suspendUntilReady()`  function fires immediatly during the first render or when the component cannot render due to the client having changed status.

- Put the Client status and the feature flag details inside React states. This is required to make APIs like `startTransition` work properly with the library

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #920

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks

- [x] Add more tests. Suspense and Transitions are very tricky. While these changes don't seem to have broken any existing tests, we should add new tests to make sure Suspense and Transitions continue to work properly in the future.

- [ ] ~I think there might still be some reactivity issues with some parts of the codebase. The client returned by `useOpenFeatureClient()` didn't seem to update properly when the client changed, which made `useOpenFeatureClientStatus()` not update properly.~ Out of the scope of this PR

### How to test
<!-- if applicable, add testing instructions under this section -->

I built the application with `npm build`, then `npm pack`. I used the modified code on a local project to see if it fixed the issues.

I built projects in CodeSanbox that demonstrate the issues.

For Suspense: https://codesandbox.io/embed/openfeature-suspense-bug-5j7yll?fontsize=14&hidenavigation=1&theme=dark

For Transitions: https://codesandbox.io/embed/openfeature-suspense-bug-forked-lqhyf3?fontsize=14&hidenavigation=1&theme=dark

