### PR TITLE
feat: allow non-singleton access to OpenFeatureAPI

### DIFF
--- a/packages/react/src/context/use-context-mutator.ts
+++ b/packages/react/src/context/use-context-mutator.ts
@@ -35,6 +35,7 @@ export type ContextMutation = {
 export function useContextMutator(options: ContextMutationOptions = { defaultContext: false }): ContextMutation {
   const { client } = useContext(Context) || {};
   const domain = client?.metadata.domain;
+  const sdk = client?.metadata.sdk || OpenFeature;
 
   // TODO: Replace this warning with a thrown error in a future major release,
   //       to match the behavior of `useOpenFeatureProvider` + `useOpenFeatureClient`,
@@ -60,15 +61,14 @@ export function useContextMutator(options: ContextMutationOptions = { defaultCon
     async (
       updatedContext: EvaluationContext | ((currentContext: EvaluationContext) => EvaluationContext),
     ): Promise<void> => {
-      // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
-      const previousContext = OpenFeature.getContext(options?.defaultContext ? undefined : domain);
+      const previousContext = sdk.getContext(options?.defaultContext ? undefined : domain);
       const resolvedContext = typeof updatedContext === 'function' ? updatedContext(previousContext) : updatedContext;
 
       if (previousContext !== resolvedContext) {
         if (!domain || options?.defaultContext) {
-          await OpenFeature.setContext(resolvedContext);
+          await sdk.setContext(resolvedContext);
         } else {
-          await OpenFeature.setContext(domain, resolvedContext);
+          await sdk.setContext(domain, resolvedContext);
         }
       }
     },

--- a/packages/react/src/context/use-context-mutator.ts
+++ b/packages/react/src/context/use-context-mutator.ts
@@ -60,6 +60,7 @@ export function useContextMutator(options: ContextMutationOptions = { defaultCon
     async (
       updatedContext: EvaluationContext | ((currentContext: EvaluationContext) => EvaluationContext),
     ): Promise<void> => {
+      // TODO: Needs to handle `isolated` option like OpenFeatureProvider
       const previousContext = OpenFeature.getContext(options?.defaultContext ? undefined : domain);
       const resolvedContext = typeof updatedContext === 'function' ? updatedContext(previousContext) : updatedContext;
 

--- a/packages/react/src/context/use-context-mutator.ts
+++ b/packages/react/src/context/use-context-mutator.ts
@@ -60,7 +60,7 @@ export function useContextMutator(options: ContextMutationOptions = { defaultCon
     async (
       updatedContext: EvaluationContext | ((currentContext: EvaluationContext) => EvaluationContext),
     ): Promise<void> => {
-      // TODO: Needs to handle `isolated` option like OpenFeatureProvider
+      // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
       const previousContext = OpenFeature.getContext(options?.defaultContext ? undefined : domain);
       const resolvedContext = typeof updatedContext === 'function' ? updatedContext(previousContext) : updatedContext;
 

--- a/packages/react/src/provider/provider.tsx
+++ b/packages/react/src/provider/provider.tsx
@@ -1,4 +1,4 @@
-import type { Client } from '@openfeature/web-sdk';
+import type { Client, OpenFeatureAPI } from '@openfeature/web-sdk';
 import { OpenFeature } from '@openfeature/web-sdk';
 import * as React from 'react';
 import type { ReactFlagEvaluationOptions } from '../options';
@@ -12,10 +12,10 @@ type ClientOrDomain =
        */
       domain?: string;
       /**
-       * If the package-local isolated OpenFeature singleton should be used
-       * @see OpenFeature.isolated for more details.
+       * An instance of the OpenFeature API to use.
+       * @see OpenFeature.getIsolated for more details.
        */
-      isolated?: boolean;
+      openfeature?: OpenFeatureAPI;
       client?: never;
     }
   | {
@@ -24,7 +24,7 @@ type ClientOrDomain =
        */
       client?: Client;
       domain?: never;
-      isolated?: never;
+      openfeature?: never;
     };
 
 type ProviderProps = {
@@ -37,11 +37,8 @@ type ProviderProps = {
  * @param {ProviderProps} properties props for the context provider
  * @returns {OpenFeatureProvider} context provider
  */
-export function OpenFeatureProvider({ client, domain, isolated, children, ...options }: ProviderProps) {
-  const stableClient = React.useMemo(
-    () => client || (isolated ? OpenFeature.isolated : OpenFeature).getClient(domain),
-    [client, domain],
-  );
+export function OpenFeatureProvider({ client, domain, openfeature, children, ...options }: ProviderProps) {
+  const stableClient = React.useMemo(() => client || (openfeature ?? OpenFeature).getClient(domain), [client, domain]);
 
   return <Context.Provider value={{ client: stableClient, options }}>{children}</Context.Provider>;
 }

--- a/packages/react/src/provider/provider.tsx
+++ b/packages/react/src/provider/provider.tsx
@@ -15,7 +15,7 @@ type ClientOrDomain =
        * An instance of the OpenFeature API to use.
        * @see OpenFeature.getIsolated for more details.
        */
-      openfeature?: OpenFeatureAPI;
+      sdk?: OpenFeatureAPI;
       client?: never;
     }
   | {
@@ -24,7 +24,7 @@ type ClientOrDomain =
        */
       client?: Client;
       domain?: never;
-      openfeature?: never;
+      sdk?: never;
     };
 
 type ProviderProps = {
@@ -37,8 +37,8 @@ type ProviderProps = {
  * @param {ProviderProps} properties props for the context provider
  * @returns {OpenFeatureProvider} context provider
  */
-export function OpenFeatureProvider({ client, domain, openfeature, children, ...options }: ProviderProps) {
-  const stableClient = React.useMemo(() => client || (openfeature ?? OpenFeature).getClient(domain), [client, domain]);
+export function OpenFeatureProvider({ client, domain, sdk, children, ...options }: ProviderProps) {
+  const stableClient = React.useMemo(() => client || (sdk ?? OpenFeature).getClient(domain), [client, domain]);
 
   return <Context.Provider value={{ client: stableClient, options }}>{children}</Context.Provider>;
 }

--- a/packages/react/src/provider/provider.tsx
+++ b/packages/react/src/provider/provider.tsx
@@ -11,6 +11,11 @@ type ClientOrDomain =
        * @see OpenFeature.setProvider() and overloads.
        */
       domain?: string;
+      /**
+       * If the package-local isolated OpenFeature singleton should be used
+       * @see OpenFeature.isolated for more details.
+       */
+      isolated?: boolean;
       client?: never;
     }
   | {
@@ -19,6 +24,7 @@ type ClientOrDomain =
        */
       client?: Client;
       domain?: never;
+      isolated?: never;
     };
 
 type ProviderProps = {
@@ -31,8 +37,11 @@ type ProviderProps = {
  * @param {ProviderProps} properties props for the context provider
  * @returns {OpenFeatureProvider} context provider
  */
-export function OpenFeatureProvider({ client, domain, children, ...options }: ProviderProps) {
-  const stableClient = React.useMemo(() => client || OpenFeature.getClient(domain), [client, domain]);
+export function OpenFeatureProvider({ client, domain, isolated, children, ...options }: ProviderProps) {
+  const stableClient = React.useMemo(
+    () => client || (isolated ? OpenFeature.isolated : OpenFeature).getClient(domain),
+    [client, domain],
+  );
 
   return <Context.Provider value={{ client: stableClient, options }}>{children}</Context.Provider>;
 }

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -87,6 +87,7 @@ export function OpenFeatureTestProvider(testProviderOptions: TestProviderProps) 
   const effectiveProvider = (
     flagValueMap ? new TestProvider(flagValueMap, testProviderOptions.delayMs) : mixInNoop(provider) || NOOP_PROVIDER
   ) as Provider;
+  // TODO: Needs to handle `isolated` option like OpenFeatureProvider
   testProviderOptions.domain
     ? OpenFeature.setProvider(testProviderOptions.domain, effectiveProvider)
     : OpenFeature.setProvider(effectiveProvider);

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -87,7 +87,7 @@ export function OpenFeatureTestProvider(testProviderOptions: TestProviderProps) 
   const effectiveProvider = (
     flagValueMap ? new TestProvider(flagValueMap, testProviderOptions.delayMs) : mixInNoop(provider) || NOOP_PROVIDER
   ) as Provider;
-  // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
+  // TODO: Should this handle the `sdk` option like OpenFeatureProvider
   testProviderOptions.domain
     ? OpenFeature.setProvider(testProviderOptions.domain, effectiveProvider)
     : OpenFeature.setProvider(effectiveProvider);

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -83,17 +83,16 @@ class TestProvider extends InMemoryProvider {
  * @returns {OpenFeatureProvider} OpenFeatureTestProvider
  */
 export function OpenFeatureTestProvider(testProviderOptions: TestProviderProps) {
-  const { flagValueMap, provider } = testProviderOptions;
+  const { flagValueMap, provider, sdk } = testProviderOptions;
   const effectiveProvider = (
     flagValueMap ? new TestProvider(flagValueMap, testProviderOptions.delayMs) : mixInNoop(provider) || NOOP_PROVIDER
   ) as Provider;
-  // TODO: Should this handle the `sdk` option like OpenFeatureProvider
   testProviderOptions.domain
-    ? OpenFeature.setProvider(testProviderOptions.domain, effectiveProvider)
-    : OpenFeature.setProvider(effectiveProvider);
+    ? (sdk ?? OpenFeature).setProvider(testProviderOptions.domain, effectiveProvider)
+    : (sdk ?? OpenFeature).setProvider(effectiveProvider);
 
   return (
-    <OpenFeatureProvider {...(testProviderOptions as NormalizedOptions)} domain={testProviderOptions.domain}>
+    <OpenFeatureProvider {...(testProviderOptions as NormalizedOptions)} sdk={sdk} domain={testProviderOptions.domain}>
       {testProviderOptions.children}
     </OpenFeatureProvider>
   );

--- a/packages/react/src/provider/test-provider.tsx
+++ b/packages/react/src/provider/test-provider.tsx
@@ -87,7 +87,7 @@ export function OpenFeatureTestProvider(testProviderOptions: TestProviderProps) 
   const effectiveProvider = (
     flagValueMap ? new TestProvider(flagValueMap, testProviderOptions.delayMs) : mixInNoop(provider) || NOOP_PROVIDER
   ) as Provider;
-  // TODO: Needs to handle `isolated` option like OpenFeatureProvider
+  // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
   testProviderOptions.domain
     ? OpenFeature.setProvider(testProviderOptions.domain, effectiveProvider)
     : OpenFeature.setProvider(effectiveProvider);

--- a/packages/react/src/provider/use-open-feature-provider.ts
+++ b/packages/react/src/provider/use-open-feature-provider.ts
@@ -17,6 +17,6 @@ export function useOpenFeatureProvider(): Provider {
     throw new MissingContextError('No OpenFeature context available');
   }
 
-  // TODO: Needs to handle `isolated` option like OpenFeatureProvider
+  // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
   return OpenFeature.getProvider(openFeatureContext.client.metadata.domain);
 }

--- a/packages/react/src/provider/use-open-feature-provider.ts
+++ b/packages/react/src/provider/use-open-feature-provider.ts
@@ -17,5 +17,6 @@ export function useOpenFeatureProvider(): Provider {
     throw new MissingContextError('No OpenFeature context available');
   }
 
+  // TODO: Needs to handle `isolated` option like OpenFeatureProvider
   return OpenFeature.getProvider(openFeatureContext.client.metadata.domain);
 }

--- a/packages/react/src/provider/use-open-feature-provider.ts
+++ b/packages/react/src/provider/use-open-feature-provider.ts
@@ -17,6 +17,5 @@ export function useOpenFeatureProvider(): Provider {
     throw new MissingContextError('No OpenFeature context available');
   }
 
-  // TODO: Needs to handle `openfeature` option like OpenFeatureProvider
-  return OpenFeature.getProvider(openFeatureContext.client.metadata.domain);
+  return (openFeatureContext.client.metadata.sdk ?? OpenFeature).getProvider(openFeatureContext.client.metadata.domain);
 }

--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -54,6 +54,7 @@ describe('OpenFeatureProvider', () => {
 
   beforeEach(async () => {
     await OpenFeature.clearContexts();
+    await OpenFeature.clearProviders();
   });
 
   describe('useOpenFeatureClient', () => {

--- a/packages/react/test/provider.spec.tsx
+++ b/packages/react/test/provider.spec.tsx
@@ -11,6 +11,7 @@ import {
   useStringFlagValue,
 } from '../src';
 import { TestingProvider } from './test.utils';
+import { useOpenFeatureProvider } from '../src/provider/use-open-feature-provider';
 
 describe('OpenFeatureProvider', () => {
   /**
@@ -99,6 +100,43 @@ describe('OpenFeatureProvider', () => {
     });
   });
 
+  describe('useOpenFeatureProvider', () => {
+    const DOMAIN = 'useOpenFeatureProvider';
+
+    it('should return provider from the global singleton when no SDK is specified', () => {
+      const provider = new InMemoryProvider();
+      OpenFeature.setProvider(DOMAIN, provider);
+
+      const wrapper = ({ children }: Parameters<typeof OpenFeatureProvider>[0]) => (
+        <OpenFeatureProvider domain={DOMAIN}>{children}</OpenFeatureProvider>
+      );
+
+      const { result } = renderHook(() => useOpenFeatureProvider(), { wrapper });
+
+      expect(result.current).toEqual(provider);
+    });
+
+    it('should return provider from the specified SDK when one is provided', () => {
+      const provider = new InMemoryProvider();
+      OpenFeature.setProvider(DOMAIN, provider);
+
+      const isolatedInstance = OpenFeature.getIsolated();
+      const isolatedProvider = new InMemoryProvider();
+      isolatedInstance.setProvider(DOMAIN, isolatedProvider);
+
+      const wrapper = ({ children }: Parameters<typeof OpenFeatureProvider>[0]) => (
+        <OpenFeatureProvider sdk={isolatedInstance} domain={DOMAIN}>
+          {children}
+        </OpenFeatureProvider>
+      );
+
+      const { result } = renderHook(() => useOpenFeatureProvider(), { wrapper });
+
+      expect(result.current).toEqual(isolatedProvider);
+      expect(result.current).not.toEqual(provider);
+    });
+  });
+
   describe('useWhenProviderReady', () => {
     describe('suspendUntilReady=true (default)', () => {
       it('should suspend until ready and then return provider status', async () => {
@@ -165,6 +203,7 @@ describe('OpenFeatureProvider', () => {
       });
     });
   });
+
   describe('useMutateContext', () => {
     const MutateButton = ({ setter }: { setter?: (prevContext: EvaluationContext) => EvaluationContext }) => {
       const { setContext } = useContextMutator();

--- a/packages/web/src/client/client.ts
+++ b/packages/web/src/client/client.ts
@@ -3,10 +3,15 @@ import type { Features } from '../evaluation';
 import type { ProviderStatus } from '../provider';
 import type { ProviderEvents } from '../events';
 import type { Tracking } from '../tracking';
+import type { OpenFeatureAPI } from '../open-feature';
+
+export interface ClientMetadataWithSDK extends ClientMetadata {
+  readonly sdk?: OpenFeatureAPI;
+}
 
 export interface Client
   extends EvaluationLifeCycle<Client>, Features, ManageLogger<Client>, Eventing<ProviderEvents>, Tracking {
-  readonly metadata: ClientMetadata;
+  readonly metadata: ClientMetadataWithSDK;
   /**
    * Returns the status of the associated provider.
    */

--- a/packages/web/src/client/internal/open-feature-client.ts
+++ b/packages/web/src/client/internal/open-feature-client.ts
@@ -1,5 +1,4 @@
 import type {
-  ClientMetadata,
   EvaluationContext,
   EvaluationDetails,
   EventHandler,
@@ -30,7 +29,8 @@ import type { InternalEventEmitter } from '../../events/internal/internal-event-
 import type { Hook } from '../../hooks';
 import type { Provider } from '../../provider';
 import { ProviderStatus } from '../../provider';
-import type { Client } from './../client';
+import type { Client, ClientMetadataWithSDK } from './../client';
+import type { OpenFeatureAPI } from '../../open-feature';
 
 type OpenFeatureClientOptions = {
   /**
@@ -39,6 +39,7 @@ type OpenFeatureClientOptions = {
   name?: string;
   domain?: string;
   version?: string;
+  sdk?: OpenFeatureAPI;
 };
 
 /**
@@ -62,12 +63,13 @@ export class OpenFeatureClient implements Client {
     private readonly options: OpenFeatureClientOptions,
   ) {}
 
-  get metadata(): ClientMetadata {
+  get metadata(): ClientMetadataWithSDK {
     return {
       // Use domain if name is not provided
       name: this.options.domain ?? this.options.name,
       domain: this.options.domain ?? this.options.name,
       version: this.options.version,
+      sdk: this.options.sdk,
       providerMetadata: this.providerAccessor().metadata,
     };
   }

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -362,7 +362,7 @@ export class OpenFeatureAPI
       (domain?: string) => this.getContext(domain),
       () => this.getHooks(),
       () => this._logger,
-      { domain, version },
+      { domain, version, sdk: this },
     );
   }
 

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -19,7 +19,6 @@ type DomainRecord = {
 };
 
 const _globalThis = globalThis as OpenFeatureGlobal;
-const _localThis = {} as OpenFeatureGlobal;
 
 export class OpenFeatureAPI
   extends OpenFeatureCommonAPI<ClientProviderStatus, Provider, Hook>
@@ -40,21 +39,23 @@ export class OpenFeatureAPI
   }
 
   /**
-   * Gets a singleton instance of the OpenFeature API.
+   * Gets a instance of the OpenFeature API.
    * @ignore
-   * @param {boolean} global Whether to get the global (window) singleton instance or a package-local singleton instance.
+   * @param {boolean} singleton Whether to get the global (window) singleton instance or an isolated non-singleton instance.
    * @returns {OpenFeatureAPI} OpenFeature API
    */
-  static getInstance(global = true): OpenFeatureAPI {
-    const store = global ? _globalThis : _localThis;
+  static getInstance(singleton = true): OpenFeatureAPI {
+    if (!singleton) {
+      return new OpenFeatureAPI();
+    }
 
-    const globalApi = store[GLOBAL_OPENFEATURE_API_KEY];
+    const globalApi = _globalThis[GLOBAL_OPENFEATURE_API_KEY];
     if (globalApi) {
       return globalApi;
     }
 
     const instance = new OpenFeatureAPI();
-    store[GLOBAL_OPENFEATURE_API_KEY] = instance;
+    _globalThis[GLOBAL_OPENFEATURE_API_KEY] = instance;
     return instance;
   }
 
@@ -427,55 +428,53 @@ export class OpenFeatureAPI
 
 interface OpenFeatureAPIWithIsolated extends OpenFeatureAPI {
   /**
-   * A package-local singleton instance of the OpenFeature API.
+   * Create a new isolated, non-singleton instance of the OpenFeature API.
    *
    * By default, the OpenFeature API is exposed as a global singleton instance (stored on `window` in browsers).
    * While this can be very convenient as domains, providers, etc., are shared across an entire application,
    * this can mean that in multi-frontend architectures (e.g. micro-frontends) different parts of an application
    * can think they're loading different versions of OpenFeature, when they're actually all sharing the same instance.
    *
-   * The `isolated` property provides access to a package-local singleton instance of the OpenFeature API,
-   * which is not shared globally, isolated from the global singleton. As such, it will not share domains, providers,
-   * etc., with the global singleton instance, and uses its own version of the SDK.
-   *
-   * The `isolated` property allows different parts of a multi-frontend application to have their own isolated
-   * OpenFeature API instances, avoiding potential conflicts and ensuring they're using the expected version of the SDK.
-   * However, it is still a singleton within the package though, so it will share state with other uses of the
-   * `isolated` instance imported from the same package within the same micro-frontend.
+   * The `getIsolated` method allows different parts of a multi-frontend application to have their own isolated
+   * OpenFeature API instances, avoiding potential conflicts and ensuring they're using the expected version of the SDK,
+   * and don't risk colliding with any other usages of OpenFeature on the same page.
    * @example
    * import { OpenFeature } from '@openfeature/web-sdk';
    *
    * OpenFeature.setProvider(new MyGlobalProvider()); // Sets the provider for the default domain on the global instance
-   * OpenFeature.isolated.setProvider(new MyIsolatedProvider()); // Sets the provider for the default domain on the isolated instance
-   *
    * const globalClient = OpenFeature.getClient(); // Uses MyGlobalProvider, the provider for the default domain on the global instance
-   * const isolatedClient = OpenFeature.isolated.getClient(); // Uses MyIsolatedProvider, the provider for the default domain on the isolated instance
+   *
+   * export const OpenFeatureIsolated = OpenFeature.getIsolated(); // Create a new isolated instance of the OpenFeature API and export it
+   * OpenFeatureIsolated.setProvider(new MyIsolatedProvider()); // Sets the provider for the default domain on the isolated instance
+   * const isolatedClient = OpenFeatureIsolated.getClient(); // Uses MyIsolatedProvider, the provider for the default domain on the isolated instance
    *
    * // In the same micro-frontend, in a different file ...
    * import { OpenFeature } from '@openfeature/web-sdk';
+   * import { OpenFeatureIsolated } from './other-file';
    *
    * const globalClient = OpenFeature.getClient(); // Uses MyGlobalProvider, the provider for the default domain on the global instance
-   * const isolatedClient = OpenFeature.isolated.getClient(); // Uses MyIsolatedProvider, the provider for the default domain on the isolated instance
+   * const isolatedClient = OpenFeatureIsolated.getClient(); // Uses MyIsolatedProvider, the provider for the default domain on the isolated instance
+   *
+   * const OpenFeatureIsolatedOther = OpenFeature.getIsolated(); // Create another new isolated instance of the OpenFeature API
+   * const isolatedOtherClient = OpenFeatureIsolatedOther.getClient(); // Uses the NOOP provider, as this is a different isolated instance
    *
    * // In another micro-frontend, after the above has executed ...
    * import { OpenFeature } from '@openfeature/web-sdk';
    *
    * const globalClient = OpenFeature.getClient(); // Uses MyGlobalProvider, the provider for the default domain on the global instance
-   * const isolatedClient = OpenFeature.isolated.getClient(); // Returns the NOOP provider, as this is a different isolated instance
+   *
+   * const OpenFeatureIsolated = OpenFeature.getIsolated(); // Create a new isolated instance of the OpenFeature API
+   * const isolatedClient = OpenFeatureIsolated.getClient(); // Uses the NOOP provider, as this is a different isolated instance
    */
-  readonly isolated: OpenFeatureAPI;
+  getIsolated: () => OpenFeatureAPI;
 }
 
-const createOpenFeatureAPI = (): OpenFeatureAPIWithIsolated => {
-  const globalInstance = OpenFeatureAPI.getInstance();
-  const localInstance = OpenFeatureAPI.getInstance(false);
-
-  return Object.assign(globalInstance, {
-    get isolated() {
-      return localInstance;
+const createOpenFeatureAPI = (): OpenFeatureAPIWithIsolated =>
+  Object.assign(OpenFeatureAPI.getInstance(), {
+    getIsolated() {
+      return OpenFeatureAPI.getInstance(false);
     },
   });
-};
 
 /**
  * A singleton instance of the OpenFeature API.

--- a/packages/web/test/isolated.spec.ts
+++ b/packages/web/test/isolated.spec.ts
@@ -1,0 +1,94 @@
+import type { JsonValue, OpenFeatureAPI, Provider, ProviderMetadata, ResolutionDetails } from '../src';
+
+const GLOBAL_OPENFEATURE_API_KEY = Symbol.for('@openfeature/web-sdk/api');
+
+class MockProvider implements Provider {
+  readonly metadata: ProviderMetadata;
+
+  constructor(options?: { name?: string }) {
+    this.metadata = { name: options?.name ?? 'mock-provider' };
+  }
+
+  resolveBooleanEvaluation(): ResolutionDetails<boolean> {
+    throw new Error('Not implemented');
+  }
+
+  resolveNumberEvaluation(): ResolutionDetails<number> {
+    throw new Error('Not implemented');
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(): ResolutionDetails<T> {
+    throw new Error('Not implemented');
+  }
+
+  resolveStringEvaluation(): ResolutionDetails<string> {
+    throw new Error('Not implemented');
+  }
+}
+
+const _globalThis = globalThis as {
+  [GLOBAL_OPENFEATURE_API_KEY]?: OpenFeatureAPI;
+};
+
+describe('OpenFeature', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(_globalThis, GLOBAL_OPENFEATURE_API_KEY);
+    expect(_globalThis[GLOBAL_OPENFEATURE_API_KEY]).toBeUndefined();
+    jest.resetModules();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  it('should persist via globalThis (window in browsers)', async () => {
+    const firstInstance = (await import('../src')).OpenFeature;
+
+    jest.resetModules();
+    const secondInstance = (await import('../src')).OpenFeature;
+
+    expect(firstInstance).toBe(secondInstance);
+    expect(_globalThis[GLOBAL_OPENFEATURE_API_KEY]).toBe(firstInstance);
+  });
+
+  describe('OpenFeature.isolated', () => {
+    it('should not be the same instance as the global singleton', async () => {
+      const { OpenFeature } = await import('../src');
+
+      expect(OpenFeature.isolated).not.toBe(OpenFeature);
+    });
+
+    it('should not share state between global and isolated instances', async () => {
+      const { OpenFeature, NOOP_PROVIDER } = await import('../src');
+      const isolatedInstance = OpenFeature.isolated;
+
+      const globalProvider = new MockProvider({ name: 'global-provider' });
+      OpenFeature.setProvider(globalProvider);
+
+      expect(OpenFeature.getProvider()).toBe(globalProvider);
+      expect(isolatedInstance.getProvider()).toBe(NOOP_PROVIDER);
+
+      const isolatedProvider = new MockProvider({ name: 'isolated-provider' });
+      isolatedInstance.setProvider(isolatedProvider);
+
+      expect(OpenFeature.getProvider()).toBe(globalProvider);
+      expect(isolatedInstance.getProvider()).toBe(isolatedProvider);
+    });
+
+    it('should persist when imported multiple times', async () => {
+      const firstIsolatedInstance = (await import('../src')).OpenFeature.isolated;
+      const secondIsolatedInstance = (await import('../src')).OpenFeature.isolated;
+
+      expect(firstIsolatedInstance).toBe(secondIsolatedInstance);
+    });
+
+    it('should not persist via globalThis (window in browsers)', async () => {
+      const firstIsolatedInstance = (await import('../src')).OpenFeature.isolated;
+
+      jest.resetModules();
+      const secondIsolatedInstance = (await import('../src')).OpenFeature.isolated;
+
+      expect(firstIsolatedInstance).not.toBe(secondIsolatedInstance);
+    });
+  });
+});

--- a/packages/web/test/tsconfig.json
+++ b/packages/web/test/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["."]
+  "include": ["."],
+  "compilerOptions": {
+    "module": "es2020"
+  }
 }


### PR DESCRIPTION
## This PR

Allows for folks who do not wish to interact with the global singleton instance of the OpenFeatureAPI in the web-sdk to instead create isolated non-singleton instances of the OpenFeatureAPI that they'll need to pass around themselves. This should be useful for micro-frontend environments where there is a risk for different versions of the SDK being loaded by micro-frontends and colliding in `window` due to the global singleton mechanism.

### Related Issues

Resolves #1308

cc https://github.com/open-feature/spec/issues/359

### Notes

N/A

### Follow-up Tasks

N/A

### How to test

tbd.

