### PR TITLE
fix(react): re-evaluate flags on re-render to detect silent provider …

### DIFF
--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -288,7 +288,7 @@ describe('OpenFeatureProvider', () => {
         { timeout: DELAY * 4 },
       );
 
-      expect(screen.getByText('Will says hi')).toBeInTheDocument();
+      expect(screen.getByText('Will says aloha')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## This PR

  - Added `useEffect` that runs on re-render to re-evaluate the flag value
  - Only updates state if the resolved value actually changed (using `isEqual` comparison)
  - Used lazy initialization for `useState` to avoid redundant initial evaluation
  - Added `useCallback` memoization for event handlers
  - Fixed `AbortController` scope issue

### Notes

This resolves a subtle issue where the provider state may update without emitting a change event, leading to confusing results. The `useFlag` hook sets the initial evaluated value in a `useState`. Since this wasn't in a closure, this evaluation happened any time the component using the hook rerendered but the result was essentially ignored. Adding a logging hook shows that the current results but since this evaluation was made in an existing `useState`, the result had no effect.

This resolves a subtle issue where the provider state may update without emitting a change event, leading to stale flag values being displayed.

The `useFlag` hook was evaluating the flag on every re-render (as part of the `useState` initialization), but because `useState` only uses its initial value on the first render, these subsequent evaluations were being discarded. This meant that even though the hook was fetching the correct updated value from the provider on each re-render, it was throwing that value away and continuing to display the stale cached value.

Adding a logging hook would show the correct evaluation happening (proving the provider had the updated value), but the UI would remain stuck with the old value because the `useState` was ignoring the re-evaluated result.

The fix ensures that these re-evaluations on re-render actually update the component's state when the resolved value changes.

The key insight is that the evaluation WAS happening on every re-render (due to how useState works), but React was discarding the result. Your fix makes those evaluations actually matter by checking if the value changed and updating state accordingly.

Original thread: https://cloud-native.slack.com/archives/C06E4DE6S07/p1754508917397519

### How to test

I created a test that reproduced the issue, and it failed. I then implemented the changes and verified that the test passed.

