### PR TITLE
feat: re-render if flagsChanged is falsy

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -233,13 +233,16 @@ function Page() {
 }
 ```
 
-Note that if your provider doesn't support updates, this configuration has no impact.
+If your provider doesn't support updates, this configuration has no impact.
+
+> [!NOTE]
+> If your provider includes a list of [flags changed](https://open-feature.github.io/js-sdk/types/_openfeature_server_sdk.ConfigChangeEvent.html) in its `PROVIDER_CONFIGURATION_CHANGED` event, that list of flags is used to decide which flag evaluation hooks should re-run by diffing the latest value of these flags with the previous render.
+> If your provider event does not the include the `flags changed` list, then the SDK diffs all flags with the previous render to determine which hooks should re-run.
 
 #### Suspense Support
 
 > [!NOTE]
 > React suspense is an experimental feature and is subject to change in future versions.
-
 
 Frequently, providers need to perform some initial startup tasks.
 It may be desirable not to display components with feature flags until this is complete or when the context changes.

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -267,7 +267,8 @@ export function useObjectFlagDetails<T extends JsonValue = JsonValue>(
 
 // determines if a flag should be re-evaluated based on a list of changed flags
 function shouldEvaluateFlag(flagKey: string, flagsChanged?: string[]): boolean {
-  return !!flagsChanged && flagsChanged.includes(flagKey);
+  // if flagsChange is missing entirely, we don't know what to re-render
+  return !flagsChanged || flagsChanged.includes(flagKey);
 }
 
 function attachHandlersAndResolve<T extends FlagValue>(


### PR DESCRIPTION
Adds an improvement to the React SDK which supports re-renders if the [flags changed](https://open-feature.github.io/js-sdk/types/_openfeature_server_sdk.ConfigChangeEvent.html) array from a provider event is falsy.

Since some providers have no knowledge of flags which are changed, this allows them to support dynamic re-rendering by not defining this property. If the prop is null/undefined, we diff all flags... If the property is explicitly set to an empty array, that means no flags have changed and the React SDK skips all diff checks.