### PR TITLE
feat: add test provider

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -322,9 +322,7 @@ The type of this option is `Partial<Provider>`, so you can pass an incomplete im
 
 ```tsx
 class MyTestProvider implements Partial<Provider> {
-  metadata = {
-    name: 'my test provider',
-  };
+  // implement the relevant resolver
   resolveBooleanEvaluation(): ResolutionDetails<boolean> {
     return {
       value: true,

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -283,7 +283,7 @@ This can be disabled in the hook options (or in the [OpenFeatureProvider](#openf
 
 The React SDK includes a built-in context provider for testing.
 This allows you to easily test components that use evaluation hooks, such as `useFlag`.
-If you try to test a component that uses an evaluation hook, you might see an error message like:
+If you try to test a component (in this case, `MyComponent`) which uses an evaluation hook, you might see an error message like:
 
 ```
 No OpenFeature client available - components using OpenFeature must be wrapped with an <OpenFeatureProvider>.
@@ -294,7 +294,7 @@ You can resolve this by simply wrapping your component under test in the OpenFea
 ```tsx
 // use default values for all evaluations
 <OpenFeatureTestProvider>
-  <TestComponent />
+  <MyComponent />
 </OpenFeatureTestProvider>
 ```
 
@@ -304,7 +304,7 @@ If you'd like to control the values returned by the evaluation hooks, you can pa
 ```tsx
 // return `true` for all evaluations of `'my-boolean-flag'`
 <OpenFeatureTestProvider flagValueMap={{ 'my-boolean-flag': true }}>
-  <TestComponent />
+  <MyComponent />
 </OpenFeatureTestProvider>
 ```
 
@@ -313,7 +313,7 @@ Additionally, you can pass an artificial delay for the provider startup to test 
 ```tsx
 // delay the provider start by 1000ms and then return `true` for all evaluations of `'my-boolean-flag'`
 <OpenFeatureTestProvider delayMs={1000} flagValueMap={{ 'my-boolean-flag': true }}>
-  <TestComponent />
+  <MyComponent />
 </OpenFeatureTestProvider>
 ```
 
@@ -338,7 +338,7 @@ class MyTestProvider implements Partial<Provider> {
 ```tsx
 // use your custom testing provider
 <OpenFeatureTestProvider provider={new MyTestProvider()}>
-  <TestComponent />
+  <MyComponent />
 </OpenFeatureTestProvider>,
 ```
 

--- a/packages/react/src/provider/index.ts
+++ b/packages/react/src/provider/index.ts
@@ -1,3 +1,4 @@
 export * from './provider';
 export * from './use-open-feature-client';
 export * from './use-when-provider-ready';
+export * from './test-provider';

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -1,0 +1,93 @@
+import {
+  EvaluationContext,
+  InMemoryProvider,
+  JsonValue,
+  NOOP_PROVIDER,
+  OpenFeature,
+  Provider,
+} from '@openfeature/web-sdk';
+import React from 'react';
+import { NormalizedOptions } from '../common/options';
+import { OpenFeatureProvider } from './provider';
+
+type FlagValueMap = { [flagKey: string]: JsonValue };
+type FlagConfig = ConstructorParameters<typeof InMemoryProvider>[0];
+type TestProviderProps = Omit<React.ComponentProps<typeof OpenFeatureProvider>, 'client'> &
+  (
+    | {
+        provider?: never;
+        /**
+         * Optional map of flagKeys to flagValues for this OpenFeatureTestProvider context.
+         * If not supplied, all flag evaluations will default.
+         */
+        flagValueMap?: FlagValueMap;
+        /**
+         * Optional delay for the underlying test provider's readiness and reconciliation.
+         * Defaults to 0.
+         */
+        delayMs?: number;
+      }
+    | {
+        /**
+         * An optional partial provider to pass for full control over the flag resolution for this OpenFeatureTestProvider context.
+         */
+        provider?: Partial<Provider>;
+        flagValueMap?: never;
+        delayMs?: never;
+      }
+  );
+
+const TEST_VARIANT = 'test-variant';
+
+// internal provider which is basically the in-memory provider with a simpler config and some optional fake delays
+class TestProvider extends InMemoryProvider {
+  constructor(
+    flagValueMap: FlagValueMap,
+    private delay = 0,
+  ) {
+    // convert the simple flagValueMap into an in-memory config
+    const flagConfig = Object.entries(flagValueMap).reduce((acc: FlagConfig, flag): FlagConfig => {
+      return {
+        ...acc,
+        [flag[0]]: {
+          variants: {
+            [TEST_VARIANT]: flag[1],
+          },
+          defaultVariant: TEST_VARIANT,
+          disabled: false,
+        },
+      };
+    }, {});
+    super(flagConfig);
+  }
+
+  async initialize(context?: EvaluationContext | undefined): Promise<void> {
+    await Promise.all([super.initialize(context), new Promise<void>((resolve) => setTimeout(resolve, this.delay))]);
+  }
+
+  async onContextChange() {
+    return new Promise<void>((resolve) => setTimeout(resolve, this.delay));
+  }
+}
+
+/**
+ * A React Context provider based on the {@link InMemoryProvider}, specifically built for testing.
+ * Use this for testing components that use flag evaluation hooks.
+ * @param {TestProviderProps} testProviderOptions options for the OpenFeatureTestProvider
+ * @returns {OpenFeatureProvider} OpenFeatureTestProvider
+ */
+export function OpenFeatureTestProvider(testProviderOptions: TestProviderProps) {
+  const { flagValueMap, provider } = testProviderOptions;
+  const effectiveProvider = (
+    flagValueMap ? new TestProvider(flagValueMap, testProviderOptions.delayMs) : provider || NOOP_PROVIDER
+  ) as Provider;
+  testProviderOptions.domain
+    ? OpenFeature.setProvider(testProviderOptions.domain, effectiveProvider)
+    : OpenFeature.setProvider(effectiveProvider);
+
+  return (
+    <OpenFeatureProvider {...(testProviderOptions as NormalizedOptions)} domain={testProviderOptions.domain}>
+      {testProviderOptions.children}
+    </OpenFeatureProvider>
+  );
+}

--- a/packages/react/src/provider/use-open-feature-client.ts
+++ b/packages/react/src/provider/use-open-feature-client.ts
@@ -12,7 +12,7 @@ export function useOpenFeatureClient(): Client {
 
   if (!client) {
     throw new Error(
-      'No OpenFeature client available - components using OpenFeature must be wrapped with an <OpenFeatureProvider>',
+      'No OpenFeature client available - components using OpenFeature must be wrapped with an <OpenFeatureProvider>. If you are seeing this in a test, see: https://openfeature.dev/docs/reference/technologies/client/web/react#testing',
     );
   }
 

--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { OpenFeatureProvider, useOpenFeatureClient, useWhenProviderReady } from '../src';
 import { TestingProvider } from './test.utils';
 
-describe('provider', () => {
+describe('OpenFeatureProvider', () => {
   /**
    * artificial delay for various async operations for our provider,
    * multiples of it are used in assertions as well

--- a/packages/react/test/test-provider.spec.tsx
+++ b/packages/react/test/test-provider.spec.tsx
@@ -17,7 +17,7 @@ function TestComponent() {
 
 describe('OpenFeatureTestProvider', () => {
   describe('no args', () => {
-    it('renders default ', async () => {
+    it('renders default', async () => {
       render(
         <OpenFeatureTestProvider>
           <TestComponent />
@@ -28,7 +28,7 @@ describe('OpenFeatureTestProvider', () => {
   });
 
   describe('flagValueMap set', () => {
-    it('renders value ', async () => {
+    it('renders value from map', async () => {
       render(
         <OpenFeatureTestProvider flagValueMap={{ [FLAG_KEY]: true }}>
           <TestComponent />
@@ -69,7 +69,7 @@ describe('OpenFeatureTestProvider', () => {
       }
     }
 
-    it('renders default ', async () => {
+    it('renders provider-returned value', async () => {
       render(
         <OpenFeatureTestProvider provider={new MyTestProvider()}>
           <TestComponent />

--- a/packages/react/test/test-provider.spec.tsx
+++ b/packages/react/test/test-provider.spec.tsx
@@ -50,7 +50,7 @@ describe('OpenFeatureTestProvider', () => {
 
       // should only be resolved after delay
       expect(await screen.findByText('👎')).toBeInTheDocument();
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay * 2));
       expect(await screen.findByText('👍')).toBeInTheDocument();
     });
   });

--- a/packages/react/test/test-provider.spec.tsx
+++ b/packages/react/test/test-provider.spec.tsx
@@ -1,0 +1,82 @@
+import { Provider, ResolutionDetails } from '@openfeature/web-sdk';
+import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { OpenFeatureTestProvider, useFlag } from '../src';
+
+const FLAG_KEY = 'thumbs';
+
+function TestComponent() {
+  const { value: thumbs } = useFlag(FLAG_KEY, false);
+  return (
+    <>
+      <div>{thumbs ? '👍' : '👎'}</div>
+    </>
+  );
+}
+
+describe('OpenFeatureTestProvider', () => {
+  describe('no args', () => {
+    it('renders default ', async () => {
+      render(
+        <OpenFeatureTestProvider>
+          <TestComponent />
+        </OpenFeatureTestProvider>,
+      );
+      expect(await screen.findByText('👎')).toBeInTheDocument();
+    });
+  });
+
+  describe('flagValueMap set', () => {
+    it('renders value ', async () => {
+      render(
+        <OpenFeatureTestProvider flagValueMap={{ [FLAG_KEY]: true }}>
+          <TestComponent />
+        </OpenFeatureTestProvider>,
+      );
+
+      expect(await screen.findByText('👍')).toBeInTheDocument();
+    });
+  });
+
+  describe('delay and flagValueMap set', () => {
+    it('renders value after delay', async () => {
+      const delay = 100;
+      render(
+        <OpenFeatureTestProvider delayMs={delay} flagValueMap={{ [FLAG_KEY]: true }}>
+          <TestComponent />
+        </OpenFeatureTestProvider>,
+      );
+
+      // should only be resolved after delay
+      expect(await screen.findByText('👎')).toBeInTheDocument();
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      expect(await screen.findByText('👍')).toBeInTheDocument();
+    });
+  });
+
+  describe('provider set', () => {
+    class MyTestProvider implements Partial<Provider> {
+      metadata = {
+        name: 'my test provider',
+      };
+      resolveBooleanEvaluation(): ResolutionDetails<boolean> {
+        return {
+          value: true,
+          variant: 'test-variant',
+          reason: 'MY_REASON',
+        };
+      }
+    }
+
+    it('renders default ', async () => {
+      render(
+        <OpenFeatureTestProvider provider={new MyTestProvider()}>
+          <TestComponent />
+        </OpenFeatureTestProvider>,
+      );
+
+      expect(await screen.findByText('👍')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Adds some testing utilities, specifically an `<OpenFeatureTestProvider/>` react context provider.

See README for details.