### PR TITLE
feat: add support for abort controllers to event handlers

### DIFF
--- a/packages/react/src/provider/use-open-feature-client-status.ts
+++ b/packages/react/src/provider/use-open-feature-client-status.ts
@@ -10,22 +10,18 @@ import { ProviderEvents } from '@openfeature/web-sdk';
 export function useOpenFeatureClientStatus(): ProviderStatus {
   const client = useOpenFeatureClient();
   const [status, setStatus] = useState<ProviderStatus>(client.providerStatus);
+  const controller = new AbortController();
 
   useEffect(() => {
     const updateStatus = () => setStatus(client.providerStatus);
-    client.addHandler(ProviderEvents.ConfigurationChanged, updateStatus);
-    client.addHandler(ProviderEvents.ContextChanged, updateStatus);
-    client.addHandler(ProviderEvents.Error, updateStatus);
-    client.addHandler(ProviderEvents.Ready, updateStatus);
-    client.addHandler(ProviderEvents.Stale, updateStatus);
-    client.addHandler(ProviderEvents.Reconciling, updateStatus);
+    client.addHandler(ProviderEvents.ConfigurationChanged, updateStatus, { signal: controller.signal });
+    client.addHandler(ProviderEvents.ContextChanged, updateStatus, { signal: controller.signal });
+    client.addHandler(ProviderEvents.Error, updateStatus, { signal: controller.signal });
+    client.addHandler(ProviderEvents.Ready, updateStatus, { signal: controller.signal });
+    client.addHandler(ProviderEvents.Stale, updateStatus, { signal: controller.signal });
+    client.addHandler(ProviderEvents.Reconciling, updateStatus, { signal: controller.signal });
     return () => {
-      client.removeHandler(ProviderEvents.ConfigurationChanged, updateStatus);
-      client.removeHandler(ProviderEvents.ContextChanged, updateStatus);
-      client.removeHandler(ProviderEvents.Error, updateStatus);
-      client.removeHandler(ProviderEvents.Ready, updateStatus);
-      client.removeHandler(ProviderEvents.Stale, updateStatus);
-      client.removeHandler(ProviderEvents.Reconciling, updateStatus);
+      controller.abort();
     };
   }, [client]);
 

--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -12,6 +12,7 @@ import type {
   OpenFeatureError,
   FlagMetadata,
   ResolutionDetails,
+  EventOptions,
 } from '@openfeature/core';
 import {
   ErrorCode,
@@ -79,7 +80,7 @@ export class OpenFeatureClient implements Client {
     return this.providerStatusAccessor();
   }
 
-  addHandler(eventType: ProviderEvents, handler: EventHandler): void {
+  addHandler(eventType: ProviderEvents, handler: EventHandler, options?: EventOptions): void {
     this.emitterAccessor().addHandler(eventType, handler);
     const shouldRunNow = statusMatchesEvent(eventType, this._providerStatus);
 
@@ -94,6 +95,12 @@ export class OpenFeatureClient implements Client {
       } catch (err) {
         this._logger?.error('Error running event handler:', err);
       }
+    }
+
+    if (options?.signal && typeof options.signal.addEventListener === 'function') {
+      options.signal.addEventListener('abort', () => {
+        this.removeHandler(eventType, handler);
+      });
     }
   }
 

--- a/packages/server/test/events.spec.ts
+++ b/packages/server/test/events.spec.ts
@@ -449,7 +449,21 @@ describe('Events', () => {
       expect(OpenFeature.getHandlers(eventType)).toHaveLength(0);
     });
 
-    it('The API provides a function allowing the removal of event handlers', () => {
+    it('The event handler can be removed using an abort signal', () => {
+      const abortController = new AbortController();
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const eventType = ProviderEvents.Stale;
+
+      OpenFeature.addHandler(eventType, handler1, { signal: abortController.signal });
+      OpenFeature.addHandler(eventType, handler2);
+      expect(OpenFeature.getHandlers(eventType)).toHaveLength(2);
+
+      abortController.abort();
+      expect(OpenFeature.getHandlers(eventType)).toHaveLength(1);
+    });
+
+    it('The API provides a function allowing the removal of event handlers from client', () => {
       const client = OpenFeature.getClient(domain);
       const handler = jest.fn();
       const eventType = ProviderEvents.Stale;
@@ -458,6 +472,21 @@ describe('Events', () => {
       expect(client.getHandlers(eventType)).toHaveLength(1);
       client.removeHandler(eventType, handler);
       expect(client.getHandlers(eventType)).toHaveLength(0);
+    });
+
+    it('The event handler on the client can be removed using an abort signal', () => {
+      const abortController = new AbortController();
+      const client = OpenFeature.getClient(domain);
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const eventType = ProviderEvents.Stale;
+
+      client.addHandler(eventType, handler1, { signal: abortController.signal });
+      client.addHandler(eventType, handler2);
+      expect(client.getHandlers(eventType)).toHaveLength(2);
+
+      abortController.abort();
+      expect(client.getHandlers(eventType)).toHaveLength(1);
     });
   });
 

--- a/packages/shared/src/events/eventing.ts
+++ b/packages/shared/src/events/eventing.ts
@@ -66,6 +66,9 @@ export type EventDetails<
 export type EventHandler<
   T extends ServerProviderEvents | ClientProviderEvents = ServerProviderEvents | ClientProviderEvents,
 > = (eventDetails?: EventDetails<T>) => Promise<unknown> | unknown;
+export type EventOptions = {
+  signal?: AbortSignal;
+};
 
 export interface Eventing<T extends ServerProviderEvents | ClientProviderEvents> {
   /**
@@ -73,6 +76,7 @@ export interface Eventing<T extends ServerProviderEvents | ClientProviderEvents>
    * The handlers are called in the order they have been added.
    * @param eventType The provider event type to listen to
    * @param {EventHandler} handler The handler to run on occurrence of the event type
+   * @param {EventOptions} options Optional options such as signal for aborting
    */
   addHandler(
     eventType: T extends ClientProviderEvents
@@ -83,14 +87,17 @@ export interface Eventing<T extends ServerProviderEvents | ClientProviderEvents>
         ? ClientProviderEvents.ConfigurationChanged
         : ServerProviderEvents.ConfigurationChanged
     >,
+    options?: EventOptions,
   ): void;
   addHandler(
     eventType: T extends ClientProviderEvents ? ClientNotChangeEvents : ServerNotChangeEvents,
     handler: EventHandler<T extends ClientProviderEvents ? ClientNotChangeEvents : ServerNotChangeEvents>,
+    options?: EventOptions,
   ): void;
   addHandler(
     eventType: T extends ClientProviderEvents ? ClientProviderEvents : ServerProviderEvents,
     handler: EventHandler<T extends ClientProviderEvents ? ClientProviderEvents : ServerProviderEvents>,
+    options?: EventOptions,
   ): void;
 
   /**

--- a/packages/shared/test/events.spec.ts
+++ b/packages/shared/test/events.spec.ts
@@ -14,17 +14,23 @@ class TestEventEmitter extends GenericEventEmitter<AnyProviderEvent> {
   }
 }
 
-// a little function to make sure we're at least waiting for the event loop 
+// a little function to make sure we're at least waiting for the event loop
 // to clear before we start making assertions
 const wait = (millis = 0) => {
-  return new Promise(resolve => {setTimeout(resolve, millis);});
+  return new Promise((resolve) => {
+    setTimeout(resolve, millis);
+  });
 };
 
 describe('GenericEventEmitter', () => {
+  const emitter = new TestEventEmitter();
+
+  afterEach(() => {
+    emitter.removeAllHandlers();
+  });
+
   describe('addHandler should', function () {
     it('attach handler for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
       emitter.emit(AllProviderEvents.Ready);
@@ -35,8 +41,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('attach several handlers for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       const handler3 = jest.fn();
@@ -64,7 +68,6 @@ describe('GenericEventEmitter', () => {
         debug: () => done(),
       };
 
-      const emitter = new TestEventEmitter();
       emitter.setLogger(logger);
 
       emitter.addHandler(AllProviderEvents.Ready, async () => {
@@ -74,8 +77,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('trigger handler for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
       emitter.emit(AllProviderEvents.Ready);
@@ -87,7 +88,6 @@ describe('GenericEventEmitter', () => {
 
     it('trigger handler for event type with event data', async function () {
       const event: ReadyEvent = { message: 'message' };
-      const emitter = new TestEventEmitter();
 
       const handler1 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
@@ -99,8 +99,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('trigger several handlers for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       const handler3 = jest.fn();
@@ -121,8 +119,6 @@ describe('GenericEventEmitter', () => {
 
   describe('removeHandler should', () => {
     it('remove single handler', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
 
@@ -138,8 +134,6 @@ describe('GenericEventEmitter', () => {
 
   describe('removeAllHandlers should', () => {
     it('remove all handlers for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
@@ -156,8 +150,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('remove same handler when assigned to multiple events', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler = jest.fn();
       emitter.addHandler(AllProviderEvents.Stale, handler);
       emitter.addHandler(AllProviderEvents.ContextChanged, handler);
@@ -174,8 +166,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('allow addition/removal of duplicate handlers', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler = jest.fn();
       emitter.addHandler(AllProviderEvents.Stale, handler);
       emitter.addHandler(AllProviderEvents.Stale, handler);
@@ -191,8 +181,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('allow duplicate event handlers and call them', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler = jest.fn();
       emitter.addHandler(AllProviderEvents.Stale, handler);
       emitter.addHandler(AllProviderEvents.Stale, handler);
@@ -205,8 +193,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('remove all handlers only for event type', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);
@@ -223,8 +209,6 @@ describe('GenericEventEmitter', () => {
     });
 
     it('remove all handlers if no event type is given', async function () {
-      const emitter = new TestEventEmitter();
-
       const handler1 = jest.fn();
       const handler2 = jest.fn();
       emitter.addHandler(AllProviderEvents.Ready, handler1);

--- a/packages/web/src/client/internal/open-feature-client.ts
+++ b/packages/web/src/client/internal/open-feature-client.ts
@@ -12,6 +12,7 @@ import type {
   OpenFeatureError,
   FlagMetadata,
   ResolutionDetails,
+  EventOptions,
 } from '@openfeature/core';
 import {
   ErrorCode,
@@ -74,7 +75,7 @@ export class OpenFeatureClient implements Client {
     return this.providerStatusAccessor();
   }
 
-  addHandler(eventType: ProviderEvents, handler: EventHandler): void {
+  addHandler(eventType: ProviderEvents, handler: EventHandler, options: EventOptions): void {
     this.emitterAccessor().addHandler(eventType, handler);
     const shouldRunNow = statusMatchesEvent(eventType, this.providerStatus);
 
@@ -89,6 +90,12 @@ export class OpenFeatureClient implements Client {
       } catch (err) {
         this._logger?.error('Error running event handler:', err);
       }
+    }
+
+    if (options?.signal && typeof options.signal.addEventListener === 'function') {
+      options.signal.addEventListener('abort', () => {
+        this.removeHandler(eventType, handler);
+      });
     }
   }
 

--- a/packages/web/test/events.spec.ts
+++ b/packages/web/test/events.spec.ts
@@ -476,7 +476,21 @@ describe('Events', () => {
       expect(OpenFeature.getHandlers(eventType)).toHaveLength(0);
     });
 
-    it('The API provides a function allowing the removal of event handlers', () => {
+    it('The event handler can be removed using an abort signal', () => {
+      const abortController = new AbortController();
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const eventType = ProviderEvents.Stale;
+
+      OpenFeature.addHandler(eventType, handler1, { signal: abortController.signal });
+      OpenFeature.addHandler(eventType, handler2);
+      expect(OpenFeature.getHandlers(eventType)).toHaveLength(2);
+
+      abortController.abort();
+      expect(OpenFeature.getHandlers(eventType)).toHaveLength(1);
+    });
+
+    it('The API provides a function allowing the removal of event handlers from client', () => {
       const client = OpenFeature.getClient(domain);
       const handler = jest.fn();
       const eventType = ProviderEvents.Stale;
@@ -485,6 +499,21 @@ describe('Events', () => {
       expect(client.getHandlers(eventType)).toHaveLength(1);
       client.removeHandler(eventType, handler);
       expect(client.getHandlers(eventType)).toHaveLength(0);
+    });
+
+    it('The event handler on the client can be removed using an abort signal', () => {
+      const abortController = new AbortController();
+      const client = OpenFeature.getClient(domain);
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const eventType = ProviderEvents.Stale;
+
+      client.addHandler(eventType, handler1, { signal: abortController.signal });
+      client.addHandler(eventType, handler2);
+      expect(client.getHandlers(eventType)).toHaveLength(2);
+
+      abortController.abort();
+      expect(client.getHandlers(eventType)).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## This PR

- adds an optional abort signal option to the `addHandler` API both globally and on the client.
- updates the React useEffect hook to leverage the abort signal

### Notes

This change was inspired by [this blog](https://kettanaito.com/blog/dont-sleep-on-abort-controller). It allows us to use abort controllers to easily unregister event handlers. I've checked [MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) to confirm that we shouldn't have any compatibility issues.

### Follow-up Tasks

We'll need to bump the min peer dependency versions when releasing to avoid issues.

### How to test

There should be pretty good test coverage of this. Please let me know if you spot any gaps.

