### PR TITLE
ci: add provenance statement to released artifacts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          # https://docs.npmjs.com/generating-provenance-statements
+          NPM_CONFIG_PROVENANCE: true
         run: npm run publish-all
 
       - name: Build Docs


### PR DESCRIPTION
## This PR

- add provenance statement to released artifacts 

### Notes

Snippet from the NPM docs:

> You can generate provenance statements for the packages you publish. This allows you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages.

It also adds a cool badge in NPM 😎 

### Resources

- https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow