### PR TITLE
feat!: rename FeatureClient decorator to OpenFeatureClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13851,7 +13851,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "1.2.0"
@@ -13862,7 +13862,7 @@
     },
     "packages/nest": {
       "name": "@openfeature/nestjs-sdk",
-      "version": "0.1.4-experimental",
+      "version": "0.1.5-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@nestjs/common": "^10.3.6",
@@ -13877,13 +13877,13 @@
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "@openfeature/server-sdk": ">=1.7.5",
+        "@openfeature/server-sdk": ">=1.14.0",
         "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0"
       }
     },
     "packages/react": {
       "name": "@openfeature/react-sdk",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "*",
@@ -13896,13 +13896,13 @@
     },
     "packages/server": {
       "name": "@openfeature/server-sdk",
-      "version": "1.13.5",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "1.2.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "@openfeature/core": "1.2.0"

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -137,13 +137,13 @@ It is also possible to inject the default or domain scoped OpenFeature clients i
 
 ```ts
 import { Injectable } from '@nestjs/common';
-import { FeatureClient, Client } from '@openfeature/nestjs-sdk';
+import { OpenFeatureClient, Client } from '@openfeature/nestjs-sdk';
 
 @Injectable()
 export class OpenFeatureTestService {
   constructor(
-    @FeatureClient() private defaultClient: Client,
-    @FeatureClient({ domain: 'my-domain' }) private scopedClient: Client,
+    @OpenFeatureClient() private defaultClient: Client,
+    @OpenFeatureClient({ domain: 'my-domain' }) private scopedClient: Client,
   ) {}
 
   public async getBoolean() {

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -48,7 +48,7 @@
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0",
-    "@openfeature/server-sdk": ">=1.7.5"
+    "@openfeature/server-sdk": ">=1.14.0"
   },
   "devDependencies": {
     "@nestjs/common": "^10.3.6",

--- a/packages/nest/src/feature.decorator.ts
+++ b/packages/nest/src/feature.decorator.ts
@@ -26,7 +26,7 @@ interface FeatureClientProps {
  * @param {FeatureClientProps} [props] The options for injecting the client.
  * @returns {PropertyDecorator & ParameterDecorator} The decorator function.
  */
-export const FeatureClient = (props?: FeatureClientProps) => Inject(getOpenFeatureClientToken(props?.domain));
+export const OpenFeatureClient = (props?: FeatureClientProps) => Inject(getOpenFeatureClientToken(props?.domain));
 
 /**
  * Options for injecting a feature flag into a route handler.

--- a/packages/nest/test/test-app.ts
+++ b/packages/nest/test/test-app.ts
@@ -1,14 +1,14 @@
 import { Controller, Get, Injectable, UseInterceptors } from '@nestjs/common';
 import { Observable, map } from 'rxjs';
-import { BooleanFeatureFlag, ObjectFeatureFlag, NumberFeatureFlag, FeatureClient, StringFeatureFlag } from '../src';
+import { BooleanFeatureFlag, ObjectFeatureFlag, NumberFeatureFlag, OpenFeatureClient, StringFeatureFlag } from '../src';
 import { Client, EvaluationDetails, FlagValue } from '@openfeature/server-sdk';
 import { EvaluationContextInterceptor } from '../src';
 
 @Injectable()
 export class OpenFeatureTestService {
   constructor(
-    @FeatureClient() public defaultClient: Client,
-    @FeatureClient({ domain: 'domainScopedClient' }) public domainScopedClient: Client,
+    @OpenFeatureClient() public defaultClient: Client,
+    @OpenFeatureClient({ domain: 'domainScopedClient' }) public domainScopedClient: Client,
   ) {}
 
   public async serviceMethod(flag: EvaluationDetails<FlagValue>) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

As discussed here [#750](https://github.com/open-feature/js-sdk/pull/750#discussion_r1450896230), renames `@FeatureClient` to `@OpenFeatureClient` which is possible since we merged #918.
