### PR TITLE
chore: bump minimum web peer

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/web-sdk": "^1.2.2",
+    "@openfeature/web-sdk": "^1.3.0",
     "react": ">=16.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- require web 1.3.0+ for tracking