### PR TITLE
fix: update core dep

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,9 +48,9 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@openfeature/core": "^1.7.0"
+    "@openfeature/core": "^1.9.0"
   },
   "devDependencies": {
-    "@openfeature/core": "^1.7.0"
+    "@openfeature/core": "^1.9.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,9 +50,9 @@
   },
   "homepage": "https://github.com/open-feature/js-sdk#readme",
   "peerDependencies": {
-    "@openfeature/core": "^1.8.0"
+    "@openfeature/core": "^1.9.0"
   },
   "devDependencies": {
-    "@openfeature/core": "^1.8.0"
+    "@openfeature/core": "^1.9.0"
   }
 }


### PR DESCRIPTION
As astutely pointed out by @JasperJuergensen in https://github.com/open-feature/js-sdk/issues/1227, we added API surface in core which we use in the latest web, but did't accordingly update the min version of core in web.