### PR TITLE
ci: add node 22 to test matrix

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -18,6 +18,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
+          - 22.x
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## This PR

- adds node 22 to the test matrix

### Notes

Node 22 is the current active LTS version. We still should target Node 18 but test Node 22.
