### PR TITLE
chore(angular): update angular package to a non-experimental version

### DIFF
--- a/packages/angular/projects/angular-sdk/package.json
+++ b/packages/angular/projects/angular-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfeature/angular-sdk",
-  "version": "0.0.9-experimental",
+  "version": "0.0.10",
   "description": "OpenFeature Angular SDK",
   "repository": {
     "type": "git",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,7 +29,7 @@
     },
     "packages/angular/projects/angular-sdk": {
       "release-type": "node",
-      "prerelease": true,
+      "prerelease": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["README.md"],


### PR DESCRIPTION
Release Angular SDK as non-experimental version as described in #1110 

Release-As: 0.0.10

Fixes #1110 
