### PR TITLE
chore: remove experimental from Nest.JS SDK

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,7 +37,8 @@
     },
     "packages/nest": {
       "release-type": "node",
-      "prerelease": true,
+      "release-as": "0.2.2",
+      "prerelease": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["README.md"],


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

As discussed, I propose to remove the experimental from the Nest.JS SDK.
It is used in several orgs and the API works well there.
