### PR TITLE
fix: reset API state on close

### DIFF
--- a/packages/nest/test/open-feature.module.spec.ts
+++ b/packages/nest/test/open-feature.module.spec.ts
@@ -19,25 +19,6 @@ describe('OpenFeatureModule', () => {
       await moduleRef.close();
     });
 
-    describe('without configured providers', () => {
-      let moduleWithoutProvidersRef: TestingModule;
-      beforeAll(async () => {
-        moduleWithoutProvidersRef = await Test.createTestingModule({
-          imports: [OpenFeatureModule.forRoot({})],
-        }).compile();
-      });
-
-      afterAll(async () => {
-        await moduleWithoutProvidersRef.close();
-      });
-
-      it('should return the SDKs default provider and not throw', async () => {
-        expect(() => {
-          moduleWithoutProvidersRef.get<Client>(getOpenFeatureClientToken());
-        }).not.toThrow();
-      });
-    });
-
     it('should return the default provider', async () => {
       const client = moduleRef.get<Client>(getOpenFeatureClientToken());
       expect(client).toBeDefined();
@@ -90,6 +71,27 @@ describe('OpenFeatureModule', () => {
         await hookModuleRef.close();
         OpenFeature.clearHooks();
       }
+    });
+
+    // Placed after provider-dependent tests: closing this inner module calls OpenFeature.close()
+    // which now fully resets API state per spec requirement 1.6.2.
+    describe('without configured providers', () => {
+      let moduleWithoutProvidersRef: TestingModule;
+      beforeAll(async () => {
+        moduleWithoutProvidersRef = await Test.createTestingModule({
+          imports: [OpenFeatureModule.forRoot({})],
+        }).compile();
+      });
+
+      afterAll(async () => {
+        await moduleWithoutProvidersRef.close();
+      });
+
+      it('should return the SDKs default provider and not throw', async () => {
+        expect(() => {
+          moduleWithoutProvidersRef.get<Client>(getOpenFeatureClientToken());
+        }).not.toThrow();
+      });
     });
   });
 

--- a/packages/server/src/open-feature.ts
+++ b/packages/server/src/open-feature.ts
@@ -219,6 +219,13 @@ export class OpenFeatureAPI
     );
   }
 
+  async close(): Promise<void> {
+    await super.close();
+    this._domainScopedProviders.clear();
+    this._defaultProvider = new ProviderWrapper(NOOP_PROVIDER, ProviderStatus.NOT_READY, this._statusEnumType);
+    this._transactionContextPropagator = NOOP_TRANSACTION_CONTEXT_PROPAGATOR;
+  }
+
   /**
    * Clears all registered providers and resets the default provider.
    * @returns {Promise<void>}

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
 import type { Paradigm } from '@openfeature/core';
-import type { Provider, ProviderStatus } from '../src';
-import { OpenFeature, OpenFeatureAPI } from '../src';
+import type { Hook, Provider, ProviderStatus, TransactionContextPropagator } from '../src';
+import { NOOP_PROVIDER, OpenFeature, OpenFeatureAPI, ProviderEvents } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
@@ -228,6 +228,96 @@ describe('OpenFeature', () => {
       expect(OpenFeature.providerMetadata.name).toBe(provider1.metadata.name);
       await OpenFeature.close();
       expect(provider3.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Requirement 1.6.2', () => {
+    it('resets the default provider to no-op after close()', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider(provider);
+      expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
+      await OpenFeature.close();
+      expect(OpenFeature.providerMetadata.name).toBe(NOOP_PROVIDER.metadata.name);
+    });
+
+    it('clears domain-scoped providers after close()', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider('domain1', provider);
+      expect(OpenFeature.getProvider('domain1')).toBe(provider);
+      await OpenFeature.close();
+      expect(OpenFeature.getProvider('domain1').metadata.name).toBe(NOOP_PROVIDER.metadata.name);
+    });
+
+    it('clears global hooks after close()', async () => {
+      const hook = { before: jest.fn() } as unknown as Hook;
+      OpenFeature.addHooks(hook);
+      expect(OpenFeature.getHooks()).toHaveLength(1);
+      await OpenFeature.close();
+      expect(OpenFeature.getHooks()).toHaveLength(0);
+    });
+
+    it('clears global evaluation context after close()', async () => {
+      OpenFeature.setContext({ user: 'test' });
+      expect(OpenFeature.getContext()).toEqual({ user: 'test' });
+      await OpenFeature.close();
+      expect(OpenFeature.getContext()).toEqual({});
+    });
+
+    it('removes API-level event handlers after close()', async () => {
+      const handler = jest.fn();
+      OpenFeature.addHandler(ProviderEvents.Ready, handler);
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(1);
+      await OpenFeature.close();
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(0);
+    });
+
+    it('resets the transaction context propagator to the default after close()', async () => {
+      const customPropagator: TransactionContextPropagator = {
+        getTransactionContext: jest.fn(() => ({ custom: true })),
+        setTransactionContext: jest.fn(),
+      };
+      OpenFeature.setTransactionContextPropagator(customPropagator);
+      expect(OpenFeature.getTransactionContext()).toEqual({ custom: true });
+      await OpenFeature.close();
+      expect(OpenFeature.getTransactionContext()).toEqual({});
+    });
+  });
+
+  describe('clearProviders() remains provider-only', () => {
+    afterEach(async () => {
+      OpenFeature.clearHooks();
+      OpenFeature.clearHandlers();
+      OpenFeature.setContext({});
+    });
+
+    it('does not clear global hooks', async () => {
+      const hook = { before: jest.fn() } as unknown as Hook;
+      OpenFeature.addHooks(hook);
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getHooks()).toHaveLength(1);
+    });
+
+    it('does not clear global evaluation context', async () => {
+      OpenFeature.setContext({ user: 'test' });
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getContext()).toEqual({ user: 'test' });
+    });
+
+    it('does not remove API-level event handlers', async () => {
+      const handler = jest.fn();
+      OpenFeature.addHandler(ProviderEvents.Ready, handler);
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(1);
+    });
+
+    it('does not reset the transaction context propagator', async () => {
+      const customPropagator: TransactionContextPropagator = {
+        getTransactionContext: jest.fn(() => ({ custom: true })),
+        setTransactionContext: jest.fn(),
+      };
+      OpenFeature.setTransactionContextPropagator(customPropagator);
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getTransactionContext()).toEqual({ custom: true });
     });
   });
 });

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -281,6 +281,14 @@ describe('OpenFeature', () => {
       await OpenFeature.close();
       expect(OpenFeature.getTransactionContext()).toEqual({});
     });
+
+    it('calls provider onClose only once when the same provider instance is registered in multiple scopes', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider(provider);
+      OpenFeature.setProvider('domain1', provider);
+      await OpenFeature.close();
+      expect(provider.onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('clearProviders() remains provider-only', () => {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -395,13 +395,18 @@ export abstract class OpenFeatureCommonAPI<
   }
 
   async close(): Promise<void> {
-    await this._shutdownAllProviders();
-    this._hooks = [];
-    this._context = {};
-    this._domainScopedContext.clear();
-    this._clientEventHandlers.clear();
-    this._clientEvents.clear();
-    this._apiEmitter.removeAllHandlers();
+    try {
+      await this._shutdownAllProviders();
+    } catch (err) {
+      this._logger.error('Unable to cleanly close providers. Resetting state.');
+    } finally {
+      this._hooks = [];
+      this._context = {};
+      this._domainScopedContext.clear();
+      this._clientEventHandlers.clear();
+      this._clientEvents.clear();
+      this._apiEmitter.removeAllHandlers();
+    }
   }
 
   protected async clearProvidersAndSetDefault(defaultProvider: P): Promise<void> {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -395,6 +395,31 @@ export abstract class OpenFeatureCommonAPI<
   }
 
   async close(): Promise<void> {
+    await this._shutdownAllProviders();
+    this._hooks = [];
+    this._context = {};
+    this._domainScopedContext.clear();
+    this._clientEventHandlers.clear();
+    this._clientEvents.clear();
+    this._apiEmitter.removeAllHandlers();
+  }
+
+  protected async clearProvidersAndSetDefault(defaultProvider: P): Promise<void> {
+    try {
+      await this._shutdownAllProviders();
+    } catch (err) {
+      this._logger.error('Unable to cleanly close providers. Resetting to the default configuration.');
+    } finally {
+      this._domainScopedProviders.clear();
+      this._defaultProvider = new ProviderWrapper<P, AnyProviderStatus>(
+        defaultProvider,
+        this._statusEnumType.NOT_READY,
+        this._statusEnumType,
+      );
+    }
+  }
+
+  private async _shutdownAllProviders(): Promise<void> {
     try {
       await this?._defaultProvider.provider?.onClose?.();
     } catch (err) {
@@ -412,21 +437,6 @@ export abstract class OpenFeatureCommonAPI<
         }
       }),
     );
-  }
-
-  protected async clearProvidersAndSetDefault(defaultProvider: P): Promise<void> {
-    try {
-      await this.close();
-    } catch (err) {
-      this._logger.error('Unable to cleanly close providers. Resetting to the default configuration.');
-    } finally {
-      this._domainScopedProviders.clear();
-      this._defaultProvider = new ProviderWrapper<P, AnyProviderStatus>(
-        defaultProvider,
-        this._statusEnumType.NOT_READY,
-        this._statusEnumType,
-      );
-    }
   }
 
   private get allProviders(): P[] {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -420,20 +420,17 @@ export abstract class OpenFeatureCommonAPI<
   }
 
   private async _shutdownAllProviders(): Promise<void> {
-    try {
-      await this?._defaultProvider.provider?.onClose?.();
-    } catch (err) {
-      this.handleShutdownError(this._defaultProvider.provider, err);
-    }
-
-    const wrappers = Array.from(this._domainScopedProviders);
+    const uniqueProviders = new Set<P>([
+      this._defaultProvider.provider,
+      ...Array.from(this._domainScopedProviders.values()).map((wrapper) => wrapper.provider),
+    ]);
 
     await Promise.all(
-      wrappers.map(async ([, wrapper]) => {
+      Array.from(uniqueProviders).map(async (provider) => {
         try {
-          await wrapper?.provider.onClose?.();
+          await provider?.onClose?.();
         } catch (err) {
-          this.handleShutdownError(wrapper?.provider, err);
+          this.handleShutdownError(provider, err);
         }
       }),
     );

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -373,7 +373,6 @@ export class OpenFeatureAPI
    */
   async clearProviders(): Promise<void> {
     await super.clearProvidersAndSetDefault(NOOP_PROVIDER);
-    this._domainScopedContext.clear();
   }
 
   private async runProviderContextChangeHandler(

--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -361,6 +361,12 @@ export class OpenFeatureAPI
     );
   }
 
+  async close(): Promise<void> {
+    await super.close();
+    this._domainScopedProviders.clear();
+    this._defaultProvider = new ProviderWrapper(NOOP_PROVIDER, ProviderStatus.NOT_READY, this._statusEnumType);
+  }
+
   /**
    * Clears all registered providers and resets the default provider.
    * @returns {Promise<void>}

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
 import type { Paradigm } from '@openfeature/core';
-import type { Provider } from '../src';
-import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
+import type { Hook, Provider } from '../src';
+import { NOOP_PROVIDER, OpenFeature, OpenFeatureAPI, ProviderEvents, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
@@ -254,6 +254,82 @@ describe('OpenFeature', () => {
 
         expect(spy).toHaveBeenCalledWith({ name: 'todd' });
       });
+    });
+  });
+
+  describe('Requirement 1.6.2', () => {
+    it('resets the default provider to no-op after close()', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider(provider);
+      expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
+      await OpenFeature.close();
+      expect(OpenFeature.providerMetadata.name).toBe(NOOP_PROVIDER.metadata.name);
+    });
+
+    it('clears domain-scoped providers after close()', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider('domain1', provider);
+      expect(OpenFeature.getProvider('domain1')).toBe(provider);
+      await OpenFeature.close();
+      expect(OpenFeature.getProvider('domain1').metadata.name).toBe(NOOP_PROVIDER.metadata.name);
+    });
+
+    it('clears global hooks after close()', async () => {
+      const hook = { before: jest.fn() } as unknown as Hook;
+      OpenFeature.addHooks(hook);
+      expect(OpenFeature.getHooks()).toHaveLength(1);
+      await OpenFeature.close();
+      expect(OpenFeature.getHooks()).toHaveLength(0);
+    });
+
+    it('clears global evaluation context after close()', async () => {
+      await OpenFeature.setContext({ user: 'test' });
+      expect(OpenFeature.getContext()).toEqual({ user: 'test' });
+      await OpenFeature.close();
+      expect(OpenFeature.getContext()).toEqual({});
+    });
+
+    it('clears domain-scoped evaluation context after close()', async () => {
+      await OpenFeature.setContext('domain1', { user: 'test' });
+      expect(OpenFeature.getContext('domain1')).toEqual({ user: 'test' });
+      await OpenFeature.close();
+      expect(OpenFeature.getContext('domain1')).toEqual({});
+    });
+
+    it('removes API-level event handlers after close()', async () => {
+      const handler = jest.fn();
+      OpenFeature.addHandler(ProviderEvents.Ready, handler);
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(1);
+      await OpenFeature.close();
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(0);
+    });
+  });
+
+  describe('clearProviders() remains provider-only', () => {
+    afterEach(async () => {
+      OpenFeature.clearHooks();
+      OpenFeature.clearHandlers();
+      await OpenFeature.setContext({});
+    });
+
+    it('does not clear global hooks', async () => {
+      const hook = { before: jest.fn() } as unknown as Hook;
+      OpenFeature.addHooks(hook);
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getHooks()).toHaveLength(1);
+    });
+
+    it('does not clear global evaluation context', async () => {
+      await OpenFeature.setContext({ user: 'test' });
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getContext()).toEqual({ user: 'test' });
+    });
+
+    it('does not remove API-level event handlers', async () => {
+      const handler = jest.fn();
+      OpenFeature.addHandler(ProviderEvents.Ready, handler);
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(1);
     });
   });
 });

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -303,6 +303,14 @@ describe('OpenFeature', () => {
       await OpenFeature.close();
       expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(0);
     });
+
+    it('calls provider onClose only once when the same provider instance is registered in multiple scopes', async () => {
+      const provider = mockProvider();
+      OpenFeature.setProvider(provider);
+      OpenFeature.setProvider('domain1', provider);
+      await OpenFeature.close();
+      expect(provider.onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('clearProviders() remains provider-only', () => {
@@ -330,6 +338,13 @@ describe('OpenFeature', () => {
       OpenFeature.addHandler(ProviderEvents.Ready, handler);
       await OpenFeature.clearProviders();
       expect(OpenFeature.getHandlers(ProviderEvents.Ready)).toHaveLength(1);
+    });
+
+    it('does not clear domain-scoped evaluation context', async () => {
+      await OpenFeature.setContext('domain1', { user: 'test' });
+      await OpenFeature.clearProviders();
+      expect(OpenFeature.getContext('domain1')).toEqual({ user: 'test' });
+      await OpenFeature.clearContext('domain1');
     });
   });
 });


### PR DESCRIPTION
Fixes #1374.

Updates the `close()` shutdown path so it fully resets API-managed state after provider shutdown, including providers, hooks, event handlers, global evaluation context, and transaction-context propagator state.

`clearProviders()` remains provider-only for backward compatibility, matching maintainer guidance.