### PR TITLE
fix: await context change in useContextMutator setContext

### DIFF
--- a/packages/react/src/context/use-context-mutator.ts
+++ b/packages/react/src/context/use-context-mutator.ts
@@ -41,9 +41,9 @@ export function useContextMutator(options: ContextMutationOptions = { defaultCon
 
         if (previousContext !== resolvedContext) {
             if (!domain || options?.defaultContext) {
-                OpenFeature.setContext(resolvedContext);
+                await OpenFeature.setContext(resolvedContext);
             } else {
-                OpenFeature.setContext(domain, resolvedContext);
+                await OpenFeature.setContext(domain, resolvedContext);
             }
         }
     }, [domain, options?.defaultContext]);


### PR DESCRIPTION
## This PR

As identified in https://github.com/open-feature/js-sdk/pull/1305#discussion_r2582976212, the signature + JSDoc for this hook method indicates it returns a Promise you can await for the context change, however, the actual logic within the method did not await the underlying setContext calls -- it now does.
