### PR TITLE
fix: attach Ready listener independent of current client status in `attachHandlersAndResolve` (closes #1331)

### DIFF
--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -342,10 +342,9 @@ function attachHandlersAndResolve<T extends FlagValue>(
 
   useEffect(() => {
     const controller = new AbortController();
-    if (status === ProviderStatus.NOT_READY) {
-      // update when the provider is ready
-      client.addHandler(ProviderEvents.Ready, updateEvaluationDetailsCallback, { signal: controller.signal });
-    }
+    // Always register the Ready handler to catch provider initialization
+    // even if current status is already READY (e.g., from a NoOp provider)
+    client.addHandler(ProviderEvents.Ready, updateEvaluationDetailsCallback, { signal: controller.signal });
 
     if (defaultedOptions.updateOnContextChanged) {
       // update when the context changes
@@ -364,7 +363,6 @@ function attachHandlersAndResolve<T extends FlagValue>(
     };
   }, [
     client,
-    status,
     defaultedOptions.updateOnContextChanged,
     defaultedOptions.updateOnConfigurationChanged,
     updateEvaluationDetailsCallback,


### PR DESCRIPTION
## Motivation

This PR fixes https://github.com/open-feature/js-sdk/issues/1331

## Changes

- Update `attachHandlersAndResolve` to always attach the `ProviderEvents.READY` listener to the client independently of the initial state.
- Add a test for the scenario listed in the associated issue.