### PR TITLE
chore: prompt release of react v1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,7 @@
       "versioning": "default"
     },
     "packages/react": {
+      "release-as": "1.0.0",
       "release-type": "node",
       "prerelease": false,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
This proposes prompting the release of `@openfeature/react-sdk` 1.0.0.

My reasoning:

- as far as I know, there's no breaking changes on the horizon
- this is being used in production by multiple orgs
- it only depends on other 1.0+ deps

Please let me know what you think, especially if you have objections.

:warning: this will not release 1.0, but will mark the NEXT release of the react SDK as 1.0