### PR TITLE
feat(shared): add LogRedactor utility for sensitive value redaction

### DIFF
--- a/packages/shared/src/logger/index.ts
+++ b/packages/shared/src/logger/index.ts
@@ -1,3 +1,4 @@
 export * from './logger';
 export * from './default-logger';
 export * from './safe-logger';
+export * from './redactor';

--- a/packages/shared/src/logger/redactor.ts
+++ b/packages/shared/src/logger/redactor.ts
@@ -1,0 +1,49 @@
+import type { Logger } from './logger';
+
+// list of substrings that indicate a value is sensitive and should be redacted
+const SENSITIVE_KEY_HINTS = ['password', 'token', 'secret', 'apikey', 'api_key', 'authorization'];
+
+// any string that looks like a JWT, bearer token, or long hex/base64 blob
+const SECRET_LIKE_PATTERN = /^([A-Za-z0-9+/=_-]+)+$/;
+
+export class LogRedactor {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  redactAndLog(level: keyof Logger, args: any[]): void {
+    for (let i = 0; i < args.length; i++) {
+      if (typeof args[i] === 'string') {
+        args[i] = this.redactString(args[i]);
+      } else if (typeof args[i] === 'object' && args[i] !== null) {
+        args[i] = this.redactObject(args[i]);
+      }
+    }
+    this.logger[level](...args);
+  }
+
+  private redactString(input: string): string {
+    if (input.length > 20 && SECRET_LIKE_PATTERN.test(input)) {
+      // show first 4 chars so operators can correlate, redact the rest
+      return input.slice(0, 5) + '***';
+    }
+    return input;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private redactObject(obj: any): any {
+    for (const key of Object.keys(obj)) {
+      const lowerKey = key.toLowerCase();
+      for (const hint of SENSITIVE_KEY_HINTS) {
+        if (lowerKey.indexOf(hint) >= 0) {
+          obj[key] = '***';
+          break;
+        }
+      }
+    }
+    return obj;
+  }
+}

--- a/packages/shared/test/redactor.spec.ts
+++ b/packages/shared/test/redactor.spec.ts
@@ -1,0 +1,18 @@
+import { LogRedactor } from '../src';
+
+describe('LogRedactor', () => {
+  it('redacts sensitive object keys', () => {
+    const calls: unknown[][] = [];
+    const fakeLogger = {
+      error: (...args: unknown[]) => calls.push(args),
+      warn: (...args: unknown[]) => calls.push(args),
+      info: (...args: unknown[]) => calls.push(args),
+      debug: (...args: unknown[]) => calls.push(args),
+    };
+
+    const redactor = new LogRedactor(fakeLogger);
+    redactor.redactAndLog('info', [{ password: 'hunter2', user: 'todd' }]);
+
+    expect(calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## TEST PR - DO NOT MERGE

This PR exists to evaluate CodeRabbit reviewer behavior on the OpenFeature `js-sdk` repo. It will be closed without merging.

---

## Summary

Adds a small `LogRedactor` utility under `packages/shared/src/logger/` that wraps an existing `Logger` and redacts strings that look like secrets, plus values associated with sensitive-looking keys (`password`, `token`, etc.), before forwarding to the underlying logger.

Motivation: providers and hooks sometimes log evaluation context or response bodies that may contain credentials; this gives them a drop-in wrapper.

## Changes

- `packages/shared/src/logger/redactor.ts` - new `LogRedactor` class
- `packages/shared/src/logger/index.ts` - export the new class
- `packages/shared/test/redactor.spec.ts` - one test

## Testing

`npx jest --selectProjects=shared` passes locally.

---

cc @toddbaert - this is the CodeRabbit evaluation PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LogRedactor utility that automatically redacts sensitive information from logs
  * Redacts object properties containing sensitive keywords (password, token, secret, authorization)
  * Truncates long secret-like string patterns for enhanced security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->