### PR TITLE
fix: angular package publish

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -9,7 +9,7 @@
     "test": "jest",
     "build": "ng build && npm run postbuild",
     "postbuild": "shx cp ./../../LICENSE ./dist/angular/LICENSE",
-    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm --prefix dist/angular run current-deployed-version -s)\" = \"$(npm --prefix dist/angular run current-version -s)\" ]; then echo 'already published, skipping'; else npm --prefix dist/angular publish --access public; fi"
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm --prefix dist/angular run current-deployed-version -s)\" = \"$(npm --prefix dist/angular run current-version -s)\" ]; then echo 'already published, skipping'; else cd dist/angular && npm publish --access public; fi"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes publishing of Angular SDK package by not removing the version scripts from the built package.json.
Also fixes SBOM generation by adding the angular subproject to workspaces.
