### PR TITLE
fix: make OTEL evaluation event attribute types compliant to OTEL types

### DIFF
--- a/packages/shared/src/telemetry/attributes.ts
+++ b/packages/shared/src/telemetry/attributes.ts
@@ -42,7 +42,6 @@ export const TelemetryAttribute = {
    *
    * - type: `undefined`
    * - requirement level: `conditionally required`
-   * - condition: variant is not defined on the evaluation details
    * - example: `#ff0000`; `1`; `true`
    */
   VALUE: 'feature_flag.result.value',

--- a/packages/shared/src/telemetry/evaluation-event.ts
+++ b/packages/shared/src/telemetry/evaluation-event.ts
@@ -11,9 +11,9 @@ export declare type AttributeValue =
   | string
   | number
   | boolean
-  | Array<null | undefined | string>
-  | Array<null | undefined | number>
-  | Array<null | undefined | boolean>;
+  | string[]
+  | number[]
+  | boolean[];
 
 type EvaluationEvent = {
   /**

--- a/packages/shared/test/telemetry.spec.ts
+++ b/packages/shared/test/telemetry.spec.ts
@@ -49,7 +49,7 @@ describe('evaluationEvent', () => {
     });
   });
 
-  it('should include variant when provided', () => {
+  it('should include variant and value when provided', () => {
     const details: EvaluationDetails<boolean> = {
       flagKey,
       value: true,
@@ -61,7 +61,7 @@ describe('evaluationEvent', () => {
     const result = createEvaluationEvent(mockHookContext, details);
 
     expect(result.attributes[TelemetryAttribute.VARIANT]).toBe('test-variant');
-    expect(result.attributes[TelemetryAttribute.VALUE]).toBeUndefined();
+    expect(result.attributes[TelemetryAttribute.VALUE]).toEqual(true);
   });
 
   it('should include flag metadata when provided', () => {

--- a/packages/shared/test/telemetry.spec.ts
+++ b/packages/shared/test/telemetry.spec.ts
@@ -64,6 +64,23 @@ describe('evaluationEvent', () => {
     expect(result.attributes[TelemetryAttribute.VALUE]).toEqual(true);
   });
 
+  it('should include object values as strings', () => {
+    const flagValue = { key: 'value' };
+
+    const details: EvaluationDetails<typeof flagValue> = {
+      flagKey,
+      value: flagValue,
+      variant: 'test-variant',
+      reason: StandardResolutionReasons.STATIC,
+      flagMetadata: {},
+    };
+
+    const result = createEvaluationEvent(mockHookContext, details);
+
+    expect(result.attributes[TelemetryAttribute.VARIANT]).toBe('test-variant');
+    expect(result.attributes[TelemetryAttribute.VALUE]).toEqual(JSON.stringify(flagValue));
+  });
+
   it('should include flag metadata when provided', () => {
     const details: EvaluationDetails<boolean> = {
       flagKey,


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Makes OTEL evaluation event attributes compliant to OTEL Api types

