### PR TITLE
fix: update OpenFeature core version to 1.5.0

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/core": "1.4.0"
+    "@openfeature/core": "1.5.0"
   },
   "devDependencies": {
     "@openfeature/core": "1.5.0"


### PR DESCRIPTION
## This PR

- bumps OpenFeature core version to match the current release

### Notes

This should have been automatically by the CI but it didn't work for some reason. I'll look into why after the issue is resolved.

https://github.com/open-feature/js-sdk/commit/fe3ad8eeb9219ff08ba287cab228016da0b88e88#diff-e35631c960979816b4b2bda7950788e968930fcaf2cf39b482ff23117cd13888R50
