### PR TITLE
fix: correct MultiProvider class name in docs and remove duplicate error logging

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -155,9 +155,9 @@ The Multi-Provider is a powerful tool for performing migrations between flag pro
 - **Multiple Data Sources**: The Multi-Provider allows you to seamlessly combine many sources of flagging data, such as environment variables, local files, database values and SaaS hosted feature management systems.
 
 ```ts
-import { WebMultiProvider } from '@openfeature/web-sdk';
+import { MultiProvider } from '@openfeature/web-sdk';
 
-const multiProvider = new WebMultiProvider([
+const multiProvider = new MultiProvider([
   { provider: new ProviderA() },
   { provider: new ProviderB() }
 ]);
@@ -179,9 +179,9 @@ The Multi-Provider comes with three strategies out of the box:
 - **ComparisonStrategy**: Evaluates all providers sequentially. If every provider returns a successful result with the same value, then that result is returned. Otherwise, the result returned by the configured "fallback provider" will be used.
 
 ```ts
-import { WebMultiProvider, FirstSuccessfulStrategy } from '@openfeature/web-sdk';
+import { MultiProvider, FirstSuccessfulStrategy } from '@openfeature/web-sdk';
 
-const multiProvider = new WebMultiProvider(
+const multiProvider = new MultiProvider(
   [
     { provider: new ProviderA() },
     { provider: new ProviderB() }

--- a/packages/web/src/provider/multi-provider/README.md
+++ b/packages/web/src/provider/multi-provider/README.md
@@ -9,7 +9,7 @@ feature flagging interface. For example:
 
 - *Migration*: When migrating between two providers, you can run both in parallel under a unified flagging interface. As flags are added to the
 new provider, the Multi-Provider will automatically find and return them, falling back to the old provider if the new provider does not have
-- *Multiple Data Sources*: The Multi-Provider allows you to seamlessly combine many sources of flagging data, such as environment variables, 
+- *Multiple Data Sources*: The Multi-Provider allows you to seamlessly combine many sources of flagging data, such as environment variables,
 local files, database values and SaaS hosted feature management systems.
 
 ## Usage
@@ -17,10 +17,10 @@ local files, database values and SaaS hosted feature management systems.
 The Multi-Provider is initialized with an array of providers it should evaluate:
 
 ```typescript
-import { WebMultiProvider } from '@openfeature/web-sdk'
+import { MultiProvider } from '@openfeature/web-sdk'
 import { OpenFeature } from '@openfeature/web-sdk'
 
-const multiProvider = new WebMultiProvider([
+const multiProvider = new MultiProvider([
   { provider: new ProviderA() },
   { provider: new ProviderB() }
 ])
@@ -41,9 +41,9 @@ will fail with a FLAG_NOT_FOUND error code.
 To change this behaviour, a different "strategy" can be provided:
 
 ```typescript
-import { WebMultiProvider, FirstSuccessfulStrategy } from '@openfeature/web-sdk'
+import { MultiProvider, FirstSuccessfulStrategy } from '@openfeature/web-sdk'
 
-const multiProvider = new WebMultiProvider(
+const multiProvider = new MultiProvider(
     [
       { provider: new ProviderA() },
       { provider: new ProviderB() }
@@ -67,10 +67,10 @@ in configuration without affecting flag behaviour.
 This strategy accepts several arguments during initialization:
 
 ```typescript
-import { WebMultiProvider, ComparisonStrategy } from '@openfeature/web-sdk'
+import { MultiProvider, ComparisonStrategy } from '@openfeature/web-sdk'
 
 const providerA = new ProviderA()
-const multiProvider = new WebMultiProvider(
+const multiProvider = new MultiProvider(
   [
     { provider: providerA },
     { provider: new ProviderB() }
@@ -137,10 +137,10 @@ The Multi-Provider supports tracking events across multiple providers, allowing 
 ### Basic Tracking Usage
 
 ```typescript
-import { WebMultiProvider } from '@openfeature/web-sdk'
+import { MultiProvider } from '@openfeature/web-sdk'
 import { OpenFeature } from '@openfeature/web-sdk'
 
-const multiProvider = new WebMultiProvider([
+const multiProvider = new MultiProvider([
   { provider: new ProviderA() },
   { provider: new ProviderB() }
 ])

--- a/packages/web/src/provider/multi-provider/hook-executor.ts
+++ b/packages/web/src/provider/multi-provider/hook-executor.ts
@@ -35,7 +35,6 @@ export class HookExecutor {
         if (err instanceof Error) {
           this.logger.error(err.stack);
         }
-        this.logger.error((err as Error)?.stack);
       }
     }
   }
@@ -55,7 +54,6 @@ export class HookExecutor {
         if (err instanceof Error) {
           this.logger.error(err.stack);
         }
-        this.logger.error((err as Error)?.stack);
       }
     }
   }


### PR DESCRIPTION
Addresses feedback from #1265 (Gemini bot review comments).

## Changes

1. **Fixed documentation mismatch**: Updated all code examples to use `MultiProvider` instead of incorrect `WebMultiProvider` class name
   - `packages/web/README.md` (4 occurrences)
   - `packages/web/src/provider/multi-provider/README.md` (4 occurrences)

2. **Removed duplicate error logging**: Fixed redundant stack trace logging in `hook-executor.ts` where errors were being logged twice in both `errorHooks` and `finallyHooks` methods

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
