### PR TITLE
chore: import type lint rule and fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,14 @@
 		"jsdoc"
 	],
 	"rules": {
+    "@typescript-eslint/consistent-type-imports": [
+       "error",
+       {
+        "disallowTypeAnnotations": true,
+        "fixStyle": "separate-type-imports",
+        "prefer": "type-imports"
+      }
+    ],
 		"jsdoc/require-jsdoc": [
 			"warn",
 			{

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e-web": "git submodule update --init --recursive && shx cp test-harness/features/evaluation.feature packages/web/e2e/features && jest --selectProjects=web-e2e --verbose",
     "e2e": "npm run e2e-server && npm run e2e-web",
     "lint": "npm run lint --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
+    "lint:fix": "npm run lint:fix --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest --fix ",
     "clean": "shx rm -rf ./dist",
     "build": "npm run build --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
     "publish-all": "npm run publish-if-not-exists --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",

--- a/packages/angular/angular.json
+++ b/packages/angular/angular.json
@@ -39,6 +39,7 @@
   "cli": {
     "schematicCollections": [
       "@angular-eslint/schematics"
-    ]
+    ],
+    "analytics": false
   }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "lint": "ng lint",
+    "lint:fix": "ng lint --fix",
     "watch": "ng build --watch --configuration development",
     "test": "jest",
     "build": "ng build && npm run postbuild",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "jest --verbose",
     "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
     "clean": "shx rm -rf ./dist",
     "build:esm": "esbuild src/index.ts --bundle --external:@nestjs/* --external:@openfeature/server-sdk --sourcemap --target=es2015 --platform=node --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:cjs": "esbuild src/index.ts --bundle --external:@nestjs/* --external:@openfeature/server-sdk --sourcemap --target=es2015 --platform=node --format=cjs --outfile=./dist/cjs/index.js --analyze",

--- a/packages/nest/src/context-factory.ts
+++ b/packages/nest/src/context-factory.ts
@@ -1,5 +1,6 @@
-import { EvaluationContext } from '@openfeature/core';
-import { ExecutionContext, Inject } from '@nestjs/common';
+import type { EvaluationContext } from '@openfeature/core';
+import type { ExecutionContext} from '@nestjs/common';
+import { Inject } from '@nestjs/common';
 
 /**
  * A factory function for creating an OpenFeature {@link EvaluationContext} from Nest {@link ExecutionContext}.

--- a/packages/nest/src/evaluation-context-interceptor.ts
+++ b/packages/nest/src/evaluation-context-interceptor.ts
@@ -1,5 +1,7 @@
-import { CallHandler, ExecutionContext, Inject, Injectable, NestInterceptor } from '@nestjs/common';
-import { ContextFactory, ContextFactoryToken } from './context-factory';
+import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import type { ContextFactory} from './context-factory';
+import { ContextFactoryToken } from './context-factory';
 import { Observable } from 'rxjs';
 import { OpenFeature } from '@openfeature/server-sdk';
 import { OpenFeatureModule } from './open-feature.module';

--- a/packages/nest/src/feature.decorator.ts
+++ b/packages/nest/src/feature.decorator.ts
@@ -1,14 +1,16 @@
 import { createParamDecorator, Inject } from '@nestjs/common';
-import {
+import type {
   EvaluationContext,
   EvaluationDetails,
   FlagValue,
-  JsonValue,
+  JsonValue} from '@openfeature/server-sdk';
+import {
   OpenFeature,
   Client,
 } from '@openfeature/server-sdk';
 import { getOpenFeatureClientToken } from './open-feature.module';
-import { from, Observable } from 'rxjs';
+import type { Observable } from 'rxjs';
+import { from } from 'rxjs';
 
 /**
  * Options for injecting an OpenFeature client into a constructor.

--- a/packages/nest/src/open-feature.module.ts
+++ b/packages/nest/src/open-feature.module.ts
@@ -1,24 +1,27 @@
-import {
+import type {
   DynamicModule,
-  Module,
   FactoryProvider as NestFactoryProvider,
   ValueProvider,
   ClassProvider,
-  Provider as NestProvider,
+  Provider as NestProvider} from '@nestjs/common';
+import {
+  Module,
   ExecutionContext,
 } from '@nestjs/common';
-import {
+import type {
   Client,
   Hook,
-  OpenFeature,
   Provider,
   EvaluationContext,
   ServerProviderEvents,
   EventHandler,
-  Logger,
+  Logger} from '@openfeature/server-sdk';
+import {
+  OpenFeature,
   AsyncLocalStorageTransactionContextPropagator,
 } from '@openfeature/server-sdk';
-import { ContextFactory, ContextFactoryToken } from './context-factory';
+import type { ContextFactory} from './context-factory';
+import { ContextFactoryToken } from './context-factory';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { EvaluationContextInterceptor } from './evaluation-context-interceptor';
 import { ShutdownService } from './shutdown.service';

--- a/packages/nest/src/shutdown.service.ts
+++ b/packages/nest/src/shutdown.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+import type { OnApplicationShutdown } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { OpenFeature } from '@openfeature/server-sdk';
 
 @Injectable()

--- a/packages/nest/test/fixtures.ts
+++ b/packages/nest/test/fixtures.ts
@@ -1,5 +1,5 @@
 import { InMemoryProvider } from '@openfeature/server-sdk';
-import { ExecutionContext } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
 import { OpenFeatureModule } from '../src';
 
 export const defaultProvider = new InMemoryProvider({

--- a/packages/nest/test/open-feature-sdk.spec.ts
+++ b/packages/nest/test/open-feature-sdk.spec.ts
@@ -1,5 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
 import supertest from 'supertest';
 import { OpenFeatureController, OpenFeatureControllerContextScopedController, OpenFeatureTestService } from './test-app';
 import { exampleContextFactory, getOpenFeatureDefaultTestModule } from './fixtures';

--- a/packages/nest/test/open-feature.module.spec.ts
+++ b/packages/nest/test/open-feature.module.spec.ts
@@ -1,6 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
 import { getOpenFeatureClientToken, OpenFeatureModule, ServerProviderEvents } from '../src';
-import { Client, OpenFeature } from '@openfeature/server-sdk';
+import type { Client} from '@openfeature/server-sdk';
+import { OpenFeature } from '@openfeature/server-sdk';
 import { getOpenFeatureDefaultTestModule } from './fixtures';
 
 describe('OpenFeatureModule', () => {

--- a/packages/nest/test/test-app.ts
+++ b/packages/nest/test/test-app.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Injectable, UseInterceptors } from '@nestjs/common';
-import { Observable, map } from 'rxjs';
+import type { Observable} from 'rxjs';
+import { map } from 'rxjs';
 import { BooleanFeatureFlag, ObjectFeatureFlag, NumberFeatureFlag, OpenFeatureClient, StringFeatureFlag } from '../src';
-import { Client, EvaluationDetails, FlagValue } from '@openfeature/server-sdk';
+import type { Client, EvaluationDetails, FlagValue } from '@openfeature/server-sdk';
 import { EvaluationContextInterceptor } from '../src';
 
 @Injectable()

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "jest --verbose",
     "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
     "clean": "shx rm -rf ./dist",
     "build:react-esm": "esbuild src/index.ts --bundle  --external:react --external:@openfeature/web-sdk --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:react-cjs": "esbuild src/index.ts --bundle  --external:react --external:@openfeature/web-sdk --sourcemap --target=es2015 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",

--- a/packages/react/src/common/options.ts
+++ b/packages/react/src/common/options.ts
@@ -1,4 +1,4 @@
-import { FlagEvaluationOptions } from '@openfeature/web-sdk';
+import type { FlagEvaluationOptions } from '@openfeature/web-sdk';
 
 export type ReactFlagEvaluationOptions = ({
   /**

--- a/packages/react/src/common/suspense.ts
+++ b/packages/react/src/common/suspense.ts
@@ -1,4 +1,5 @@
-import { Client, ProviderEvents } from '@openfeature/web-sdk';
+import type { Client} from '@openfeature/web-sdk';
+import { ProviderEvents } from '@openfeature/web-sdk';
 
 /**
  * Suspends until the client is ready to evaluate feature flags.

--- a/packages/react/src/evaluation/hook-flag-query.ts
+++ b/packages/react/src/evaluation/hook-flag-query.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   EvaluationDetails,
-  FlagValue,
+  FlagValue} from '@openfeature/web-sdk';
+import {
   StandardResolutionReasons
 } from '@openfeature/web-sdk';
-import { FlagQuery } from '../query';
+import type { FlagQuery } from '../query';
 
 
 // FlagQuery implementation, do not export

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -1,21 +1,23 @@
-import {
+import type {
   Client,
   ClientProviderEvents,
   EvaluationDetails,
   EventHandler,
   FlagEvaluationOptions,
   FlagValue,
-  JsonValue,
+  JsonValue} from '@openfeature/web-sdk';
+import {
   ProviderEvents,
   ProviderStatus,
 } from '@openfeature/web-sdk';
 import { useEffect, useRef, useState } from 'react';
-import { DEFAULT_OPTIONS, ReactFlagEvaluationOptions, normalizeOptions } from '../common/options';
+import type { ReactFlagEvaluationOptions} from '../common/options';
+import { DEFAULT_OPTIONS, normalizeOptions } from '../common/options';
 import { suspendUntilReady } from '../common/suspense';
 import { useProviderOptions } from '../provider/context';
 import { useOpenFeatureClient } from '../provider/use-open-feature-client';
 import { useOpenFeatureClientStatus } from '../provider/use-open-feature-client-status';
-import { FlagQuery } from '../query';
+import type { FlagQuery } from '../query';
 import { HookFlagQuery } from './hook-flag-query';
 import { isEqual } from '../common/is-equal';
 

--- a/packages/react/src/provider/context.ts
+++ b/packages/react/src/provider/context.ts
@@ -1,6 +1,7 @@
-import { Client } from '@openfeature/web-sdk';
+import type { Client } from '@openfeature/web-sdk';
 import React from 'react';
-import { NormalizedOptions, ReactFlagEvaluationOptions, normalizeOptions } from '../common/options';
+import type { NormalizedOptions, ReactFlagEvaluationOptions} from '../common/options';
+import { normalizeOptions } from '../common/options';
 
 /**
  * The underlying React context.

--- a/packages/react/src/provider/provider.tsx
+++ b/packages/react/src/provider/provider.tsx
@@ -1,6 +1,7 @@
-import { Client, OpenFeature } from '@openfeature/web-sdk';
+import type { Client} from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
 import * as React from 'react';
-import { ReactFlagEvaluationOptions } from '../common/options';
+import type { ReactFlagEvaluationOptions } from '../common/options';
 import { Context } from './context';
 
 type ClientOrDomain =

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -1,12 +1,13 @@
+import type {
+  JsonValue,
+  Provider} from '@openfeature/web-sdk';
 import {
   InMemoryProvider,
-  JsonValue,
   NOOP_PROVIDER,
-  OpenFeature,
-  Provider,
+  OpenFeature
 } from '@openfeature/web-sdk';
 import React from 'react';
-import { NormalizedOptions } from '../common/options';
+import type { NormalizedOptions } from '../common/options';
 import { OpenFeatureProvider } from './provider';
 
 type FlagValueMap = { [flagKey: string]: JsonValue };

--- a/packages/react/src/provider/use-open-feature-client-status.ts
+++ b/packages/react/src/provider/use-open-feature-client-status.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useOpenFeatureClient } from './use-open-feature-client';
-import { ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+import type { ProviderStatus } from '@openfeature/web-sdk';
+import { ProviderEvents } from '@openfeature/web-sdk';
 
 /**
  * Get the {@link ProviderStatus} for the OpenFeatureClient.

--- a/packages/react/src/provider/use-open-feature-client.ts
+++ b/packages/react/src/provider/use-open-feature-client.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Context } from './context';
-import { Client } from '@openfeature/web-sdk';
+import type { Client } from '@openfeature/web-sdk';
 
 /**
  * Get the {@link Client} instance for this OpenFeatureProvider context.

--- a/packages/react/src/provider/use-when-provider-ready.ts
+++ b/packages/react/src/provider/use-when-provider-ready.ts
@@ -1,5 +1,6 @@
 import { ProviderStatus } from '@openfeature/web-sdk';
-import { DEFAULT_OPTIONS, ReactFlagEvaluationOptions, normalizeOptions } from '../common/options';
+import type { ReactFlagEvaluationOptions} from '../common/options';
+import { DEFAULT_OPTIONS, normalizeOptions } from '../common/options';
 import { useProviderOptions } from './context';
 import { useOpenFeatureClient } from './use-open-feature-client';
 import { useOpenFeatureClientStatus } from './use-open-feature-client-status';

--- a/packages/react/src/query/query.ts
+++ b/packages/react/src/query/query.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, EvaluationDetails, FlagMetadata, FlagValue, StandardResolutionReasons } from '@openfeature/core';
+import type { ErrorCode, EvaluationDetails, FlagMetadata, FlagValue, StandardResolutionReasons } from '@openfeature/core';
 
 export interface FlagQuery<T extends FlagValue = FlagValue> {
   /**

--- a/packages/react/test/evaluation.spec.tsx
+++ b/packages/react/test/evaluation.spec.tsx
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
-import {
-  ErrorCode,
+import type {
   EvaluationContext,
   EvaluationDetails,
-  Hook,
+  Hook} from '../src/';
+import {
+  ErrorCode,
   InMemoryProvider,
   OpenFeature,
   OpenFeatureProvider,

--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -1,4 +1,5 @@
-import { EvaluationContext, OpenFeature } from '@openfeature/web-sdk';
+import type { EvaluationContext} from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
 import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';

--- a/packages/react/test/test-provider.spec.tsx
+++ b/packages/react/test/test-provider.spec.tsx
@@ -1,4 +1,4 @@
-import { Provider, ResolutionDetails } from '@openfeature/web-sdk';
+import type { Provider, ResolutionDetails } from '@openfeature/web-sdk';
 import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';

--- a/packages/server/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/server/e2e/step-definitions/evaluation.spec.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   EvaluationContext,
   EvaluationDetails,
   JsonObject,
   JsonValue,
-  ResolutionDetails,
+  ResolutionDetails} from '@openfeature/core';
+import {
   StandardResolutionReasons,
 } from '@openfeature/core';
 import { defineFeature, loadFeature } from 'jest-cucumber';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "jest --verbose",
     "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
     "clean": "shx rm -rf ./dist",
     "build:esm": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=node --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:cjs": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=node --format=cjs --outfile=./dist/cjs/index.js --analyze",

--- a/packages/server/src/client/client.ts
+++ b/packages/server/src/client/client.ts
@@ -1,13 +1,13 @@
-import {
+import type {
   ClientMetadata,
   EvaluationLifeCycle,
   Eventing,
   ManageContext,
   ManageLogger,
 } from '@openfeature/core';
-import { Features } from '../evaluation';
-import { ProviderStatus } from '../provider';
-import { ProviderEvents } from '../events';
+import type { Features } from '../evaluation';
+import type { ProviderStatus } from '../provider';
+import type { ProviderEvents } from '../events';
 
 export interface Client
   extends EvaluationLifeCycle<Client>,

--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -1,6 +1,5 @@
-import {
+import type {
   ClientMetadata,
-  ErrorCode,
   EvaluationContext,
   EvaluationDetails,
   EventHandler,
@@ -10,21 +9,24 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
+  ResolutionDetails} from '@openfeature/core';
+import {
+  ErrorCode,
   ProviderFatalError,
   ProviderNotReadyError,
-  ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
   instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
-import { FlagEvaluationOptions } from '../../evaluation';
-import { ProviderEvents } from '../../events';
-import { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
-import { Hook } from '../../hooks';
+import type { FlagEvaluationOptions } from '../../evaluation';
+import type { ProviderEvents } from '../../events';
+import type { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
+import type { Hook } from '../../hooks';
 import { OpenFeature } from '../../open-feature';
-import { Provider, ProviderStatus } from '../../provider';
-import { Client } from './../client';
+import type { Provider} from '../../provider';
+import { ProviderStatus } from '../../provider';
+import type { Client } from './../client';
 
 type OpenFeatureClientOptions = {
   /**

--- a/packages/server/src/evaluation/evaluation.ts
+++ b/packages/server/src/evaluation/evaluation.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext, EvaluationDetails, HookHints, JsonValue } from '@openfeature/core';
-import { Hook } from '../hooks';
+import type { EvaluationContext, EvaluationDetails, HookHints, JsonValue } from '@openfeature/core';
+import type { Hook } from '../hooks';
 
 export interface FlagEvaluationOptions {
   hooks?: Hook[];

--- a/packages/server/src/events/internal/internal-event-emitter.ts
+++ b/packages/server/src/events/internal/internal-event-emitter.ts
@@ -1,5 +1,5 @@
 import { GenericEventEmitter } from '@openfeature/core';
-import { ProviderEvents } from '../events';
+import type { ProviderEvents } from '../events';
 
 /**
  * The InternalEventEmitter is not exported publicly and should only be used within the SDK. It extends the

--- a/packages/server/src/events/open-feature-event-emitter.ts
+++ b/packages/server/src/events/open-feature-event-emitter.ts
@@ -1,6 +1,6 @@
 import { GenericEventEmitter } from '@openfeature/core';
 import { EventEmitter } from 'node:events';
-import { ProviderEvents } from './events';
+import type { ProviderEvents } from './events';
 
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit

--- a/packages/server/src/hooks/hook.ts
+++ b/packages/server/src/hooks/hook.ts
@@ -1,4 +1,4 @@
-import { BaseHook, EvaluationContext, FlagValue } from '@openfeature/core';
+import type { BaseHook, EvaluationContext, FlagValue } from '@openfeature/core';
 
 export type Hook = BaseHook<
   FlagValue,

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -1,22 +1,25 @@
-import {
+import type {
   EvaluationContext,
   ManageContext,
+  ServerProviderStatus} from '@openfeature/core';
+import {
   OpenFeatureCommonAPI,
   ProviderWrapper,
-  ServerProviderStatus,
   objectOrUndefined,
   stringOrUndefined,
 } from '@openfeature/core';
-import { Client } from './client';
+import type { Client } from './client';
 import { OpenFeatureClient } from './client/internal/open-feature-client';
 import { OpenFeatureEventEmitter } from './events';
-import { Hook } from './hooks';
-import { NOOP_PROVIDER, Provider, ProviderStatus } from './provider';
-import {
+import type { Hook } from './hooks';
+import type { Provider} from './provider';
+import { NOOP_PROVIDER, ProviderStatus } from './provider';
+import type {
   ManageTransactionContextPropagator,
-  NOOP_TRANSACTION_CONTEXT_PROPAGATOR,
   TransactionContext,
-  TransactionContextPropagator,
+  TransactionContextPropagator} from './transaction-context';
+import {
+  NOOP_TRANSACTION_CONTEXT_PROPAGATOR
 } from './transaction-context';
 
 // use a symbol as a key for the global singleton

--- a/packages/server/src/provider/in-memory-provider/flag-configuration.ts
+++ b/packages/server/src/provider/in-memory-provider/flag-configuration.ts
@@ -3,7 +3,7 @@
  * It might cause confusion since these types are not a part of the general API,
  * but just for the in-memory provider.
  */
-import { EvaluationContext, JsonValue } from '@openfeature/core';
+import type { EvaluationContext, JsonValue } from '@openfeature/core';
 
 type Variants<T> = Record<string, T>;
 

--- a/packages/server/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/server/src/provider/in-memory-provider/in-memory-provider.ts
@@ -1,17 +1,18 @@
-import {
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValueType,
-  GeneralError,
   JsonValue,
   Logger,
+  ResolutionDetails} from '@openfeature/core';
+import {
+  FlagNotFoundError,
+  GeneralError,
   OpenFeatureError,
-  ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError
 } from '@openfeature/core';
-import { Provider } from '../provider';
-import { Flag, FlagConfiguration } from './flag-configuration';
+import type { Provider } from '../provider';
+import type { Flag, FlagConfiguration } from './flag-configuration';
 import { VariantFoundError } from './variant-not-found-error';
 import { OpenFeatureEventEmitter, ProviderEvents } from '../..';
 

--- a/packages/server/src/provider/no-op-provider.ts
+++ b/packages/server/src/provider/no-op-provider.ts
@@ -1,5 +1,5 @@
-import { JsonValue, ResolutionDetails } from '@openfeature/core';
-import { Provider } from './provider';
+import type { JsonValue, ResolutionDetails } from '@openfeature/core';
+import type { Provider } from './provider';
 
 const REASON_NO_OP = 'No-op';
 

--- a/packages/server/src/provider/provider.ts
+++ b/packages/server/src/provider/provider.ts
@@ -1,5 +1,6 @@
-import { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails, ServerProviderStatus } from '@openfeature/core';
-import { Hook } from '../hooks';
+import type { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails} from '@openfeature/core';
+import { ServerProviderStatus } from '@openfeature/core';
+import type { Hook } from '../hooks';
 
 export { ServerProviderStatus as ProviderStatus };
 

--- a/packages/server/src/transaction-context/async-local-storage-transaction-context-propagator.ts
+++ b/packages/server/src/transaction-context/async-local-storage-transaction-context-propagator.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext } from '@openfeature/core';
-import { TransactionContext, TransactionContextPropagator } from './transaction-context';
+import type { EvaluationContext } from '@openfeature/core';
+import type { TransactionContext, TransactionContextPropagator } from './transaction-context';
 import { AsyncLocalStorage } from 'async_hooks';
 
 export class AsyncLocalStorageTransactionContextPropagator implements TransactionContextPropagator {

--- a/packages/server/src/transaction-context/no-op-transaction-context-propagator.ts
+++ b/packages/server/src/transaction-context/no-op-transaction-context-propagator.ts
@@ -1,5 +1,5 @@
-import { EvaluationContext } from '@openfeature/core';
-import { TransactionContext, TransactionContextPropagator } from './transaction-context';
+import type { EvaluationContext } from '@openfeature/core';
+import type { TransactionContext, TransactionContextPropagator } from './transaction-context';
 
 class NoopTransactionContextPropagator implements TransactionContextPropagator {
   getTransactionContext(): EvaluationContext {

--- a/packages/server/src/transaction-context/transaction-context.ts
+++ b/packages/server/src/transaction-context/transaction-context.ts
@@ -1,4 +1,4 @@
-import { EvaluationContext } from '@openfeature/core';
+import type { EvaluationContext } from '@openfeature/core';
 
 /**
  * Transaction context is a mechanism for adding transaction specific context that

--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -1,26 +1,27 @@
 import { GeneralError } from '@openfeature/core';
-import {
+import type {
   Client,
-  ErrorCode,
   EvaluationContext,
   EvaluationDetails,
-  FlagNotFoundError,
   Hook,
   JsonArray,
   JsonObject,
   JsonValue,
-  OpenFeature,
   Provider,
+  ResolutionDetails,
+  TransactionContext,
+  TransactionContextPropagator} from '../src';
+import {
+  ErrorCode,
+  FlagNotFoundError,
+  OpenFeature,
   ProviderFatalError,
   ProviderStatus,
-  ResolutionDetails,
-  StandardResolutionReasons,
-  TransactionContext,
-  TransactionContextPropagator,
+  StandardResolutionReasons
 } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 import { isDeepStrictEqual } from 'node:util';
-import { HookContext } from '@openfeature/core';
+import type { HookContext } from '@openfeature/core';
 
 const BOOLEAN_VALUE = true;
 const STRING_VALUE = 'val';

--- a/packages/server/test/evaluation-context.spec.ts
+++ b/packages/server/test/evaluation-context.spec.ts
@@ -1,4 +1,5 @@
-import { EvaluationContext, OpenFeature } from '../src';
+import type { EvaluationContext} from '../src';
+import { OpenFeature } from '../src';
 
 describe('Evaluation Context', () => {
   afterEach(async () => {

--- a/packages/server/test/events.spec.ts
+++ b/packages/server/test/events.spec.ts
@@ -1,15 +1,17 @@
 import { v4 as uuid } from 'uuid';
-import {
+import type {
   JsonValue,
+  Provider,
+  ProviderMetadata,
+  ResolutionDetails,
+  StaleEvent
+} from '../src';
+import {
   NOOP_PROVIDER,
   OpenFeature,
   OpenFeatureEventEmitter,
-  Provider,
   ProviderEvents,
-  ProviderMetadata,
-  ProviderStatus,
-  ResolutionDetails,
-  StaleEvent
+  ProviderStatus
 } from '../src';
 
 const TIMEOUT = 1000;

--- a/packages/server/test/hooks.spec.ts
+++ b/packages/server/test/hooks.spec.ts
@@ -1,11 +1,12 @@
-import {
-  OpenFeature,
+import type {
   Provider,
   ResolutionDetails,
   Client,
   FlagValueType,
   EvaluationContext,
-  Hook,
+  Hook} from '../src';
+import {
+  OpenFeature,
   StandardResolutionReasons,
   ErrorCode,
 } from '../src';

--- a/packages/server/test/logger.spec.ts
+++ b/packages/server/test/logger.spec.ts
@@ -1,4 +1,5 @@
-import { OpenFeature, BaseHook, Logger, Provider, DefaultLogger, SafeLogger } from '../src';
+import type { BaseHook, Logger, Provider} from '../src';
+import { OpenFeature, DefaultLogger, SafeLogger } from '../src';
 
 class MockedLogger implements Logger {
   error = jest.fn();

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -1,5 +1,6 @@
-import { Paradigm } from '@openfeature/core';
-import { OpenFeature, OpenFeatureAPI, Provider, ProviderStatus } from '../src';
+import type { Paradigm } from '@openfeature/core';
+import type { Provider, ProviderStatus } from '../src';
+import { OpenFeature, OpenFeatureAPI } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "test": "jest --verbose",
     "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
     "clean": "shx rm -rf ./dist",
     "type": "tsc --project ./tsconfig.json --declaration --emitDeclarationOnly",
     "build:esm": "esbuild src/index.ts --bundle --external:events --sourcemap --target=es2015 --format=esm --outfile=./dist/esm/index.js --analyze",

--- a/packages/shared/src/client/client.ts
+++ b/packages/shared/src/client/client.ts
@@ -1,4 +1,4 @@
-import { ProviderMetadata } from '../provider/provider';
+import type { ProviderMetadata } from '../provider/provider';
 
 export interface ClientMetadata {
   /**

--- a/packages/shared/src/errors/flag-not-found-error.ts
+++ b/packages/shared/src/errors/flag-not-found-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class FlagNotFoundError extends OpenFeatureError {

--- a/packages/shared/src/errors/general-error.ts
+++ b/packages/shared/src/errors/general-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class GeneralError extends OpenFeatureError {

--- a/packages/shared/src/errors/invalid-context-error.ts
+++ b/packages/shared/src/errors/invalid-context-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class InvalidContextError extends OpenFeatureError {

--- a/packages/shared/src/errors/open-feature-error-abstract.ts
+++ b/packages/shared/src/errors/open-feature-error-abstract.ts
@@ -1,4 +1,4 @@
-import { ErrorCode } from '../evaluation';
+import type { ErrorCode } from '../evaluation';
 
 /**
  * Error Options were added in ES2022. Manually adding the type so that an

--- a/packages/shared/src/errors/parse-error.ts
+++ b/packages/shared/src/errors/parse-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class ParseError extends OpenFeatureError {

--- a/packages/shared/src/errors/provider-fatal-error.ts
+++ b/packages/shared/src/errors/provider-fatal-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class ProviderFatalError extends OpenFeatureError {

--- a/packages/shared/src/errors/provider-not-ready-error.ts
+++ b/packages/shared/src/errors/provider-not-ready-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class ProviderNotReadyError extends OpenFeatureError {

--- a/packages/shared/src/errors/targeting-key-missing-error.ts
+++ b/packages/shared/src/errors/targeting-key-missing-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class TargetingKeyMissingError extends OpenFeatureError {

--- a/packages/shared/src/errors/type-mismatch-error.ts
+++ b/packages/shared/src/errors/type-mismatch-error.ts
@@ -1,4 +1,5 @@
-import { ErrorOptions, OpenFeatureError } from './open-feature-error-abstract';
+import type { ErrorOptions} from './open-feature-error-abstract';
+import { OpenFeatureError } from './open-feature-error-abstract';
 import { ErrorCode } from '../evaluation';
 
 export class TypeMismatchError extends OpenFeatureError {

--- a/packages/shared/src/evaluation/context.ts
+++ b/packages/shared/src/evaluation/context.ts
@@ -1,4 +1,4 @@
-import { PrimitiveValue } from './evaluation';
+import type { PrimitiveValue } from './evaluation';
 
 export type EvaluationContextValue =
   | PrimitiveValue

--- a/packages/shared/src/events/event-utils.ts
+++ b/packages/shared/src/events/event-utils.ts
@@ -1,5 +1,7 @@
-import { AllProviderStatus, ClientProviderStatus, ServerProviderStatus } from '../provider';
-import { AllProviderEvents, AnyProviderEvent } from './events';
+import type { ClientProviderStatus, ServerProviderStatus } from '../provider';
+import { AllProviderStatus } from '../provider';
+import type { AnyProviderEvent } from './events';
+import { AllProviderEvents } from './events';
 
 const eventStatusMap = {
     [AllProviderStatus.READY]: AllProviderEvents.Ready,

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -1,5 +1,6 @@
-import { ErrorCode } from '../evaluation';
-import { ClientProviderEvents, ServerProviderEvents, AnyProviderEvent } from './events';
+import type { ErrorCode } from '../evaluation';
+import type { ClientProviderEvents, ServerProviderEvents} from './events';
+import { AnyProviderEvent } from './events';
 
 export type EventMetadata = {
   [key: string]: string | boolean | number;

--- a/packages/shared/src/events/generic-event-emitter.ts
+++ b/packages/shared/src/events/generic-event-emitter.ts
@@ -1,7 +1,9 @@
-import { Logger, ManageLogger, SafeLogger } from '../logger';
-import { ProviderEventEmitter } from './provider-event-emitter';
-import { EventContext, EventDetails, EventHandler } from './eventing';
-import { AllProviderEvents, AnyProviderEvent } from './events';
+import type { Logger, ManageLogger} from '../logger';
+import { SafeLogger } from '../logger';
+import type { ProviderEventEmitter } from './provider-event-emitter';
+import type { EventContext, EventDetails, EventHandler } from './eventing';
+import type { AnyProviderEvent } from './events';
+import { AllProviderEvents } from './events';
 
 /**
  * The GenericEventEmitter should only be used within the SDK. It supports additional properties that can be included

--- a/packages/shared/src/events/provider-event-emitter.ts
+++ b/packages/shared/src/events/provider-event-emitter.ts
@@ -1,6 +1,6 @@
-import { ManageLogger } from '../logger';
-import { EventContext, EventHandler } from './eventing';
-import { AnyProviderEvent } from './events';
+import type { ManageLogger } from '../logger';
+import type { EventContext, EventHandler } from './eventing';
+import type { AnyProviderEvent } from './events';
 
 /**
  * Event emitter to be optionally implemented by providers.

--- a/packages/shared/src/hooks/evaluation-lifecycle.ts
+++ b/packages/shared/src/hooks/evaluation-lifecycle.ts
@@ -1,4 +1,4 @@
-import { BaseHook } from './hook';
+import type { BaseHook } from './hook';
 
 export interface EvaluationLifeCycle<T> {
   /**

--- a/packages/shared/src/hooks/hook.ts
+++ b/packages/shared/src/hooks/hook.ts
@@ -1,5 +1,5 @@
-import { BeforeHookContext, HookContext, HookHints } from './hooks';
-import { EvaluationDetails, FlagValue } from '../evaluation';
+import type { BeforeHookContext, HookContext, HookHints } from './hooks';
+import type { EvaluationDetails, FlagValue } from '../evaluation';
 
 export interface BaseHook<T extends FlagValue = FlagValue, BeforeHookReturn = unknown, HooksReturn = unknown> {
   /**

--- a/packages/shared/src/hooks/hooks.ts
+++ b/packages/shared/src/hooks/hooks.ts
@@ -1,7 +1,7 @@
-import { ProviderMetadata } from '../provider';
-import { ClientMetadata } from '../client';
-import { EvaluationContext, FlagValue, FlagValueType } from '../evaluation';
-import { Logger } from '../logger';
+import type { ProviderMetadata } from '../provider';
+import type { ClientMetadata } from '../client';
+import type { EvaluationContext, FlagValue, FlagValueType } from '../evaluation';
+import type { Logger } from '../logger';
 
 export type HookHints = Readonly<Record<string, unknown>>;
 

--- a/packages/shared/src/logger/default-logger.ts
+++ b/packages/shared/src/logger/default-logger.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { Logger } from './logger';
+import type { Logger } from './logger';
 
 export class DefaultLogger implements Logger {
   error(...args: unknown[]): void {

--- a/packages/shared/src/logger/safe-logger.ts
+++ b/packages/shared/src/logger/safe-logger.ts
@@ -1,4 +1,4 @@
-import { Logger } from './logger';
+import type { Logger } from './logger';
 import { DefaultLogger } from './default-logger';
 
 export const LOG_LEVELS: Array<keyof Logger> = ['error', 'warn', 'info', 'debug'];

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -1,20 +1,24 @@
-import { GeneralError, OpenFeatureError } from './errors';
-import { ErrorCode, EvaluationContext } from './evaluation';
-import {
-  AllProviderEvents,
+import type { OpenFeatureError } from './errors';
+import { GeneralError } from './errors';
+import type { EvaluationContext } from './evaluation';
+import { ErrorCode } from './evaluation';
+import type {
   AnyProviderEvent,
   EventDetails,
   EventHandler,
   Eventing,
-  GenericEventEmitter,
+  GenericEventEmitter} from './events';
+import {
+  AllProviderEvents,
   statusMatchesEvent,
 } from './events';
 import { isDefined } from './filter';
-import { BaseHook, EvaluationLifeCycle } from './hooks';
-import { DefaultLogger, Logger, ManageLogger, SafeLogger } from './logger';
-import { ClientProviderStatus, CommonProvider, ProviderMetadata, ServerProviderStatus } from './provider';
+import type { BaseHook, EvaluationLifeCycle } from './hooks';
+import type { Logger, ManageLogger} from './logger';
+import { DefaultLogger, SafeLogger } from './logger';
+import type { ClientProviderStatus, CommonProvider, ProviderMetadata, ServerProviderStatus } from './provider';
 import { objectOrUndefined, stringOrUndefined } from './type-guards';
-import { Paradigm } from './types';
+import type { Paradigm } from './types';
 
 type AnyProviderStatus = ClientProviderStatus | ServerProviderStatus;
 

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -1,6 +1,6 @@
-import { EvaluationContext } from '../evaluation';
-import { AnyProviderEvent, ProviderEventEmitter } from '../events';
-import { Metadata, Paradigm } from '../types';
+import type { EvaluationContext } from '../evaluation';
+import type { AnyProviderEvent, ProviderEventEmitter } from '../events';
+import type { Metadata, Paradigm } from '../types';
 
 // TODO: with TypeScript 5+, we can use computed string properties,
 // so we can extract all of these into a shared set of string consts and use that in both enums

--- a/packages/shared/test/events.spec.ts
+++ b/packages/shared/test/events.spec.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
-import { GenericEventEmitter, Logger, AllProviderEvents, ReadyEvent, AnyProviderEvent } from '../src';
+import type { Logger, ReadyEvent, AnyProviderEvent } from '../src';
+import { GenericEventEmitter, AllProviderEvents } from '../src';
 
 // create concrete class to test the abstract functionality.
 class TestEventEmitter extends GenericEventEmitter<AnyProviderEvent> {

--- a/packages/web/e2e/step-definitions/evaluation.spec.ts
+++ b/packages/web/e2e/step-definitions/evaluation.spec.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   EvaluationContext,
   EvaluationDetails,
   JsonObject,
   JsonValue,
-  ResolutionDetails,
+  ResolutionDetails} from '@openfeature/core';
+import {
   StandardResolutionReasons,
 } from '@openfeature/core';
 import { defineFeature, loadFeature } from 'jest-cucumber';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "jest --verbose",
     "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
     "clean": "shx rm -rf ./dist",
     "build:web-esm": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:web-cjs": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",

--- a/packages/web/src/client/client.ts
+++ b/packages/web/src/client/client.ts
@@ -1,7 +1,7 @@
-import { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger } from '@openfeature/core';
-import { Features } from '../evaluation';
-import { ProviderStatus } from '../provider';
-import { ProviderEvents } from '../events';
+import type { ClientMetadata, EvaluationLifeCycle, Eventing, ManageLogger } from '@openfeature/core';
+import type { Features } from '../evaluation';
+import type { ProviderStatus } from '../provider';
+import type { ProviderEvents } from '../events';
 
 export interface Client extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing<ProviderEvents> {
   readonly metadata: ClientMetadata;

--- a/packages/web/src/client/internal/open-feature-client.ts
+++ b/packages/web/src/client/internal/open-feature-client.ts
@@ -1,6 +1,5 @@
-import {
+import type {
   ClientMetadata,
-  ErrorCode,
   EvaluationContext,
   EvaluationDetails,
   EventHandler,
@@ -10,21 +9,24 @@ import {
   JsonValue,
   Logger,
   OpenFeatureError,
+  ResolutionDetails} from '@openfeature/core';
+import {
+  ErrorCode,
   ProviderFatalError,
   ProviderNotReadyError,
-  ResolutionDetails,
   SafeLogger,
   StandardResolutionReasons,
   instantiateErrorByErrorCode,
   statusMatchesEvent,
 } from '@openfeature/core';
-import { FlagEvaluationOptions } from '../../evaluation';
-import { ProviderEvents } from '../../events';
-import { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
-import { Hook } from '../../hooks';
+import type { FlagEvaluationOptions } from '../../evaluation';
+import type { ProviderEvents } from '../../events';
+import type { InternalEventEmitter } from '../../events/internal/internal-event-emitter';
+import type { Hook } from '../../hooks';
 import { OpenFeature } from '../../open-feature';
-import { Provider, ProviderStatus } from '../../provider';
-import { Client } from './../client';
+import type { Provider} from '../../provider';
+import { ProviderStatus } from '../../provider';
+import type { Client } from './../client';
 
 type OpenFeatureClientOptions = {
   /**

--- a/packages/web/src/evaluation/evaluation.ts
+++ b/packages/web/src/evaluation/evaluation.ts
@@ -1,4 +1,4 @@
-import { EvaluationDetails, BaseHook, HookHints, JsonValue } from '@openfeature/core';
+import type { EvaluationDetails, BaseHook, HookHints, JsonValue } from '@openfeature/core';
 
 export interface FlagEvaluationOptions {
   hooks?: BaseHook[];

--- a/packages/web/src/events/internal/internal-event-emitter.ts
+++ b/packages/web/src/events/internal/internal-event-emitter.ts
@@ -1,5 +1,6 @@
-import { CommonEventDetails, GenericEventEmitter } from '@openfeature/core';
-import { ProviderEvents } from '../events';
+import type { CommonEventDetails} from '@openfeature/core';
+import { GenericEventEmitter } from '@openfeature/core';
+import type { ProviderEvents } from '../events';
 
 /**
  * The InternalEventEmitter is not exported publicly and should only be used within the SDK. It extends the

--- a/packages/web/src/events/open-feature-event-emitter.ts
+++ b/packages/web/src/events/open-feature-event-emitter.ts
@@ -1,6 +1,6 @@
 import { GenericEventEmitter } from '@openfeature/core';
 import { EventEmitter } from 'eventemitter3';
-import { ProviderEmittableEvents } from './events';
+import type { ProviderEmittableEvents } from './events';
 
 /**
  * The OpenFeatureEventEmitter can be used by provider developers to emit

--- a/packages/web/src/hooks/hook.ts
+++ b/packages/web/src/hooks/hook.ts
@@ -1,3 +1,3 @@
-import { BaseHook, FlagValue } from '@openfeature/core';
+import type { BaseHook, FlagValue } from '@openfeature/core';
 
 export type Hook = BaseHook<FlagValue, void, void>;

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -1,18 +1,20 @@
-import {
+import type {
   ClientProviderStatus,
   EvaluationContext,
   GenericEventEmitter,
-  ManageContext,
+  ManageContext} from '@openfeature/core';
+import {
   OpenFeatureCommonAPI,
   ProviderWrapper,
   objectOrUndefined,
   stringOrUndefined,
 } from '@openfeature/core';
-import { Client } from './client';
+import type { Client } from './client';
 import { OpenFeatureClient } from './client/internal/open-feature-client';
 import { OpenFeatureEventEmitter, ProviderEvents } from './events';
-import { Hook } from './hooks';
-import { NOOP_PROVIDER, Provider, ProviderStatus } from './provider';
+import type { Hook } from './hooks';
+import type { Provider} from './provider';
+import { NOOP_PROVIDER, ProviderStatus } from './provider';
 
 // use a symbol as a key for the global singleton
 const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');

--- a/packages/web/src/provider/in-memory-provider/flag-configuration.ts
+++ b/packages/web/src/provider/in-memory-provider/flag-configuration.ts
@@ -3,7 +3,7 @@
  * It might cause confusion since these types are not a part of the general API,
  * but just for the in-memory provider.
  */
-import { EvaluationContext, JsonValue } from '@openfeature/core';
+import type { EvaluationContext, JsonValue } from '@openfeature/core';
 
 type Variants<T> = Record<string, T>;
 

--- a/packages/web/src/provider/in-memory-provider/in-memory-provider.ts
+++ b/packages/web/src/provider/in-memory-provider/in-memory-provider.ts
@@ -1,18 +1,19 @@
-import {
+import type {
   EvaluationContext,
-  FlagNotFoundError,
   FlagValueType,
-  GeneralError,
   JsonValue,
   Logger,
+  ResolutionDetails} from '@openfeature/core';
+import {
+  FlagNotFoundError,
+  GeneralError,
   OpenFeatureError,
-  ResolutionDetails,
   StandardResolutionReasons,
   TypeMismatchError,
 } from '@openfeature/core';
-import { Provider } from '../provider';
+import type { Provider } from '../provider';
 import { OpenFeatureEventEmitter, ProviderEvents } from '../../events';
-import { FlagConfiguration, Flag } from './flag-configuration';
+import type { FlagConfiguration, Flag } from './flag-configuration';
 import { VariantNotFoundError } from './variant-not-found-error';
 
 /**

--- a/packages/web/src/provider/no-op-provider.ts
+++ b/packages/web/src/provider/no-op-provider.ts
@@ -1,5 +1,5 @@
-import { JsonValue, ResolutionDetails } from '@openfeature/core';
-import { Provider } from './provider';
+import type { JsonValue, ResolutionDetails } from '@openfeature/core';
+import type { Provider } from './provider';
 
 const REASON_NO_OP = 'No-op';
 

--- a/packages/web/src/provider/provider.ts
+++ b/packages/web/src/provider/provider.ts
@@ -1,5 +1,6 @@
-import { ClientProviderStatus, CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/core';
-import { Hook } from '../hooks';
+import type { CommonProvider, EvaluationContext, JsonValue, Logger, ResolutionDetails } from '@openfeature/core';
+import { ClientProviderStatus } from '@openfeature/core';
+import type { Hook } from '../hooks';
 
 export { ClientProviderStatus as ProviderStatus };
 

--- a/packages/web/test/client.spec.ts
+++ b/packages/web/test/client.spec.ts
@@ -1,17 +1,18 @@
-import {
+import type {
   Client,
-  ErrorCode,
   EvaluationDetails,
-  FlagNotFoundError,
-  GeneralError,
   JsonArray,
   JsonObject,
   JsonValue,
-  OpenFeature,
   Provider,
+  ResolutionDetails} from '../src';
+import {
+  ErrorCode,
+  FlagNotFoundError,
+  GeneralError,
+  OpenFeature,
   ProviderFatalError,
   ProviderStatus,
-  ResolutionDetails,
   StandardResolutionReasons,
 } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';

--- a/packages/web/test/evaluation-context.spec.ts
+++ b/packages/web/test/evaluation-context.spec.ts
@@ -1,4 +1,5 @@
-import { EvaluationContext, JsonValue, OpenFeature, Provider, ProviderMetadata, ResolutionDetails } from '../src';
+import type { EvaluationContext, JsonValue, Provider, ProviderMetadata, ResolutionDetails } from '../src';
+import { OpenFeature } from '../src';
 
 const initializeMock = jest.fn();
 

--- a/packages/web/test/events.spec.ts
+++ b/packages/web/test/events.spec.ts
@@ -1,16 +1,18 @@
-import { EventDetails } from '@openfeature/core';
+import type { EventDetails } from '@openfeature/core';
 import { v4 as uuid } from 'uuid';
-import {
+import type {
   JsonValue,
+  Provider,
+  ProviderMetadata,
+  ResolutionDetails,
+  StaleEvent
+} from '../src';
+import {
   NOOP_PROVIDER,
   OpenFeature,
   OpenFeatureEventEmitter,
-  Provider,
   ProviderEvents,
-  ProviderMetadata,
-  ProviderStatus,
-  ResolutionDetails,
-  StaleEvent
+  ProviderStatus
 } from '../src';
 
 const TIMEOUT = 1000;

--- a/packages/web/test/hooks.spec.ts
+++ b/packages/web/test/hooks.spec.ts
@@ -1,12 +1,13 @@
-import {
+import type {
   Provider,
   ResolutionDetails,
   Client,
   FlagValueType,
   EvaluationContext,
+  Hook} from '../src';
+import {
   GeneralError,
   OpenFeature,
-  Hook,
   StandardResolutionReasons,
   ErrorCode,
 } from '../src';

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -1,5 +1,6 @@
-import { Paradigm } from '@openfeature/core';
-import { OpenFeature, OpenFeatureAPI, Provider, ProviderStatus } from '../src';
+import type { Paradigm } from '@openfeature/core';
+import type { Provider} from '../src';
+import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {


### PR DESCRIPTION
Inspired by [this comment](https://github.com/open-feature/js-sdk/pull/1020#discussion_r1777829664) I've added a lint rule to enforce `import type`, and some additional package changes to add a `lint:fix`.

The only changes I made manually here is to add the lint rule, and the package.json script. All the changes are auto-generated by the `lint:fix`.