### PR TITLE
chore: prompt release for angular 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,7 +33,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["README.md"],
-      "versioning": "default"
+      "versioning": "default",
+      "release-as": "1.0.0"
     },
     "packages/nest": {
       "release-type": "node",


### PR DESCRIPTION
Releases the Angular SDK as 1.0.0 closing #1329
