### PR TITLE
feat: updated the Metadata type to allow for custom properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13851,7 +13851,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "1.3.0"
@@ -13883,7 +13883,7 @@
     },
     "packages/react": {
       "name": "@openfeature/react-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/core": "*",

--- a/packages/shared/src/client/client.ts
+++ b/packages/shared/src/client/client.ts
@@ -1,7 +1,6 @@
-import { Metadata } from '../types';
 import { ProviderMetadata } from '../provider/provider';
 
-export interface ClientMetadata extends Metadata {
+export interface ClientMetadata {
   /**
    * @deprecated alias of "domain", use domain instead
    */

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -82,7 +82,7 @@ export { ClientProviderStatus as AllProviderStatus };
 /**
  * Static data about the provider.
  */
-export interface ProviderMetadata extends Metadata {
+export interface ProviderMetadata extends Readonly<Metadata> {
   readonly name: string;
 }
 
@@ -99,7 +99,7 @@ export interface CommonProvider<S extends ClientProviderStatus | ServerProviderS
   /**
    * @deprecated the SDK now maintains the provider's state; there's no need for providers to implement this field.
    * Returns a representation of the current readiness of the provider.
-   * 
+   *
    * _Providers which do not implement this method are assumed to be ready immediately._
    */
   readonly status?: S;

--- a/packages/shared/src/types/metadata.ts
+++ b/packages/shared/src/types/metadata.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Metadata {}
+export type Metadata = Record<string, string>;


### PR DESCRIPTION
## This PR
- Updates the `Metadata` type to a `Record` so that Providers can provide more than just the `name` property as part of the `metadata`.

### Notes
Conversation [here](https://cloud-native.slack.com/archives/C03J36ZP020/p1721747906370629).

