### PR TITLE
fix: msg missing when providers return err resolutions

### DIFF
--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -298,7 +298,7 @@ export class OpenFeatureClient implements Client {
       };
 
       if (resolutionDetails.errorCode) {
-        const err = instantiateErrorByErrorCode(resolutionDetails.errorCode);
+        const err = instantiateErrorByErrorCode(resolutionDetails.errorCode, resolutionDetails.errorMessage);
         await this.errorHooks(allHooksReversed, hookContext, err, options);
         evaluationDetails = this.getErrorEvaluationDetails(flagKey, defaultValue, err, resolutionDetails.flagMetadata);
       } else {

--- a/packages/web/src/client/internal/open-feature-client.ts
+++ b/packages/web/src/client/internal/open-feature-client.ts
@@ -253,7 +253,7 @@ export class OpenFeatureClient implements Client {
       };
 
       if (resolutionDetails.errorCode) {
-        const err = instantiateErrorByErrorCode(resolutionDetails.errorCode);
+        const err = instantiateErrorByErrorCode(resolutionDetails.errorCode, resolutionDetails.errorMessage);
         this.errorHooks(allHooksReversed, hookContext, err, options);
         evaluationDetails = this.getErrorEvaluationDetails(flagKey, defaultValue, err, resolutionDetails.flagMetadata);
       } else {


### PR DESCRIPTION
Fixes an issue where the error message was lost if a provider returned a resolution which had an error code (instead of throwing).

Frankly I don't think testing this is worth it. I debating making the second arg to this function `message: string | undefined` instead of `message?: string` (which would force a second arg to be set) but that would be breaking and we'd need to release a core v2 to avoid possible tsc issues in consumers, which I don't think is worth it ether.