### PR TITLE
fix: race condition in test provider with suspense

### DIFF
--- a/packages/client/test/in-memory-provider.spec.ts
+++ b/packages/client/test/in-memory-provider.spec.ts
@@ -1,44 +1,7 @@
-import { FlagNotFoundError, GeneralError, InMemoryProvider, ProviderEvents, StandardResolutionReasons, TypeMismatchError } from '../src';
-import { FlagConfiguration } from '../src/provider/in-memory-provider/flag-configuration';
+import { FlagNotFoundError, InMemoryProvider, ProviderEvents, StandardResolutionReasons, TypeMismatchError } from '../src';
 import { VariantNotFoundError } from '../src/provider/in-memory-provider/variant-not-found-error';
 
 describe('in-memory provider', () => {
-  describe('initialize', () => {
-    it('Should not throw for valid flags', async () => {
-      const booleanFlagSpec = {
-        'a-boolean-flag': {
-          variants: {
-            on: true,
-            off: false,
-          },
-          disabled: false,
-          defaultVariant: 'on',
-        },
-      };
-      const provider = new InMemoryProvider(booleanFlagSpec);
-      await provider.initialize();
-    });
-
-    it('Should throw on invalid flags', async () => {
-      const throwingFlagSpec: FlagConfiguration = {
-        'a-boolean-flag': {
-          variants: {
-            on: true,
-            off: false,
-          },
-          disabled: false,
-          defaultVariant: 'on',
-          contextEvaluator: () => {
-            throw new GeneralError('context eval error');
-          },
-        },
-      };
-      const provider = new InMemoryProvider(throwingFlagSpec);
-      const someContext = {};
-      await expect(provider.initialize(someContext)).rejects.toThrow();
-    });
-  });
-
   describe('boolean flags', () => {
     const provider = new InMemoryProvider({});
     it('resolves to default variant with reason static', async () => {
@@ -531,8 +494,6 @@ describe('in-memory provider', () => {
         },
       });
 
-      await provider.initialize();
-
       const firstResolution = provider.resolveStringEvaluation('some-flag', 'deafaultFirstResolution');
 
       expect(firstResolution).toEqual({
@@ -576,8 +537,6 @@ describe('in-memory provider', () => {
       };
 
       const provider = new InMemoryProvider(flagsSpec);
-
-      await provider.initialize();
 
       // I passed configuration by reference, so maybe I can mess
       // with it behind the providers back!

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": "^1.0.2",
+    "@openfeature/web-sdk": "^1.2.2",
     "react": ">=16.8.0"
   },
   "devDependencies": {

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -44,6 +44,10 @@ type TestProviderProps = Omit<React.ComponentProps<typeof OpenFeatureProvider>, 
 class TestProvider extends InMemoryProvider {
 
   // initially make this undefined, we still set it if a delay is specified
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - For maximum compatibility with previous versions, we ignore a possible TS error here,
+  // since "initialize" was previously defined in superclass.
+  // We can safely remove this ts-ignore in a few versions
   initialize: Provider['initialize'] = undefined;
 
   // "place-holder" init function which we only assign if want a delay

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -1,5 +1,4 @@
 import {
-  EvaluationContext,
   InMemoryProvider,
   JsonValue,
   NOOP_PROVIDER,

--- a/packages/react/test/test-provider.spec.tsx
+++ b/packages/react/test/test-provider.spec.tsx
@@ -6,8 +6,8 @@ import { OpenFeatureTestProvider, useFlag } from '../src';
 
 const FLAG_KEY = 'thumbs';
 
-function TestComponent() {
-  const { value: thumbs, reason } = useFlag(FLAG_KEY, false);
+function TestComponent(props: { suspend: boolean }) {
+  const { value: thumbs, reason } = useFlag(FLAG_KEY, false, { suspend: props.suspend });
   return (
     <>
       <div>{thumbs ? '👍' : '👎'}</div>
@@ -21,10 +21,10 @@ describe('OpenFeatureTestProvider', () => {
     it('renders default', async () => {
       render(
         <OpenFeatureTestProvider>
-          <TestComponent />
+          <TestComponent suspend={false} />
         </OpenFeatureTestProvider>,
       );
-      expect(await screen.findByText('👎')).toBeInTheDocument();
+      expect(screen.getByText('👎')).toBeInTheDocument();
     });
   });
 
@@ -32,11 +32,11 @@ describe('OpenFeatureTestProvider', () => {
     it('renders value from map', async () => {
       render(
         <OpenFeatureTestProvider flagValueMap={{ [FLAG_KEY]: true }}>
-          <TestComponent />
+          <TestComponent suspend={false} />
         </OpenFeatureTestProvider>,
       );
 
-      expect(await screen.findByText('👍')).toBeInTheDocument();
+      expect(screen.getByText('👍')).toBeInTheDocument();
     });
   });
 
@@ -45,14 +45,14 @@ describe('OpenFeatureTestProvider', () => {
       const delay = 100;
       render(
         <OpenFeatureTestProvider delayMs={delay} flagValueMap={{ [FLAG_KEY]: true }}>
-          <TestComponent />
+          <TestComponent suspend={false} />
         </OpenFeatureTestProvider>,
       );
 
       // should only be resolved after delay
-      expect(await screen.findByText('👎')).toBeInTheDocument();
+      expect(screen.getByText('👎')).toBeInTheDocument();
       await new Promise((resolve) => setTimeout(resolve, delay * 2));
-      expect(await screen.findByText('👍')).toBeInTheDocument();
+      expect(screen.getByText('👍')).toBeInTheDocument();
     });
   });
 
@@ -60,7 +60,6 @@ describe('OpenFeatureTestProvider', () => {
     const reason = 'MY_REASON';
 
     it('renders provider-returned value', async () => {
-
       class MyTestProvider implements Partial<Provider> {
         resolveBooleanEvaluation(): ResolutionDetails<boolean> {
           return {
@@ -73,27 +72,60 @@ describe('OpenFeatureTestProvider', () => {
 
       render(
         <OpenFeatureTestProvider provider={new MyTestProvider()}>
-          <TestComponent />
+          <TestComponent suspend={false} />
         </OpenFeatureTestProvider>,
       );
 
-      expect(await screen.findByText('👍')).toBeInTheDocument();
-      expect(await screen.findByText(/reason/)).toBeInTheDocument();
+      expect(screen.getByText('👍')).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(`${reason}`))).toBeInTheDocument();
     });
 
     it('falls back to no-op for missing methods', async () => {
-
-      class MyEmptyProvider implements Partial<Provider> {
-      }
+      class MyEmptyProvider implements Partial<Provider> {}
 
       render(
         <OpenFeatureTestProvider provider={new MyEmptyProvider()}>
-          <TestComponent />
+          <TestComponent suspend={false} />
         </OpenFeatureTestProvider>,
       );
 
-      expect(await screen.findByText('👎')).toBeInTheDocument();
-      expect(await screen.findByText(/No-op/)).toBeInTheDocument();
+      expect(screen.getByText('👎')).toBeInTheDocument();
+      expect(screen.getByText(/No-op/)).toBeInTheDocument();
+    });
+  });
+
+  describe('component under test suspends', () => {
+    describe('delay non-zero', () => {
+      it('renders fallback then value after delay', async () => {
+        const delay = 100;
+        render(
+          <OpenFeatureTestProvider delayMs={delay} flagValueMap={{ [FLAG_KEY]: true }}>
+            <React.Suspense fallback={<>🕒</>}>
+              <TestComponent suspend={true} />
+            </React.Suspense>
+          </OpenFeatureTestProvider>,
+        );
+
+        // should initially show fallback, then resolve
+        expect(screen.getByText('🕒')).toBeInTheDocument();
+        await new Promise((resolve) => setTimeout(resolve, delay * 2));
+        expect(screen.getByText('👍')).toBeInTheDocument();
+      });
+    });
+
+    describe('delay zero', () => {
+      it('renders value immediately', async () => {
+        render(
+          <OpenFeatureTestProvider delayMs={0} flagValueMap={{ [FLAG_KEY]: true }}>
+            <React.Suspense fallback={<>🕒</>}>
+              <TestComponent suspend={true} />
+            </React.Suspense>
+          </OpenFeatureTestProvider>,
+        );
+
+        // should resolve immediately since delay is falsy
+        expect(screen.getByText('👍')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/react/test/test.utils.ts
+++ b/packages/react/test/test.utils.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext, InMemoryProvider } from '@openfeature/web-sdk';
+import { InMemoryProvider } from '@openfeature/web-sdk';
 
 export class TestingProvider extends InMemoryProvider {
     constructor(
@@ -9,9 +9,8 @@ export class TestingProvider extends InMemoryProvider {
     }
   
     // artificially delay our init (delaying PROVIDER_READY event)
-    async initialize(context?: EvaluationContext | undefined): Promise<void> {
+    async initialize(): Promise<void> {
       await new Promise((resolve) => setTimeout(resolve, this.delay));
-      return super.initialize(context);
     }
   
     // artificially delay context changes


### PR DESCRIPTION
Fixes an issues with the React `OpenFeatureTestProvider` where the provider was not ready until the next event loop tick when the `flagValueMap` was used.

Also removes the initialization in the client in-memory provider, since it was only doing some un-needed validation inconsistent with the server provider.