### PR TITLE
chore: Test OIDC Changes with Angular Release

### DIFF
--- a/packages/angular/projects/angular-sdk/README.md
+++ b/packages/angular/projects/angular-sdk/README.md
@@ -10,6 +10,7 @@
 <h2 align="center">OpenFeature Angular SDK</h2>
 
 <!-- x-hide-in-docs-end -->
+
 <!-- The 'github-badges' class is used in the docs -->
 <p align="center" class="github-badges">
   <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">


### PR DESCRIPTION
Making a minimal change to trigger an Angular SDK patch release (0.0.18) to validate the recent OIDC npm auth updates.

Chose Angular as it's the lowest-downloaded package, reducing risk for this validation test.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
