### PR TITLE
fix: multi-provider hook context management

### DIFF
--- a/packages/server/src/client/internal/open-feature-client.ts
+++ b/packages/server/src/client/internal/open-feature-client.ts
@@ -332,7 +332,7 @@ export class OpenFeatureClient implements Client {
     mergedContext: EvaluationContext,
     options: FlagEvaluationOptions,
   ) {
-    let accumulatedContext = mergedContext;
+    const accumulatedContext = mergedContext;
 
     for (const [index, hook] of hooks.entries()) {
       const hookContextIndex = hooks.length - 1 - index; // reverse index for before hooks
@@ -343,10 +343,7 @@ export class OpenFeatureClient implements Client {
 
       const hookResult = await hook?.before?.(hookContext, Object.freeze(options.hookHints));
       if (hookResult) {
-        accumulatedContext = {
-          ...accumulatedContext,
-          ...hookResult,
-        };
+        Object.assign(accumulatedContext, hookResult);
 
         for (let i = 0; i < hooks.length; i++) {
           Object.assign(hookContexts[hookContextIndex].context, accumulatedContext);


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Fixing an issue with the MultiProvider where hook contexts and hints were being lost due to copies of the context data being created in the OpenFeature sdk evaluation.

Since key evaluation of Maps using objects is done by reference, the lookup of the context during evaluation was failing, leading to errors.

- adds this new feature

### Related Issues

Fixes #1268

### Notes

### Follow-up Tasks

### How to test


