### PR TITLE
fix(nest): correct rxjs 8.0.0 peer, remove rxjs 6 support (EOL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16264,7 +16264,11 @@
         "@angular/build": "^21.0.3",
         "@angular/cli": "^21.0.3",
         "@angular/common": "^21.0.4",
+<<<<<<< HEAD
         "@angular/compiler": "^21.1.0",
+=======
+        "@angular/compiler": "^21.0.4",
+>>>>>>> 0b884709 (fixup: lock)
         "@angular/compiler-cli": "^21.0.4",
         "@angular/core": "^21.0.4",
         "@angular/forms": "^21.0.4",
@@ -17881,7 +17885,7 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "@openfeature/server-sdk": "^1.17.1",
-        "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0"
+        "rxjs": "^7.0.0 || ^8.0.0"
       }
     },
     "packages/nest/node_modules/@nestjs/platform-express": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16264,11 +16264,7 @@
         "@angular/build": "^21.0.3",
         "@angular/cli": "^21.0.3",
         "@angular/common": "^21.0.4",
-<<<<<<< HEAD
-        "@angular/compiler": "^21.1.0",
-=======
         "@angular/compiler": "^21.0.4",
->>>>>>> 0b884709 (fixup: lock)
         "@angular/compiler-cli": "^21.0.4",
         "@angular/core": "^21.0.4",
         "@angular/forms": "^21.0.4",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "rxjs": "^6.0.0 || ^7.0.0 || ^8.0.0",
+    "rxjs": "^7.0.0 || ^8.0.0",
     "@openfeature/server-sdk": "^1.17.1"
   },
   "devDependencies": {

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "rxjs": "^6.0.0 || ^7.0.0 || 8.0.0",
+    "rxjs": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "@openfeature/server-sdk": "^1.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Add missing caret to the `rxjs` peer dependency range in `packages/nest/package.json`

## Context

While reviewing the README in #1378, the `rxjs` peer dependency range was noted as inconsistent: `"^6.0.0 || ^7.0.0 || 8.0.0"` — the first two versions use caret ranges, but `8.0.0` is an exact version. That restricts compatibility to exactly rxjs `8.0.0` and excludes any future rxjs `8.x` patch/minor releases, which is almost certainly not the intent.

This PR aligns the range with the caret convention used for the other versions.