### PR TITLE
chore: use server src not dist in nest tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -161,6 +161,7 @@ export default {
       testMatch: ['<rootDir>/packages/nest/test/**/*.spec.ts'],
       moduleNameMapper: {
         '@openfeature/core': '<rootDir>/packages/shared/src',
+        '@openfeature/server-sdk': '<rootDir>/packages/server/src',
       },
       transform: {
         '^.+\\.ts$': [


### PR DESCRIPTION
Fixes issue where nest test suite was running using dist not source of server sdk.