### PR TITLE
docs: add Multi-Provider to features list in README's

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -110,6 +110,7 @@ See [here](https://open-feature.github.io/js-sdk/modules/_openfeature_server_sdk
 | ✅      | [Tracking](#tracking)                                               | Associate user actions with feature flag evaluations, particularly for A/B testing.                                                   |
 | ✅      | [Shutdown](#shutdown)                                               | Gracefully clean up a provider during application shutdown.                                                                           |
 | ✅      | [Extending](#extending)                                             | Extend OpenFeature with custom providers and hooks.                                                                                   |
+| ✅      | [Multi-Provider](#multi-provider)                                   | Combine multiple providers with configurable evaluation strategies.                                                                    |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -109,6 +109,7 @@ See [here](https://open-feature.github.io/js-sdk/modules/_openfeature_web_sdk.ht
 | ✅      | [Tracking](#tracking)               | Associate user actions with feature flag evaluations, particularly for A/B testing.                                                |
 | ✅      | [Shutdown](#shutdown)               | Gracefully clean up a provider during application shutdown.                                                                        |
 | ✅      | [Extending](#extending)             | Extend OpenFeature with custom providers and hooks.                                                                                |
+| ✅      | [Multi-Provider](#multi-provider)   | Combine multiple providers with configurable evaluation strategies.                                                                |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 


### PR DESCRIPTION
## Description
Adds the `Multi-Provider` feature to the features list in both the server and web SDK package READMEs.

