### PR TITLE
fix: Type soundness issue with Provider.resolveObjectEvaluation #1158

### DIFF
--- a/packages/server/src/provider/provider.ts
+++ b/packages/server/src/provider/provider.ts
@@ -52,7 +52,7 @@ export interface Provider extends CommonProvider<ServerProviderStatus> {
   /**
    * Resolve and parse an object flag and its evaluation details.
    */
-  resolveObjectEvaluation<T extends JsonValue>(
+  resolveObjectEvaluation(
     flagKey: string,
     defaultValue: JsonValue,
     context: EvaluationContext,

--- a/packages/server/src/provider/provider.ts
+++ b/packages/server/src/provider/provider.ts
@@ -54,8 +54,8 @@ export interface Provider extends CommonProvider<ServerProviderStatus> {
    */
   resolveObjectEvaluation<T extends JsonValue>(
     flagKey: string,
-    defaultValue: T,
+    defaultValue: JsonValue,
     context: EvaluationContext,
     logger: Logger,
-  ): Promise<ResolutionDetails<T>>;
+  ): Promise<ResolutionDetails<JsonValue>>;
 }


### PR DESCRIPTION
## This PR
Updates the TypeScript method signature of `resolveObjectEvaluation` so that the `defaultValue` has a type of `JsonValue` and the returned promise's `ResolutionDetails` has a type of `JsonValue`
