### PR TITLE
feat: Make value optional if no defaultVariant is set

### DIFF
--- a/packages/shared/src/evaluation/evaluation.ts
+++ b/packages/shared/src/evaluation/evaluation.ts
@@ -17,7 +17,7 @@ export type ResolutionReason = keyof typeof StandardResolutionReasons | (string 
 export type FlagMetadata = Record<string, string | number | boolean>;
 
 export type ResolutionDetails<U> = {
-  value: U;
+  value?: U;
   variant?: string;
   flagMetadata?: FlagMetadata;
   reason?: ResolutionReason;


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Makes the resolution value optional. If no targeting rules match and no defaultVariant is set it should be possible to return reason DEFAULT and no value to fall back to the code default.

### Related Issues
https://github.com/open-feature/flagd/issues/1856

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

