### PR TITLE
feat(angular): add provideOpenFeature() standalone provider function

### DIFF
--- a/packages/angular/projects/angular-sdk/CHANGELOG.md
+++ b/packages/angular/projects/angular-sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### ✨ New Features
+
+* **angular:** add provideOpenFeature() standalone provider function (#1365)
+
+### ⚠ Deprecations
+
+* **angular:** OpenFeatureModule and forRoot() deprecated in favour of provideOpenFeature()
 
 ## [1.2.0](https://github.com/open-feature/js-sdk/compare/angular-sdk-v1.1.0...angular-sdk-v1.2.0) (2026-04-21)
 

--- a/packages/angular/projects/angular-sdk/README.md
+++ b/packages/angular/projects/angular-sdk/README.md
@@ -50,8 +50,8 @@ In addition to the features provided by the [web sdk](https://openfeature.dev/do
     - [yarn](#yarn)
     - [Required peer dependencies](#required-peer-dependencies)
   - [Usage](#usage)
-    - [Module](#module)
-      - [Minimal Example](#minimal-example)
+    - [Standalone configuration (recommended)](#standalone-configuration-recommended)
+    - [NgModule configuration (deprecated)](#ngmodule-configuration-deprecated)
     - [How to use](#how-to-use)
       - [Structural Directives](#structural-directives)
         - [Boolean Feature Flag](#boolean-feature-flag)
@@ -104,9 +104,44 @@ See the [package.json](./package.json) for the required versions.
 
 ### Usage
 
-#### Module
+#### Standalone configuration (recommended)
 
-To configure OpenFeature for your application, import the `OpenFeatureModule` and call `forRoot` to register the provider(s) and optional evaluation context.
+For standalone / `bootstrapApplication`-based apps, pass `provideOpenFeature()` in the `providers` array of your `ApplicationConfig`:
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideOpenFeature } from '@openfeature/angular-sdk';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideOpenFeature({
+      provider: yourFeatureProvider,
+      // domainBoundProviders are optional, mostly needed if more than one provider is used in the application.
+      domainBoundProviders: {
+        domain1: new YourOpenFeatureProvider(),
+        domain2: new YourOtherOpenFeatureProvider(),
+      },
+    }),
+  ],
+};
+```
+
+Then bootstrap your app with this config:
+
+```typescript
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig);
+```
+
+#### NgModule configuration (deprecated)
+
+> [!WARNING]
+> `OpenFeatureModule` and `forRoot()` are deprecated. Use [`provideOpenFeature()`](#standalone-configuration-recommended) instead.
+
+To configure OpenFeature for NgModule-based applications, import the `OpenFeatureModule` and call `forRoot` to register the provider(s) and optional evaluation context.
 
 ```typescript
 import { NgModule } from '@angular/core';
@@ -362,7 +397,7 @@ const flag$ = this.flagService.getBooleanDetails('my-flag', false, 'my-domain', 
 
 ##### Setting evaluation context
 
-To set the initial evaluation context, you can add the `context` parameter to the `OpenFeatureModule` configuration.
+To set the initial evaluation context, you can add the `context` parameter to the `provideOpenFeature()` configuration.
 This context can be either an object or a factory function that returns an `EvaluationContext`.
 
 > [!TIP]
@@ -373,48 +408,42 @@ Here’s how you can define and use the initial client evaluation context:
 ###### Using a static object
 
 ```typescript
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { OpenFeatureModule } from '@openfeature/angular-sdk';
+import { ApplicationConfig } from ‘@angular/core’;
+import { provideOpenFeature } from ‘@openfeature/angular-sdk’;
 
 const initialContext = {
   user: {
-    id: 'user123',
-    role: 'admin',
+    id: ‘user123’,
+    role: ‘admin’,
   },
 };
 
-@NgModule({
-  imports: [
-    CommonModule,
-    OpenFeatureModule.forRoot({
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideOpenFeature({
       provider: yourFeatureProvider,
       context: initialContext,
     }),
   ],
-})
-export class AppModule {}
+};
 ```
 
 ###### Using a factory function
 
 ```typescript
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { OpenFeatureModule, EvaluationContext } from '@openfeature/angular-sdk';
+import { ApplicationConfig } from ‘@angular/core’;
+import { provideOpenFeature, EvaluationContext } from ‘@openfeature/angular-sdk’;
 
 const contextFactory = (): EvaluationContext => loadContextFromLocalStorage();
 
-@NgModule({
-  imports: [
-    CommonModule,
-    OpenFeatureModule.forRoot({
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideOpenFeature({
       provider: yourFeatureProvider,
       context: contextFactory,
     }),
   ],
-})
-export class AppModule {}
+};
 ```
 
 ##### Observability considerations

--- a/packages/angular/projects/angular-sdk/README.md
+++ b/packages/angular/projects/angular-sdk/README.md
@@ -403,18 +403,18 @@ This context can be either an object or a factory function that returns an `Eval
 > [!TIP]
 > Updating the context can be done directly via the global OpenFeature API using `OpenFeature.setContext()`
 
-Here’s how you can define and use the initial client evaluation context:
+Here's how you can define and use the initial client evaluation context:
 
 ###### Using a static object
 
 ```typescript
-import { ApplicationConfig } from ‘@angular/core’;
-import { provideOpenFeature } from ‘@openfeature/angular-sdk’;
+import { ApplicationConfig } from '@angular/core';
+import { provideOpenFeature } from '@openfeature/angular-sdk';
 
 const initialContext = {
   user: {
-    id: ‘user123’,
-    role: ‘admin’,
+    id: 'user123',
+    role: 'admin',
   },
 };
 
@@ -431,8 +431,8 @@ export const appConfig: ApplicationConfig = {
 ###### Using a factory function
 
 ```typescript
-import { ApplicationConfig } from ‘@angular/core’;
-import { provideOpenFeature, EvaluationContext } from ‘@openfeature/angular-sdk’;
+import { ApplicationConfig } from '@angular/core';
+import { provideOpenFeature, EvaluationContext } from '@openfeature/angular-sdk';
 
 const contextFactory = (): EvaluationContext => loadContextFromLocalStorage();
 

--- a/packages/angular/projects/angular-sdk/src/lib/open-feature.module.ts
+++ b/packages/angular/projects/angular-sdk/src/lib/open-feature.module.ts
@@ -38,17 +38,19 @@ export const OPEN_FEATURE_CONFIG_TOKEN = new InjectionToken<OpenFeatureConfig>('
 
 export function provideOpenFeature(config: OpenFeatureConfig): EnvironmentProviders {
   const context = typeof config.context === 'function' ? config.context() : config.context;
-  OpenFeature.setProvider(config.provider, context);
+  if (config.provider) {
+    OpenFeature.setProvider(config.provider, context);
+  }
   if (config.domainBoundProviders) {
-    Object.entries(config.domainBoundProviders).map(([domain, provider]) =>
-      OpenFeature.setProvider(domain, provider, context),
-    );
+    Object.entries(config.domainBoundProviders).forEach(([domain, provider]) => {
+      OpenFeature.setProvider(domain, provider, context);
+    });
   }
   return makeEnvironmentProviders([{ provide: OPEN_FEATURE_CONFIG_TOKEN, useValue: config }]);
 }
 
 /**
- * @deprecated Use {@link provideOpenFeature} instead. OpenFeatureModule will be removed in a future version.
+ * @deprecated Use {@link provideOpenFeature} instead.
  */
 @NgModule({
   declarations: [],

--- a/packages/angular/projects/angular-sdk/src/lib/open-feature.module.ts
+++ b/packages/angular/projects/angular-sdk/src/lib/open-feature.module.ts
@@ -1,4 +1,10 @@
-import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
+import {
+  EnvironmentProviders,
+  InjectionToken,
+  makeEnvironmentProviders,
+  ModuleWithProviders,
+  NgModule,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EvaluationContext, OpenFeature, Provider } from '@openfeature/web-sdk';
 
@@ -30,25 +36,33 @@ export interface OpenFeatureConfig {
 
 export const OPEN_FEATURE_CONFIG_TOKEN = new InjectionToken<OpenFeatureConfig>('OPEN_FEATURE_CONFIG_TOKEN');
 
+export function provideOpenFeature(config: OpenFeatureConfig): EnvironmentProviders {
+  const context = typeof config.context === 'function' ? config.context() : config.context;
+  OpenFeature.setProvider(config.provider, context);
+  if (config.domainBoundProviders) {
+    Object.entries(config.domainBoundProviders).map(([domain, provider]) =>
+      OpenFeature.setProvider(domain, provider, context),
+    );
+  }
+  return makeEnvironmentProviders([{ provide: OPEN_FEATURE_CONFIG_TOKEN, useValue: config }]);
+}
+
+/**
+ * @deprecated Use {@link provideOpenFeature} instead. OpenFeatureModule will be removed in a future version.
+ */
 @NgModule({
   declarations: [],
   imports: [CommonModule],
   exports: [],
 })
 export class OpenFeatureModule {
+  /**
+   * @deprecated Use {@link provideOpenFeature} instead.
+   */
   static forRoot(config: OpenFeatureConfig): ModuleWithProviders<OpenFeatureModule> {
-    const context = typeof config.context === 'function' ? config.context() : config.context;
-    OpenFeature.setProvider(config.provider, context);
-
-    if (config.domainBoundProviders) {
-      Object.entries(config.domainBoundProviders).map(([domain, provider]) =>
-        OpenFeature.setProvider(domain, provider, context),
-      );
-    }
-
     return {
       ngModule: OpenFeatureModule,
-      providers: [{ provide: OPEN_FEATURE_CONFIG_TOKEN, useValue: config }],
+      providers: [provideOpenFeature(config)],
     };
   }
 }

--- a/packages/angular/projects/angular-sdk/src/lib/provide-open-feature.spec.ts
+++ b/packages/angular/projects/angular-sdk/src/lib/provide-open-feature.spec.ts
@@ -1,0 +1,165 @@
+import { TestBed } from '@angular/core/testing';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { vi } from 'vitest';
+import { TestingProvider } from '../test/test.utils';
+import {
+  OPEN_FEATURE_CONFIG_TOKEN,
+  OpenFeatureModule,
+  provideOpenFeature,
+  OpenFeatureConfig,
+} from './open-feature.module';
+
+describe('provideOpenFeature', () => {
+  let provider: TestingProvider;
+
+  beforeEach(() => {
+    provider = new TestingProvider(
+      {
+        testFlag: { variants: { on: true, off: false }, defaultVariant: 'on', disabled: false },
+      },
+      0,
+    );
+  });
+
+  afterEach(async () => {
+    await OpenFeature.close();
+    await OpenFeature.setContext({});
+    vi.restoreAllMocks();
+  });
+
+  it('registers OPEN_FEATURE_CONFIG_TOKEN with the original config object', () => {
+    const config: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    const token = TestBed.inject(OPEN_FEATURE_CONFIG_TOKEN);
+    expect(token).toBe(config);
+  });
+
+  it('configures the default provider via OpenFeature.setProvider', () => {
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(spy).toHaveBeenCalledWith(provider, undefined);
+  });
+
+  it('configures domain-bound providers', () => {
+    const domainProvider = new TestingProvider(
+      { flag: { variants: { on: true }, defaultVariant: 'on', disabled: false } },
+      0,
+    );
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider, domainBoundProviders: { myDomain: domainProvider } };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(spy).toHaveBeenCalledWith('myDomain', domainProvider, undefined);
+  });
+
+  it('passes static evaluation context to default and domain providers', () => {
+    const domainProvider = new TestingProvider(
+      { flag: { variants: { on: true }, defaultVariant: 'on', disabled: false } },
+      0,
+    );
+    const context = { userId: 'abc123' };
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider, context, domainBoundProviders: { myDomain: domainProvider } };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(spy).toHaveBeenCalledWith(provider, context);
+    expect(spy).toHaveBeenCalledWith('myDomain', domainProvider, context);
+  });
+
+  it('invokes context factory exactly once and uses the resolved context everywhere', () => {
+    const domainProvider = new TestingProvider(
+      { flag: { variants: { on: true }, defaultVariant: 'on', disabled: false } },
+      0,
+    );
+    const resolvedContext = { userId: 'factory-user' };
+    const factory = vi.fn().mockReturnValue(resolvedContext);
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider, context: factory, domainBoundProviders: { d1: domainProvider } };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(provider, resolvedContext);
+    expect(spy).toHaveBeenCalledWith('d1', domainProvider, resolvedContext);
+  });
+
+  it('uses the same context reference for all providers', () => {
+    const domainProvider1 = new TestingProvider(
+      { flag: { variants: { on: true }, defaultVariant: 'on', disabled: false } },
+      0,
+    );
+    const domainProvider2 = new TestingProvider(
+      { flag: { variants: { on: true }, defaultVariant: 'on', disabled: false } },
+      0,
+    );
+    const resolvedContext = { userId: 'shared' };
+    const factory = vi.fn().mockReturnValue(resolvedContext);
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = {
+      provider,
+      context: factory,
+      domainBoundProviders: { d1: domainProvider1, d2: domainProvider2 },
+    };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    const calls = spy.mock.calls;
+    const contexts = calls.map((c) => c[c.length - 1]);
+    expect(contexts.every((ctx) => ctx === resolvedContext)).toBe(true);
+  });
+
+  it('OpenFeatureModule.forRoot() still works', () => {
+    const config: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      imports: [OpenFeatureModule.forRoot(config)],
+    });
+    const token = TestBed.inject(OPEN_FEATURE_CONFIG_TOKEN);
+    expect(token).toBe(config);
+  });
+
+  it('works when no domain-bound providers are specified', () => {
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(provider, undefined);
+  });
+
+  it('works when context is omitted entirely', () => {
+    const spy = vi.spyOn(OpenFeature, 'setProvider');
+    const config: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(config)],
+    });
+    expect(spy).toHaveBeenCalledWith(provider, undefined);
+  });
+
+  it('module and standalone paths produce the same OPEN_FEATURE_CONFIG_TOKEN', async () => {
+    const configA: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      imports: [OpenFeatureModule.forRoot(configA)],
+    });
+    const tokenFromModule = TestBed.inject(OPEN_FEATURE_CONFIG_TOKEN);
+
+    TestBed.resetTestingModule();
+    await OpenFeature.close();
+
+    const configB: OpenFeatureConfig = { provider };
+    TestBed.configureTestingModule({
+      providers: [provideOpenFeature(configB)],
+    });
+    const tokenFromStandalone = TestBed.inject(OPEN_FEATURE_CONFIG_TOKEN);
+
+    expect(tokenFromModule).toBe(configA);
+    expect(tokenFromStandalone).toBe(configB);
+  });
+});

--- a/packages/angular/projects/angular-sdk/src/lib/provide-open-feature.spec.ts
+++ b/packages/angular/projects/angular-sdk/src/lib/provide-open-feature.spec.ts
@@ -134,12 +134,13 @@ describe('provideOpenFeature', () => {
     expect(spy).toHaveBeenCalledWith(provider, undefined);
   });
 
-  it('works when context is omitted entirely', () => {
+  it('empty domainBoundProviders causes only one setProvider() call', () => {
     const spy = vi.spyOn(OpenFeature, 'setProvider');
-    const config: OpenFeatureConfig = { provider };
+    const config: OpenFeatureConfig = { provider, domainBoundProviders: {} };
     TestBed.configureTestingModule({
       providers: [provideOpenFeature(config)],
     });
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(provider, undefined);
   });
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Adds `provideOpenFeature()` as the modern, recommended way to configure OpenFeature in standalone Angular apps, and deprecates `OpenFeatureModule` without removing it.

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1365 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

