### PR TITLE
fix(angular): bump @openfeature/web-sdk peer to ^1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19709,13 +19709,13 @@
       "devDependencies": {
         "@angular/common": "^21.0.4",
         "@angular/core": "^21.0.4",
-        "@openfeature/core": "^1.10.0",
-        "@openfeature/web-sdk": "^1.8.0"
+        "@openfeature/core": "*",
+        "@openfeature/web-sdk": "*"
       },
       "peerDependencies": {
         "@angular/common": "^16.2.12 || ^17.3.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
         "@angular/core": "^16.2.12 || ^17.3.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
-        "@openfeature/web-sdk": "^1.8.0"
+        "@openfeature/web-sdk": "^1.9.0"
       }
     },
     "packages/nest": {

--- a/packages/angular/projects/angular-sdk/package.json
+++ b/packages/angular/projects/angular-sdk/package.json
@@ -19,14 +19,14 @@
   "peerDependencies": {
     "@angular/common": "^16.2.12 || ^17.3.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/core": "^16.2.12 || ^17.3.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
-    "@openfeature/web-sdk": "^1.8.0"
+    "@openfeature/web-sdk": "^1.9.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@openfeature/core": "^1.10.0",
-    "@openfeature/web-sdk": "^1.8.0",
+    "@openfeature/core": "*",
+    "@openfeature/web-sdk": "*",
     "@angular/common": "^21.0.4",
     "@angular/core": "^21.0.4"
   },


### PR DESCRIPTION
1.3.0 was published without the web-sdk peer bump. Corrects the peer to `^1.9.0` so release-please cuts a 1.3.1.