### PR TITLE
feat: allow validating context to skip initialization + context changes

### DIFF
--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -52,7 +52,7 @@ export class ProviderWrapper<P extends CommonProvider<AnyProviderStatus>, S exte
       }
     });
 
-    this._initialized = !(typeof _provider.initialize === 'function');
+    this._initialized = typeof _provider.initialize !== 'function';
   }
 
   get provider(): P {

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -276,21 +276,17 @@ export class OpenFeatureAPI
       const wrapper = domain ? this._domainScopedProviders.get(domain) : this._defaultProvider;
       if (wrapper) {
         wrapper.status = this._statusEnumType.ERROR;
-        const providerName = wrapper.provider?.metadata?.name || 'unnamed-provider';
-        this.getAssociatedEventEmitters(domain).forEach((emitter) => {
-          emitter?.emit(ProviderEvents.Error, {
-            clientName: domain,
-            domain,
-            providerName,
-            message: `Error validating context during setProvider: ${validateContextError instanceof Error ? validateContextError.message : String(validateContextError)}`,
-          });
-        });
-        this._apiEmitter?.emit(ProviderEvents.Error, {
+        const payload = {
           clientName: domain,
           domain,
-          providerName,
+          providerName: wrapper.provider?.metadata?.name || 'unnamed-provider',
           message: `Error validating context during setProvider: ${validateContextError instanceof Error ? validateContextError.message : String(validateContextError)}`,
+        };
+
+        this.getAssociatedEventEmitters(domain).forEach((emitter) => {
+          emitter?.emit(ProviderEvents.Error, { ...payload });
         });
+        this._apiEmitter?.emit(ProviderEvents.Error, { ...payload });
         this._logger.error('Error validating context during setProvider:', validateContextError);
       }
     }

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -12,7 +12,7 @@ interface ProviderOptions {
    * If provided, will be used to check if the current context is valid during initialization and context changes.
    * When calling `setProvider`, returning `false` will skip provider initialization. Throwing will move the provider to the ERROR state.
    * When calling `setProviderAndWait`, returning `false` will skip provider initialization. Throwing will reject the promise.
-   * When calling `setContext`, returning `false` will skip provider context change handling. Throwing will move the provider to the ERROR state.
+   * When calling `setContext`, returning `false` will skip provider reconciliation of the context change. Throwing will move the provider to the ERROR state.
    * @param context The evaluation context to validate.
    */
   validateContext?: (context: EvaluationContext) => boolean;
@@ -489,6 +489,7 @@ export class OpenFeatureAPI
 
     try {
       // validate the context to decide if we should run the context change handler.
+      // notably, the stored context will still be updated by this point, this just skips reconciliation.
       const options = this.getProviderOptions(domain);
       if (typeof options.validateContext === 'function') {
         if (!options.validateContext(newContext)) {

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -380,6 +380,14 @@ export class OpenFeatureAPI
     const providerName = wrapper.provider?.metadata?.name || 'unnamed-provider';
 
     try {
+      // if the provider hasn't initialized yet, and isn't actively initializing, initialize instead of running context change handler
+      // the provider will be in this state if the user requested delayed initialization until the first context change
+      const initializationPromise = this.initializeProviderForDomain(wrapper, domain);
+      if (initializationPromise) {
+        await initializationPromise;
+        return;
+      }
+
       if (typeof wrapper.provider.onContextChange === 'function') {
         const maybePromise = wrapper.provider.onContextChange(oldContext, newContext);
 

--- a/packages/web/test/evaluation-context.spec.ts
+++ b/packages/web/test/evaluation-context.spec.ts
@@ -1,7 +1,7 @@
 import type { EvaluationContext, JsonValue, Provider, ProviderMetadata, ResolutionDetails } from '../src';
 import { OpenFeature } from '../src';
 
-const initializeMock = jest.fn();
+const initializeMock = jest.fn().mockResolvedValue(undefined);
 
 class MockProvider implements Provider {
   readonly metadata: ProviderMetadata;

--- a/packages/web/test/validate-context.spec.ts
+++ b/packages/web/test/validate-context.spec.ts
@@ -1,0 +1,293 @@
+import type { JsonValue, Provider, ProviderMetadata, ResolutionDetails } from '../src';
+import { NOOP_PROVIDER, OpenFeature, ProviderStatus } from '../src';
+
+const initializeMock = jest.fn().mockResolvedValue(undefined);
+const contextChangeMock = jest.fn().mockResolvedValue(undefined);
+
+class MockProvider implements Provider {
+  readonly metadata: ProviderMetadata;
+
+  constructor(options?: { name?: string }) {
+    this.metadata = { name: options?.name ?? 'mock-provider' };
+  }
+
+  initialize = initializeMock;
+  onContextChange = contextChangeMock;
+
+  resolveBooleanEvaluation(): ResolutionDetails<boolean> {
+    throw new Error('Not implemented');
+  }
+
+  resolveNumberEvaluation(): ResolutionDetails<number> {
+    throw new Error('Not implemented');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(): ResolutionDetails<T> {
+    throw new Error('Not implemented');
+  }
+
+  resolveStringEvaluation(): ResolutionDetails<string> {
+    throw new Error('Not implemented');
+  }
+}
+
+describe('validateContext', () => {
+  afterEach(async () => {
+    await OpenFeature.clearContexts();
+    await OpenFeature.setProviderAndWait(NOOP_PROVIDER, {});
+    jest.clearAllMocks();
+  });
+
+  describe('when validateContext is not provided', () => {
+    it('should call initialize on setProvider', async () => {
+      const provider = new MockProvider();
+      OpenFeature.setProvider(provider, {});
+
+      await new Promise(process.nextTick);
+
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+    });
+
+    it('should call initialize on setProviderAndWait', async () => {
+      const provider = new MockProvider();
+      await OpenFeature.setProviderAndWait(provider, {});
+
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+    });
+
+    it('should not call initialize on context change', async () => {
+      const provider = new MockProvider();
+      await OpenFeature.setProviderAndWait(provider, {});
+
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+      await OpenFeature.setContext({ user: 'test-user' });
+
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(contextChangeMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when validateContext evaluates to true', () => {
+    it('should call initialize on setProvider', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockReturnValue(true);
+      OpenFeature.setProvider(provider, {}, { validateContext });
+
+      await new Promise(process.nextTick);
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+    });
+
+    it('should call initialize on setProviderAndWait', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockReturnValue(true);
+      await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+    });
+
+    describe('when the provider is initialized', () => {
+      it('should not call initialize again on context change', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(true);
+        await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when the provider is not yet initialized', () => {
+      it('should call initialize on the first valid context change', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(false);
+        OpenFeature.setProvider(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+
+        validateContext.mockReturnValue(true);
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+        await OpenFeature.setContext({ user: 'another-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(3);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('when validateContext evaluates to false', () => {
+    it('should not call initialize on setProvider', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockReturnValue(false);
+      OpenFeature.setProvider(provider, {}, { validateContext });
+
+      await new Promise(process.nextTick);
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(0);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+    });
+
+    it('should not call initialize on setProviderAndWait', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockReturnValue(false);
+      await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(0);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+    });
+
+    describe('when the provider is initialized', () => {
+      it('should not process a context change that fails validation', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(true);
+        await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+        validateContext.mockReturnValue(false);
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('when the provider is not yet initialized', () => {
+      it('should not call initialize until a valid context is provided', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(false);
+        OpenFeature.setProvider(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(0);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+
+        validateContext.mockReturnValue(true);
+        await OpenFeature.setContext({ user: 'another-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(3);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+        await OpenFeature.setContext({ user: 'final-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(4);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('when validateContext throws an error', () => {
+    it('should move to ERROR status on setProvider', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockImplementation(() => {
+        throw new Error('Validation error');
+      });
+      OpenFeature.setProvider(provider, {}, { validateContext });
+
+      await new Promise(process.nextTick);
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(0);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.ERROR);
+    });
+
+    it('should propagate error on setProviderAndWait', async () => {
+      const provider = new MockProvider();
+      const validateContext = jest.fn().mockImplementation(() => {
+        throw new Error('Validation error');
+      });
+
+      await expect(OpenFeature.setProviderAndWait(provider, {}, { validateContext })).rejects.toThrow(
+        'Validation error',
+      );
+
+      expect(validateContext).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(0);
+      expect(OpenFeature.getProvider()).toBe(NOOP_PROVIDER);
+      expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+    });
+
+    describe('when the provider is initialized', () => {
+      it('should move to ERROR status on context change', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(true);
+        await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
+
+        validateContext.mockImplementation(() => {
+          throw new Error('Validation error');
+        });
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(1);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.ERROR);
+      });
+    });
+
+    describe('when the provider is not yet initialized', () => {
+      it('should move to ERROR status on context change', async () => {
+        const provider = new MockProvider();
+        const validateContext = jest.fn().mockReturnValue(false);
+        await OpenFeature.setProviderAndWait(provider, {}, { validateContext });
+
+        expect(validateContext).toHaveBeenCalledTimes(1);
+        expect(initializeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
+
+        validateContext.mockImplementation(() => {
+          throw new Error('Validation error');
+        });
+        await OpenFeature.setContext({ user: 'test-user' });
+
+        expect(validateContext).toHaveBeenCalledTimes(2);
+        expect(initializeMock).toHaveBeenCalledTimes(0);
+        expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.ERROR);
+      });
+    });
+  });
+});

--- a/packages/web/test/validate-context.spec.ts
+++ b/packages/web/test/validate-context.spec.ts
@@ -68,6 +68,7 @@ describe('validateContext', () => {
 
       expect(initializeMock).toHaveBeenCalledTimes(1);
       expect(contextChangeMock).toHaveBeenCalledTimes(1);
+      expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
     });
   });
 
@@ -109,6 +110,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
       });
     });
 
@@ -128,6 +130,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
         expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
 
         await OpenFeature.setContext({ user: 'another-user' });
@@ -135,6 +138,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(3);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getContext()).toEqual({ user: 'another-user' });
       });
     });
   });
@@ -178,6 +182,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
       });
     });
 
@@ -196,6 +201,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(0);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
         expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.NOT_READY);
 
         validateContext.mockReturnValue(true);
@@ -204,6 +210,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(3);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'another-user' });
         expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.READY);
 
         await OpenFeature.setContext({ user: 'final-user' });
@@ -211,6 +218,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(4);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(1);
+        expect(OpenFeature.getContext()).toEqual({ user: 'final-user' });
       });
     });
   });
@@ -264,6 +272,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(1);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
         expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.ERROR);
       });
     });
@@ -286,6 +295,7 @@ describe('validateContext', () => {
         expect(validateContext).toHaveBeenCalledTimes(2);
         expect(initializeMock).toHaveBeenCalledTimes(0);
         expect(contextChangeMock).toHaveBeenCalledTimes(0);
+        expect(OpenFeature.getContext()).toEqual({ user: 'test-user' });
         expect(OpenFeature.getClient().providerStatus).toBe(ProviderStatus.ERROR);
       });
     });


### PR DESCRIPTION
## This PR

Adds a new options argument when calling `setProvider` and `setProviderAndWait` in the web SDK, allowing for a context validation method to be provided. This method can cause the initialization of the provider to be skipped when setting a new provider, leaving it NOT_READY, until a future valid context change is made. It can also cause context change reconciliation to be skipped.

### Related Issues

Resolves #1279

### Notes

While returning false during context validation will prevent a provider from reconciling context changes, the updated context is still stored and persisted.

### Follow-up Tasks

N/A

### How to test

See test suite :)