### PR TITLE
feat(web-global-build): impl

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,8 +3,8 @@
   "version": "1.5.0",
   "description": "OpenFeature SDK for Web",
   "main": "./dist/cjs/index.js",
-  "unpkg": "dist/global/index.js",
-  "jsdelivr": "dist/global/index.js",
+  "unpkg": "dist/global/index.min.js",
+  "jsdelivr": "dist/global/index.min.js",
   "files": [
     "dist/"
   ],
@@ -23,8 +23,9 @@
     "build:web-esm": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:web-cjs": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",
     "build:web-global": "esbuild src/index.ts --bundle --sourcemap --target=es2015 --platform=browser --format=iife --outfile=./dist/global/index.js --global-name=OpenFeature --analyze",
+    "build:web-global:min": "esbuild src/index.ts --bundle --sourcemap --target=es2015 --platform=browser --format=iife --outfile=./dist/global/index.min.js --global-name=OpenFeature --minify --analyze",
     "build:rollup-types": "rollup -c ../../rollup.config.mjs",
-    "build": "npm run clean && npm run build:web-esm && npm run build:web-cjs && npm run build:web-global && npm run build:rollup-types",
+    "build": "npm run clean && npm run build:web-esm && npm run build:web-cjs && npm run build:web-global && npm run build:web-global:min && npm run build:rollup-types",
     "postbuild": "shx cp ./../../package.esm.json ./dist/esm/package.json",
     "current-version": "echo $npm_package_version",
     "prepack": "shx cp ./../../LICENSE ./LICENSE",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,8 @@
   "version": "1.5.0",
   "description": "OpenFeature SDK for Web",
   "main": "./dist/cjs/index.js",
+  "unpkg": "dist/global/index.js",
+  "jsdelivr": "dist/global/index.js",
   "files": [
     "dist/"
   ],
@@ -20,8 +22,9 @@
     "clean": "shx rm -rf ./dist",
     "build:web-esm": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:web-cjs": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",
+    "build:web-global": "esbuild src/index.ts --bundle --format=iife --platform=browser --target=es2015 --outfile=./dist/global/index.js --global-name=OpenFeature --analyze",
     "build:rollup-types": "rollup -c ../../rollup.config.mjs",
-    "build": "npm run clean && npm run build:web-esm && npm run build:web-cjs && npm run build:rollup-types",
+    "build": "npm run clean && npm run build:web-esm && npm run build:web-cjs && npm run build:web-global && npm run build:rollup-types",
     "postbuild": "shx cp ./../../package.esm.json ./dist/esm/package.json",
     "current-version": "echo $npm_package_version",
     "prepack": "shx cp ./../../LICENSE ./LICENSE",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,7 +22,7 @@
     "clean": "shx rm -rf ./dist",
     "build:web-esm": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
     "build:web-cjs": "esbuild src/index.ts --bundle --external:@openfeature/core --sourcemap --target=es2015 --platform=browser --format=cjs --outfile=./dist/cjs/index.js --analyze",
-    "build:web-global": "esbuild src/index.ts --bundle --format=iife --platform=browser --target=es2015 --outfile=./dist/global/index.js --global-name=OpenFeature --analyze",
+    "build:web-global": "esbuild src/index.ts --bundle --sourcemap --target=es2015 --platform=browser --format=iife --outfile=./dist/global/index.js --global-name=OpenFeature --analyze",
     "build:rollup-types": "rollup -c ../../rollup.config.mjs",
     "build": "npm run clean && npm run build:web-esm && npm run build:web-cjs && npm run build:web-global && npm run build:rollup-types",
     "postbuild": "shx cp ./../../package.esm.json ./dist/esm/package.json",


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Implements a global (IIFE) build for the web.
- Adds support for global distribution via CDN by including `unpkg` and `jsdelivr` fields in `package.json`.

### Notes

- The global build outputs to `dist/global/index.js`.
- The global bundle is exposed under the global name `OpenFeature`.

### Follow-up Tasks

- Consider adding automated tests or validation for the global bundle.
- If this bundle should be included in a release checklist or CI, link the appropriate issue here.

### How to test

1. Run `npm run build` and ensure `dist/global/index.js` is generated.
2. Serve the file locally or upload to a CDN and verify that `window.OpenFeature` is available in the browser console.

### Motivation
Trying to load OpenFeature as a first dependency before browser will resolve any modules.
