### PR TITLE
fix: run error hook when provider returns reason error or error code

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -175,13 +175,13 @@ export default {
       displayName: 'react',
       testEnvironment: 'jsdom',
       preset: 'ts-jest',
-      testMatch: ['<rootDir>/packages/react/test/**/*.spec.ts*'],
+      testMatch: ['<rootDir>/packages/react/test/**/*.spec.{ts,tsx}'],
       moduleNameMapper: {
         '@openfeature/core': '<rootDir>/packages/shared/src',
         '@openfeature/web-sdk': '<rootDir>/packages/client/src',
       },
       transform: {
-        '^.+\\.tsx$': [
+        '^.+\\.(ts|tsx)$': [
           'ts-jest',
           {
             tsconfig: '<rootDir>/packages/react/test/tsconfig.json',

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -226,12 +226,15 @@ export class OpenFeatureClient implements Client {
         flagKey,
       };
 
-      if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
-        const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
-        this.errorHooks(allHooksReversed, hookContext, instantiateErrorByErrorCode(errorCode), options);
+      if (evaluationDetails.errorCode) {
+        this.errorHooks(
+          allHooksReversed,
+          hookContext,
+          instantiateErrorByErrorCode(evaluationDetails.errorCode),
+          options,
+        );
         return {
           ...evaluationDetails,
-          errorCode,
           reason: StandardResolutionReasons.ERROR,
         };
       }

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -227,16 +227,7 @@ export class OpenFeatureClient implements Client {
       };
 
       if (evaluationDetails.errorCode) {
-        this.errorHooks(
-          allHooksReversed,
-          hookContext,
-          instantiateErrorByErrorCode(evaluationDetails.errorCode),
-          options,
-        );
-        return {
-          ...evaluationDetails,
-          reason: StandardResolutionReasons.ERROR,
-        };
+        throw instantiateErrorByErrorCode(evaluationDetails.errorCode);
       }
 
       this.afterHooks(allHooksReversed, hookContext, evaluationDetails, options);

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -15,7 +15,7 @@ import {
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
-  instantiateErrorByKey,
+  instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
@@ -209,7 +209,7 @@ export class OpenFeatureClient implements Client {
 
     try {
       this.beforeHooks(allHooks, hookContext, options);
-      
+
       // short circuit evaluation entirely if provider is in a bad state
       if (this.providerStatus === ProviderStatus.NOT_READY) {
         throw new ProviderNotReadyError('provider has not yet initialized');
@@ -228,7 +228,7 @@ export class OpenFeatureClient implements Client {
 
       if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
         const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
-        this.errorHooks(allHooksReversed, hookContext, instantiateErrorByKey(errorCode), options);
+        this.errorHooks(allHooksReversed, hookContext, instantiateErrorByErrorCode(errorCode), options);
         return {
           ...evaluationDetails,
           errorCode,

--- a/packages/client/src/client/open-feature-client.ts
+++ b/packages/client/src/client/open-feature-client.ts
@@ -15,7 +15,8 @@ import {
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
-  statusMatchesEvent
+  instantiateErrorByKey,
+  statusMatchesEvent,
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
 import { ProviderEvents } from '../events';
@@ -224,6 +225,16 @@ export class OpenFeatureClient implements Client {
         flagMetadata: Object.freeze(resolution.flagMetadata ?? {}),
         flagKey,
       };
+
+      if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
+        const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
+        this.errorHooks(allHooksReversed, hookContext, instantiateErrorByKey(errorCode), options);
+        return {
+          ...evaluationDetails,
+          errorCode,
+          reason: StandardResolutionReasons.ERROR,
+        };
+      }
 
       this.afterHooks(allHooksReversed, hookContext, evaluationDetails, options);
 

--- a/packages/client/test/hooks.spec.ts
+++ b/packages/client/test/hooks.spec.ts
@@ -7,6 +7,8 @@ import {
   GeneralError,
   OpenFeature,
   Hook,
+  StandardResolutionReasons,
+  ErrorCode,
 } from '../src';
 
 const BOOLEAN_VALUE = true;
@@ -205,6 +207,48 @@ describe('Hooks', () => {
             },
           ],
         });
+      });
+
+      it('"error" must run if resolution details contains an error code', () => {
+        (MOCK_ERROR_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockReturnValue({
+          value: BOOLEAN_VALUE,
+          errorCode: ErrorCode.FLAG_NOT_FOUND,
+        });
+
+        const mockErrorHook = jest.fn();
+
+        const details = client.getBooleanDetails(FLAG_KEY, false, {
+          hooks: [{ error: mockErrorHook }],
+        });
+
+        expect(mockErrorHook).toHaveBeenCalled();
+        expect(details).toEqual(
+          expect.objectContaining({
+            errorCode: ErrorCode.FLAG_NOT_FOUND,
+            reason: StandardResolutionReasons.ERROR,
+          }),
+        );
+      });
+
+      it('"error" must run if resolution details contains the reason "ERROR"', () => {
+        (MOCK_ERROR_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockReturnValue({
+          value: BOOLEAN_VALUE,
+          reason: StandardResolutionReasons.ERROR,
+        });
+
+        const mockErrorHook = jest.fn();
+
+        const details = client.getBooleanDetails(FLAG_KEY, false, {
+          hooks: [{ error: mockErrorHook }],
+        });
+
+        expect(mockErrorHook).toHaveBeenCalled();
+        expect(details).toEqual(
+          expect.objectContaining({
+            errorCode: ErrorCode.GENERAL,
+            reason: StandardResolutionReasons.ERROR,
+          }),
+        );
       });
     });
   });

--- a/packages/client/test/hooks.spec.ts
+++ b/packages/client/test/hooks.spec.ts
@@ -229,27 +229,6 @@ describe('Hooks', () => {
           }),
         );
       });
-
-      it('"error" must run if resolution details contains the reason "ERROR"', () => {
-        (MOCK_ERROR_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockReturnValue({
-          value: BOOLEAN_VALUE,
-          reason: StandardResolutionReasons.ERROR,
-        });
-
-        const mockErrorHook = jest.fn();
-
-        const details = client.getBooleanDetails(FLAG_KEY, false, {
-          hooks: [{ error: mockErrorHook }],
-        });
-
-        expect(mockErrorHook).toHaveBeenCalled();
-        expect(details).toEqual(
-          expect.objectContaining({
-            errorCode: ErrorCode.GENERAL,
-            reason: StandardResolutionReasons.ERROR,
-          }),
-        );
-      });
     });
   });
 

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -279,12 +279,15 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
         flagKey,
       };
 
-      if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
-        const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
-        await this.errorHooks(allHooksReversed, hookContext, instantiateErrorByErrorCode(errorCode), options);
+      if (evaluationDetails.errorCode) {
+        await this.errorHooks(
+          allHooksReversed,
+          hookContext,
+          instantiateErrorByErrorCode(evaluationDetails.errorCode),
+          options,
+        );
         return {
           ...evaluationDetails,
-          errorCode,
           reason: StandardResolutionReasons.ERROR,
         };
       }

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -16,7 +16,7 @@ import {
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
-  instantiateErrorByKey,
+  instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
@@ -281,7 +281,7 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
 
       if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
         const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
-        await this.errorHooks(allHooksReversed, hookContext, instantiateErrorByKey(errorCode), options);
+        await this.errorHooks(allHooksReversed, hookContext, instantiateErrorByErrorCode(errorCode), options);
         return {
           ...evaluationDetails,
           errorCode,

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -16,6 +16,7 @@ import {
   ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
+  instantiateErrorByKey,
   statusMatchesEvent,
 } from '@openfeature/core';
 import { FlagEvaluationOptions } from '../evaluation';
@@ -277,6 +278,16 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
         flagMetadata: Object.freeze(resolution.flagMetadata ?? {}),
         flagKey,
       };
+
+      if (evaluationDetails.errorCode || evaluationDetails.reason === StandardResolutionReasons.ERROR) {
+        const errorCode = evaluationDetails.errorCode || ErrorCode.GENERAL;
+        await this.errorHooks(allHooksReversed, hookContext, instantiateErrorByKey(errorCode), options);
+        return {
+          ...evaluationDetails,
+          errorCode,
+          reason: StandardResolutionReasons.ERROR,
+        };
+      }
 
       await this.afterHooks(allHooksReversed, hookContext, evaluationDetails, options);
 

--- a/packages/server/src/client/open-feature-client.ts
+++ b/packages/server/src/client/open-feature-client.ts
@@ -280,16 +280,7 @@ export class OpenFeatureClient implements Client, ManageContext<OpenFeatureClien
       };
 
       if (evaluationDetails.errorCode) {
-        await this.errorHooks(
-          allHooksReversed,
-          hookContext,
-          instantiateErrorByErrorCode(evaluationDetails.errorCode),
-          options,
-        );
-        return {
-          ...evaluationDetails,
-          reason: StandardResolutionReasons.ERROR,
-        };
+        throw instantiateErrorByErrorCode(evaluationDetails.errorCode);
       }
 
       await this.afterHooks(allHooksReversed, hookContext, evaluationDetails, options);

--- a/packages/server/test/hooks.spec.ts
+++ b/packages/server/test/hooks.spec.ts
@@ -386,27 +386,6 @@ describe('Hooks', () => {
           }),
         );
       });
-
-      it('"error" must run if resolution details contains the reason "ERROR"', async () => {
-        (MOCK_ERROR_PROVIDER.resolveBooleanEvaluation as jest.Mock).mockResolvedValueOnce({
-          value: BOOLEAN_VALUE,
-          reason: StandardResolutionReasons.ERROR,
-        });
-
-        const mockErrorHook = jest.fn();
-
-        const details = await client.getBooleanDetails(FLAG_KEY, false, undefined, {
-          hooks: [{ error: mockErrorHook }],
-        });
-
-        expect(mockErrorHook).toHaveBeenCalled();
-        expect(details).toEqual(
-          expect.objectContaining({
-            errorCode: ErrorCode.GENERAL,
-            reason: StandardResolutionReasons.ERROR,
-          }),
-        );
-      });
     });
   });
 

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -41,5 +41,5 @@ export {
   TargetingKeyMissingError,
   TypeMismatchError,
   OpenFeatureError,
-  instantiateErrorByKey,
+  instantiateErrorByErrorCode,
 };

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -1,9 +1,45 @@
-export * from './general-error';
-export * from './flag-not-found-error';
-export * from './parse-error';
-export * from './type-mismatch-error';
-export * from './targeting-key-missing-error';
-export * from './invalid-context-error';
-export * from './open-feature-error-abstract';
-export * from './provider-not-ready-error';
-export * from './provider-fatal-error';
+import { ErrorCode } from '../evaluation';
+
+import { FlagNotFoundError } from './flag-not-found-error';
+import { GeneralError } from './general-error';
+import { InvalidContextError } from './invalid-context-error';
+import { OpenFeatureError } from './open-feature-error-abstract';
+import { ParseError } from './parse-error';
+import { ProviderFatalError } from './provider-fatal-error';
+import { ProviderNotReadyError } from './provider-not-ready-error';
+import { TargetingKeyMissingError } from './targeting-key-missing-error';
+import { TypeMismatchError } from './type-mismatch-error';
+
+const instantiateErrorByKey = (key: ErrorCode, message?: string): OpenFeatureError => {
+  switch (key) {
+    case ErrorCode.FLAG_NOT_FOUND:
+      return new FlagNotFoundError(message);
+    case ErrorCode.PARSE_ERROR:
+      return new ParseError(message);
+    case ErrorCode.TYPE_MISMATCH:
+      return new TypeMismatchError(message);
+    case ErrorCode.TARGETING_KEY_MISSING:
+      return new TargetingKeyMissingError(message);
+    case ErrorCode.INVALID_CONTEXT:
+      return new InvalidContextError(message);
+    case ErrorCode.PROVIDER_NOT_READY:
+      return new ProviderNotReadyError(message);
+    case ErrorCode.PROVIDER_FATAL:
+      return new ProviderFatalError(message);
+    default:
+      return new GeneralError(message);
+  }
+};
+
+export {
+  FlagNotFoundError,
+  GeneralError,
+  InvalidContextError,
+  ParseError,
+  ProviderFatalError,
+  ProviderNotReadyError,
+  TargetingKeyMissingError,
+  TypeMismatchError,
+  OpenFeatureError,
+  instantiateErrorByKey,
+};

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -10,8 +10,8 @@ import { ProviderNotReadyError } from './provider-not-ready-error';
 import { TargetingKeyMissingError } from './targeting-key-missing-error';
 import { TypeMismatchError } from './type-mismatch-error';
 
-const instantiateErrorByKey = (key: ErrorCode, message?: string): OpenFeatureError => {
-  switch (key) {
+const instantiateErrorByErrorCode = (errorCode: ErrorCode, message?: string): OpenFeatureError => {
+  switch (errorCode) {
     case ErrorCode.FLAG_NOT_FOUND:
       return new FlagNotFoundError(message);
     case ErrorCode.PARSE_ERROR:


### PR DESCRIPTION
## This PR

- runs error hook when provider returns reason error or error code

### Related Issues

Fixes #925

### Notes

Based on a conversation in Slack: https://cloud-native.slack.com/archives/C06E4DE6S07/p1714581197391509
