### PR TITLE
fix: remove explicit return type for React `OpenFeatureProvider`

### DIFF
--- a/packages/react/src/provider/provider.tsx
+++ b/packages/react/src/provider/provider.tsx
@@ -31,7 +31,7 @@ type ProviderProps = {
  * @param {ProviderProps} properties props for the context provider
  * @returns {OpenFeatureProvider} context provider
  */
-export function OpenFeatureProvider({ client, domain, children, ...options }: ProviderProps): JSX.Element {
+export function OpenFeatureProvider({ client, domain, children, ...options }: ProviderProps) {
   const stableClient = React.useMemo(() => client || OpenFeature.getClient(domain), [client, domain]);
 
   return <Context.Provider value={{ client: stableClient, options, domain }}>{children}</Context.Provider>;


### PR DESCRIPTION

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

This PR removes the explicit `JSX.Element` return type from the type signature of the React SDK `OpenFeatureProvider`.
`JSX.Element` is narrow for React 19+ as types have widened to include Portals etc. & this was throwing TS compilation errors


### Related Issues

Fixes #1307

### Notes
As this is purely a type change I didn't feel it necessary to add additional tests, happy to investigate further if required though

