### PR TITLE
feat: Add evaluation options to FeatureFlag component

### DIFF
--- a/packages/react/src/declarative/FeatureFlag.tsx
+++ b/packages/react/src/declarative/FeatureFlag.tsx
@@ -97,7 +97,7 @@ export function FeatureFlag<T extends FlagValue = FlagValue>({
 }: FeatureFlagComponentProps<T>): React.ReactElement | null {
   const details = useFlag(flagKey, defaultValue, {
     updateOnContextChanged: true,
-    ...evaluationOptions
+    ...evaluationOptions,
   });
 
   // If the flag evaluation failed, we render the fallback

--- a/packages/react/test/declarative.spec.tsx
+++ b/packages/react/test/declarative.spec.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
 import { render, screen } from '@testing-library/react';
 import { FeatureFlag } from '../src/declarative/FeatureFlag'; // Assuming Feature.tsx is in the same directory or adjust path
-import type { Provider} from '../src';
+import type { Provider } from '../src';
 import { InMemoryProvider, OpenFeature, OpenFeatureProvider, ProviderStatus } from '../src';
 import type { EvaluationDetails } from '@openfeature/core';
 
@@ -127,13 +127,9 @@ describe('Feature Component', () => {
       render(
         <OpenFeatureProvider domain={EVALUATION}>
           <Suspense fallback={<div>Suspense</div>}>
-              <FeatureFlag
-                flagKey={BOOL_FLAG_KEY}
-                defaultValue={false}
-                evaluationOptions={{ suspend: true }}
-              >
-                <ChildComponent />
-              </FeatureFlag>
+            <FeatureFlag flagKey={BOOL_FLAG_KEY} defaultValue={false} evaluationOptions={{ suspend: true }}>
+              <ChildComponent />
+            </FeatureFlag>
           </Suspense>
         </OpenFeatureProvider>,
       );
@@ -145,13 +141,9 @@ describe('Feature Component', () => {
       render(
         <OpenFeatureProvider domain={EVALUATION}>
           <Suspense fallback={<div>Suspense</div>}>
-              <FeatureFlag
-                flagKey={BOOL_FLAG_KEY}
-                defaultValue={false}
-                evaluationOptions={{ suspend: true }}
-              >
-                <ChildComponent />
-              </FeatureFlag>
+            <FeatureFlag flagKey={BOOL_FLAG_KEY} defaultValue={false} evaluationOptions={{ suspend: true }}>
+              <ChildComponent />
+            </FeatureFlag>
           </Suspense>
         </OpenFeatureProvider>,
       );


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR is adding evaluation options to the FeatureFlag component to allow the use of suspend options.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/js-sdk/issues/1321

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

