### PR TITLE
fix: redundant re-renders with unstable inputs

### DIFF
--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -356,7 +356,7 @@ function attachHandlersAndResolve<T extends FlagValue>(
     }
 
     updateEvaluationDetailsCallback();
-  });
+  }, [client, flagKey, defaultValue, options, resolver, updateEvaluationDetailsCallback]);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -279,12 +279,22 @@ function shouldEvaluateFlag(flagKey: string, flagsChanged?: string[]): boolean {
   return !flagsChanged || flagsChanged.includes(flagKey);
 }
 
+type EvaluationResolver<T extends FlagValue> = (
+  client: Client,
+) => (flagKey: string, defaultValue: T, options?: FlagEvaluationOptions) => EvaluationDetails<T>;
+
+type EvaluationInputs<T extends FlagValue> = {
+  client: Client;
+  flagKey: string;
+  defaultValue: T;
+  resolver: EvaluationResolver<T>;
+  options?: ReactFlagEvaluationOptions;
+};
+
 function attachHandlersAndResolve<T extends FlagValue>(
   flagKey: string,
   defaultValue: T,
-  resolver: (
-    client: Client,
-  ) => (flagKey: string, defaultValue: T, options?: FlagEvaluationOptions) => EvaluationDetails<T>,
+  resolver: EvaluationResolver<T>,
   options?: ReactFlagEvaluationOptions,
 ): EvaluationDetails<T> {
   // highest priority > evaluation hook options > provider options > default options > lowest priority
@@ -306,44 +316,47 @@ function attachHandlersAndResolve<T extends FlagValue>(
     resolver(client).call(client, flagKey, defaultValue, options),
   );
 
-  // Re-evaluate when dependencies change (handles prop changes like flagKey), or if during a re-render, we have detected a change in the evaluated value
-  useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-
-    const newDetails = resolver(client).call(client, flagKey, defaultValue, options);
-    if (!isEqual(newDetails, evaluationDetails)) {
-      setEvaluationDetails(newDetails);
-    }
-  }, [client, flagKey, defaultValue, options, resolver, evaluationDetails]);
-
-  // Maintain a mutable reference to the evaluation details to have a up-to-date reference in the handlers.
+  // Maintain mutable references so event handlers stay stable while evaluating the latest render inputs.
+  const evaluationInputsRef = useRef<EvaluationInputs<T>>({ client, flagKey, defaultValue, resolver, options });
   const evaluationDetailsRef = useRef<EvaluationDetails<T>>(evaluationDetails);
+
   useEffect(() => {
+    evaluationInputsRef.current = { client, flagKey, defaultValue, resolver, options };
     evaluationDetailsRef.current = evaluationDetails;
-  }, [evaluationDetails]);
+  });
 
   const updateEvaluationDetailsCallback = useCallback(() => {
+    const { client, flagKey, defaultValue, resolver, options } = evaluationInputsRef.current;
     const updatedEvaluationDetails = resolver(client).call(client, flagKey, defaultValue, options);
 
     /**
      * Avoid re-rendering if the evaluation details haven't changed.
      */
     if (!isEqual(updatedEvaluationDetails, evaluationDetailsRef.current)) {
+      evaluationDetailsRef.current = updatedEvaluationDetails;
       setEvaluationDetails(updatedEvaluationDetails);
     }
-  }, [client, flagKey, defaultValue, options, resolver]);
+  }, []);
 
   const configurationChangeCallback = useCallback<EventHandler<ClientProviderEvents.ConfigurationChanged>>(
     (eventDetails) => {
+      const { flagKey } = evaluationInputsRef.current;
       if (shouldEvaluateFlag(flagKey, eventDetails?.flagsChanged)) {
         updateEvaluationDetailsCallback();
       }
     },
-    [flagKey, updateEvaluationDetailsCallback],
+    [updateEvaluationDetailsCallback],
   );
+
+  // Re-evaluate after every re-render to detect silent provider updates, without churning event subscriptions.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    updateEvaluationDetailsCallback();
+  });
 
   useEffect(() => {
     const controller = new AbortController();

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -340,8 +340,8 @@ function attachHandlersAndResolve<T extends FlagValue>(
 
   const configurationChangeCallback = useCallback<EventHandler<ClientProviderEvents.ConfigurationChanged>>(
     (eventDetails) => {
-      const { flagKey } = evaluationInputsRef.current;
-      if (shouldEvaluateFlag(flagKey, eventDetails?.flagsChanged)) {
+      const { flagKey: currentFlagKey } = evaluationInputsRef.current;
+      if (shouldEvaluateFlag(currentFlagKey, eventDetails?.flagsChanged)) {
         updateEvaluationDetailsCallback();
       }
     },

--- a/packages/react/src/evaluation/use-feature-flag.ts
+++ b/packages/react/src/evaluation/use-feature-flag.ts
@@ -348,7 +348,7 @@ function attachHandlersAndResolve<T extends FlagValue>(
     [updateEvaluationDetailsCallback],
   );
 
-  // Re-evaluate after every re-render to detect silent provider updates, without churning event subscriptions.
+  // Re-evaluate on render input changes to catch silent provider updates
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;

--- a/packages/react/test/evaluation.spec.tsx
+++ b/packages/react/test/evaluation.spec.tsx
@@ -391,10 +391,12 @@ describe('evaluation', () => {
         const { rerender, unmount } = render(renderHookComponents(0));
 
         await waitFor(() => {
-          // One Ready handler tracks client status, and one re-evaluates the flag.
-          expect(client.getHandlers(ProviderEvents.Ready)).toHaveLength(HOOK_COUNT * 2);
+          expect(client.getHandlers(ProviderEvents.Ready).length).toBeGreaterThan(0);
         });
 
+        const readyHandlersAfterMount = client.getHandlers(ProviderEvents.Ready).length;
+        const contextChangedHandlersAfterMount = client.getHandlers(ProviderEvents.ContextChanged).length;
+        const configurationChangedHandlersAfterMount = client.getHandlers(ProviderEvents.ConfigurationChanged).length;
         const readyAddsAfterMount = addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.Ready).length;
         const contextAddsAfterMount = addHandlerSpy.mock.calls.filter(
           ([event]) => event === ProviderEvents.ContextChanged,
@@ -419,6 +421,11 @@ describe('evaluation', () => {
         expect(
           addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.ConfigurationChanged),
         ).toHaveLength(configurationAddsAfterMount);
+        expect(client.getHandlers(ProviderEvents.Ready)).toHaveLength(readyHandlersAfterMount);
+        expect(client.getHandlers(ProviderEvents.ContextChanged)).toHaveLength(contextChangedHandlersAfterMount);
+        expect(client.getHandlers(ProviderEvents.ConfigurationChanged)).toHaveLength(
+          configurationChangedHandlersAfterMount,
+        );
         expect(removeHandlerSpy).not.toHaveBeenCalled();
         expect(resolverSpy).toHaveBeenCalledTimes(evaluationsAfterMount + HOOK_COUNT * RERENDERS);
 

--- a/packages/react/test/evaluation.spec.tsx
+++ b/packages/react/test/evaluation.spec.tsx
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 import type { InMemoryFlagConfiguration, InMemoryFlagVariants, ProviderEmittableEvents } from '@openfeature/web-sdk';
-import { ClientProviderEvents } from '@openfeature/web-sdk';
+import { ClientProviderEvents, ProviderEvents } from '@openfeature/web-sdk';
 import '@testing-library/jest-dom'; // see: https://testing-library.com/docs/react-testing-library/setup
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
@@ -344,6 +344,89 @@ describe('evaluation', () => {
 
       afterEach(() => {
         jest.clearAllMocks();
+      });
+
+      it.each([
+        ['default options', undefined],
+        [
+          'inline options',
+          () => ({
+            updateOnConfigurationChanged: true,
+            updateOnContextChanged: true,
+          }),
+        ],
+      ])('should not re-register event handlers on steady-state parent re-renders with %s', async (_, getOptions) => {
+        const HANDLER_DOMAIN = `ready-handler-lifecycle-${getOptions ? 'inline' : 'default'}`;
+        const HOOK_COUNT = 8;
+        const RERENDERS = 4;
+
+        await OpenFeature.setProviderAndWait(HANDLER_DOMAIN, makeProvider());
+        const client = OpenFeature.getClient(HANDLER_DOMAIN);
+        const addHandlerSpy = jest.spyOn(client, 'addHandler');
+        const removeHandlerSpy = jest.spyOn(client, 'removeHandler');
+        const resolverSpy = jest.spyOn(client, 'getBooleanDetails');
+
+        function HookComponent() {
+          useBooleanFlagValue(BOOL_FLAG_KEY, false, getOptions?.());
+          return null;
+        }
+
+        function TestComponent({ tick }: { tick: number }) {
+          return (
+            <>
+              <div data-testid="tick">{tick}</div>
+              {Array.from({ length: HOOK_COUNT }, (_, index) => (
+                <HookComponent key={index} />
+              ))}
+            </>
+          );
+        }
+
+        const renderHookComponents = (tick: number) => (
+          <OpenFeatureProvider client={client}>
+            <TestComponent tick={tick} />
+          </OpenFeatureProvider>
+        );
+
+        const { rerender, unmount } = render(renderHookComponents(0));
+
+        await waitFor(() => {
+          // One Ready handler tracks client status, and one re-evaluates the flag.
+          expect(client.getHandlers(ProviderEvents.Ready)).toHaveLength(HOOK_COUNT * 2);
+        });
+
+        const readyAddsAfterMount = addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.Ready).length;
+        const contextAddsAfterMount = addHandlerSpy.mock.calls.filter(
+          ([event]) => event === ProviderEvents.ContextChanged,
+        ).length;
+        const configurationAddsAfterMount = addHandlerSpy.mock.calls.filter(
+          ([event]) => event === ProviderEvents.ConfigurationChanged,
+        ).length;
+        const evaluationsAfterMount = resolverSpy.mock.calls.length;
+
+        for (let tick = 1; tick <= RERENDERS; tick++) {
+          act(() => {
+            rerender(renderHookComponents(tick));
+          });
+        }
+
+        expect(addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.Ready)).toHaveLength(
+          readyAddsAfterMount,
+        );
+        expect(addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.ContextChanged)).toHaveLength(
+          contextAddsAfterMount,
+        );
+        expect(
+          addHandlerSpy.mock.calls.filter(([event]) => event === ProviderEvents.ConfigurationChanged),
+        ).toHaveLength(configurationAddsAfterMount);
+        expect(removeHandlerSpy).not.toHaveBeenCalled();
+        expect(resolverSpy).toHaveBeenCalledTimes(evaluationsAfterMount + HOOK_COUNT * RERENDERS);
+
+        unmount();
+
+        expect(client.getHandlers(ProviderEvents.Ready)).toHaveLength(0);
+        expect(client.getHandlers(ProviderEvents.ContextChanged)).toHaveLength(0);
+        expect(client.getHandlers(ProviderEvents.ConfigurationChanged)).toHaveLength(0);
       });
 
       it('should not rerender on context change because the evaluated values did not change', async () => {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes repeated event handler registration in React flag evaluation hooks during normal parent re-renders.

The hook now keeps event handlers stable and reads the latest evaluation inputs from refs. This prevents repeated `Ready`, `ContextChanged`, and `ConfigurationChanged` handler registration while still allowing hooks to re-evaluate on parent re-renders for silent provider updates.

This keeps the behavior fixed by #1331: hooks still update when a provider is set after context is changed.

- stabilizes React flag evaluation event handlers
- prevents handler registration churn during steady-state re-renders
- keeps parent re-render evaluation behavior
- adds regression coverage for many `useBooleanFlagValue` hooks
- verifies handlers are cleaned up on unmount


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1360

### Notes
<!-- any additional notes for this PR -->
N/A

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
N/A

### How to test
<!-- if applicable, add testing instructions under this section -->

```bash
npx jest --selectProjects=react --silent
npm run lint --workspace=packages/react
npm run build --workspace=packages/react
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature flag evaluation to reduce unnecessary recomputation and ensure updates remain consistent, including during configuration changes.
  * Prevented repeated event handler re-registration on steady-state parent re-renders, resulting in more efficient and reliable hook behavior.

* **Tests**
  * Added coverage to verify hook event handlers stay stable across repeated parent re-renders.
  * Confirmed handler registration/unregistration counts and resolver invocations behave correctly when configuration/context update options are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->