### PR TITLE
fix: skip reconciling event for synchronous onContextChange operations

### DIFF
--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -234,7 +234,7 @@ export class OpenFeatureAPI
         const maybePromise = wrapper.provider.onContextChange(oldContext, newContext);
 
         // only reconcile if the onContextChange method returns a promise
-        if (maybePromise instanceof Promise) {
+        if (typeof maybePromise?.then === 'function') {
           wrapper.incrementPendingContextChanges();
           wrapper.status = this._statusEnumType.RECONCILING;
           this.getAssociatedEventEmitters(domain).forEach((emitter) => {

--- a/packages/client/src/open-feature.ts
+++ b/packages/client/src/open-feature.ts
@@ -231,14 +231,20 @@ export class OpenFeatureAPI
 
     try {
       if (typeof wrapper.provider.onContextChange === 'function') {
-        wrapper.incrementPendingContextChanges();
-        wrapper.status = this._statusEnumType.RECONCILING;
-        this.getAssociatedEventEmitters(domain).forEach((emitter) => {
-          emitter?.emit(ProviderEvents.Reconciling, { domain, providerName });
-        });
-        this._apiEmitter?.emit(ProviderEvents.Reconciling, { domain, providerName });
-        await wrapper.provider.onContextChange(oldContext, newContext);
-        wrapper.decrementPendingContextChanges();
+        const maybePromise = wrapper.provider.onContextChange(oldContext, newContext);
+
+        // only reconcile if the onContextChange method returns a promise
+        if (maybePromise instanceof Promise) {
+          wrapper.incrementPendingContextChanges();
+          wrapper.status = this._statusEnumType.RECONCILING;
+          this.getAssociatedEventEmitters(domain).forEach((emitter) => {
+            emitter?.emit(ProviderEvents.Reconciling, { domain, providerName });
+          });
+          this._apiEmitter?.emit(ProviderEvents.Reconciling, { domain, providerName });
+
+          await maybePromise;
+          wrapper.decrementPendingContextChanges();
+        }
       }
       // only run the event handlers, and update the state if the onContextChange method succeeded
       wrapper.status = this._statusEnumType.READY;

--- a/packages/client/src/provider/provider.ts
+++ b/packages/client/src/provider/provider.ts
@@ -19,12 +19,18 @@ export interface Provider extends CommonProvider<ClientProviderStatus> {
   readonly hooks?: Hook[];
 
   /**
-   * A handler function to reconcile changes when the static context.
+   * A handler function to reconcile changes made to the static context.
    * Called by the SDK when the context is changed.
+   *
+   * Returning a promise will put the provider in the RECONCILING state and
+   * emit the ProviderEvents.Reconciling event.
+   *
+   * Return void will avoid putting the provider in the RECONCILING state and
+   * **not** emit the ProviderEvents.Reconciling event.
    * @param oldContext
    * @param newContext
    */
-  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>;
+  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void> | void;
 
   /**
    * Resolve a boolean flag and its evaluation details.


### PR DESCRIPTION
## This PR

- skips emitting a reconciling event for synchronous onContextChange operations

### Notes

This will avoid unexpected component rerenders for synchronous onContextChange operations.

The spec states that the SDK may avoid emitting the `PROVIDER_RECONCILING` if a provider can reconcile synchronously.

https://openfeature.dev/specification/sections/events#event-handlers-and-context-reconciliation

