### PR TITLE
feat(core): pass bound domain to provider initialize and enforce domain-scoped binding

### DIFF
--- a/packages/server/src/provider/multi-provider/multi-provider.ts
+++ b/packages/server/src/provider/multi-provider/multi-provider.ts
@@ -104,9 +104,9 @@ export class MultiProvider implements Provider {
     Object.freeze(this.providerEntriesByName);
   }
 
-  async initialize(context?: EvaluationContext): Promise<void> {
+  async initialize(context?: EvaluationContext, domain?: string): Promise<void> {
     const result = await Promise.allSettled(
-      this.providerEntries.map((provider) => provider.provider.initialize?.(context)),
+      this.providerEntries.map((provider) => provider.provider.initialize?.(context, domain)),
     );
     throwAggregateErrorFromPromiseResults(result, this.providerEntries);
   }

--- a/packages/server/test/multi-provider.spec.ts
+++ b/packages/server/test/multi-provider.spec.ts
@@ -22,6 +22,7 @@ import {
   FirstSuccessfulStrategy,
   ComparisonStrategy,
 } from '../src';
+import { legacyInitTestProvider } from '../../shared/test/legacy-initialize-provider';
 
 class TestProvider implements Provider {
   public metadata: ProviderMetadata = {
@@ -42,28 +43,6 @@ class TestProvider implements Provider {
   emitEvent(type: ServerProviderEvents) {
     this.events.emit(type, { providerName: this.metadata.name });
   }
-}
-
-/** Child provider with a single-argument initialize that ignores any extra arguments. */
-class LegacyInitTestProvider implements Provider {
-  public metadata: ProviderMetadata = {
-    name: 'LegacyInitTestProvider',
-  };
-  public events = new OpenFeatureEventEmitter();
-  public hooks: Hook[] = [];
-  public track = jest.fn();
-  public initializeCalls = 0;
-  public lastContext?: EvaluationContext;
-
-  async initialize(context?: EvaluationContext): Promise<void> {
-    this.lastContext = context;
-    this.initializeCalls++;
-  }
-
-  resolveBooleanEvaluation = jest.fn().mockResolvedValue({ value: false });
-  resolveStringEvaluation = jest.fn().mockResolvedValue({ value: 'default' });
-  resolveObjectEvaluation = jest.fn().mockResolvedValue({ value: {} });
-  resolveNumberEvaluation = jest.fn().mockResolvedValue({ value: 0 });
 }
 
 const callEvaluation = async (multi: MultiProvider, context: EvaluationContext, logger: Logger) => {
@@ -185,16 +164,25 @@ describe('MultiProvider', () => {
     });
 
     it('forwards domain to legacy single-argument child providers without error', async () => {
-      const provider1 = new LegacyInitTestProvider();
-      const provider2 = new LegacyInitTestProvider();
-      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+      const legacyProvider1 = legacyInitTestProvider(
+        { runsOn: 'server', asyncResolvers: true, name: 'LegacyInitTestProvider' },
+        { events: new OpenFeatureEventEmitter() },
+      );
+      const legacyProvider2 = legacyInitTestProvider(
+        { runsOn: 'server', asyncResolvers: true, name: 'LegacyInitTestProvider' },
+        { events: new OpenFeatureEventEmitter() },
+      );
+      const multiProvider = new MultiProvider([
+        { provider: legacyProvider1 as unknown as Provider },
+        { provider: legacyProvider2 as unknown as Provider },
+      ]);
 
       await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
 
-      expect(provider1.initializeCalls).toBe(1);
-      expect(provider2.initializeCalls).toBe(1);
-      expect(provider1.lastContext).toEqual({ targetingKey: 'user' });
-      expect(provider2.lastContext).toEqual({ targetingKey: 'user' });
+      expect(legacyProvider1.initializeCalls).toBe(1);
+      expect(legacyProvider2.initializeCalls).toBe(1);
+      expect(legacyProvider1.lastContext).toEqual({ targetingKey: 'user' });
+      expect(legacyProvider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
     it('throws error if a provider errors on initialization', async () => {

--- a/packages/server/test/multi-provider.spec.ts
+++ b/packages/server/test/multi-provider.spec.ts
@@ -44,6 +44,28 @@ class TestProvider implements Provider {
   }
 }
 
+/** Child provider with a single-argument initialize that ignores any extra arguments. */
+class LegacyInitTestProvider implements Provider {
+  public metadata: ProviderMetadata = {
+    name: 'LegacyInitTestProvider',
+  };
+  public events = new OpenFeatureEventEmitter();
+  public hooks: Hook[] = [];
+  public track = jest.fn();
+  public initializeCalls = 0;
+  public lastContext?: EvaluationContext;
+
+  async initialize(context?: EvaluationContext): Promise<void> {
+    this.lastContext = context;
+    this.initializeCalls++;
+  }
+
+  resolveBooleanEvaluation = jest.fn().mockResolvedValue({ value: false });
+  resolveStringEvaluation = jest.fn().mockResolvedValue({ value: 'default' });
+  resolveObjectEvaluation = jest.fn().mockResolvedValue({ value: {} });
+  resolveNumberEvaluation = jest.fn().mockResolvedValue({ value: 0 });
+}
+
 const callEvaluation = async (multi: MultiProvider, context: EvaluationContext, logger: Logger) => {
   await callBeforeHook(multi, context, 'flag', 'boolean', false, logger);
   return multi.resolveBooleanEvaluation('flag', false, context);
@@ -160,6 +182,19 @@ describe('MultiProvider', () => {
       provider2.initialize.mockImplementation(() => initializations++);
       await multiProvider.initialize();
       expect(initializations).toBe(2);
+    });
+
+    it('forwards domain to legacy single-argument child providers without error', async () => {
+      const provider1 = new LegacyInitTestProvider();
+      const provider2 = new LegacyInitTestProvider();
+      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+
+      await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
+
+      expect(provider1.initializeCalls).toBe(1);
+      expect(provider2.initializeCalls).toBe(1);
+      expect(provider1.lastContext).toEqual({ targetingKey: 'user' });
+      expect(provider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
     it('throws error if a provider errors on initialization', async () => {

--- a/packages/server/test/multi-provider.spec.ts
+++ b/packages/server/test/multi-provider.spec.ts
@@ -185,6 +185,17 @@ describe('MultiProvider', () => {
       expect(legacyProvider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
+    it('forwards domain to child provider initialize', async () => {
+      const provider1 = new TestProvider();
+      const provider2 = new TestProvider();
+      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+
+      await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
+
+      expect(provider1.initialize).toHaveBeenCalledWith({ targetingKey: 'user' }, 'my-domain');
+      expect(provider2.initialize).toHaveBeenCalledWith({ targetingKey: 'user' }, 'my-domain');
+    });
+
     it('throws error if a provider errors on initialization', async () => {
       const provider1 = new TestProvider();
       const provider2 = new TestProvider();

--- a/packages/server/test/multi-provider.spec.ts
+++ b/packages/server/test/multi-provider.spec.ts
@@ -22,7 +22,7 @@ import {
   FirstSuccessfulStrategy,
   ComparisonStrategy,
 } from '../src';
-import { legacyInitTestProvider } from '../../shared/test/legacy-initialize-provider';
+import { legacyInitializeProvider } from '../../shared/test/legacy-initialize-provider';
 
 class TestProvider implements Provider {
   public metadata: ProviderMetadata = {
@@ -164,11 +164,11 @@ describe('MultiProvider', () => {
     });
 
     it('forwards domain to legacy single-argument child providers without error', async () => {
-      const legacyProvider1 = legacyInitTestProvider(
+      const legacyProvider1 = legacyInitializeProvider(
         { runsOn: 'server', asyncResolvers: true, name: 'LegacyInitTestProvider' },
         { events: new OpenFeatureEventEmitter() },
       );
-      const legacyProvider2 = legacyInitTestProvider(
+      const legacyProvider2 = legacyInitializeProvider(
         { runsOn: 'server', asyncResolvers: true, name: 'LegacyInitTestProvider' },
         { events: new OpenFeatureEventEmitter() },
       );

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -1,6 +1,6 @@
-import type { Paradigm } from '@openfeature/core';
-import type { Provider, ProviderStatus } from '../src';
-import { OpenFeature, OpenFeatureAPI } from '../src';
+import type { Paradigm, EvaluationContext } from '@openfeature/core';
+import type { Provider } from '../src';
+import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
@@ -16,6 +16,23 @@ const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradi
       return Promise.resolve('closed');
     }),
   } as unknown as Provider;
+};
+
+/** Provider with a single-argument initialize that ignores any extra arguments. */
+const legacyInitializeProvider = (): Provider & { lastContext?: EvaluationContext } => {
+  const provider = {
+    metadata: { name: 'legacy-init' },
+    runsOn: 'server',
+    lastContext: undefined as EvaluationContext | undefined,
+    async initialize(context?: EvaluationContext): Promise<void> {
+      provider.lastContext = context;
+    },
+    resolveBooleanEvaluation: jest.fn().mockResolvedValue({ value: false }),
+    resolveStringEvaluation: jest.fn().mockResolvedValue({ value: '' }),
+    resolveNumberEvaluation: jest.fn().mockResolvedValue({ value: 0 }),
+    resolveObjectEvaluation: jest.fn().mockResolvedValue({ value: {} }),
+  };
+  return provider as Provider & { lastContext?: EvaluationContext };
 };
 
 describe('OpenFeature', () => {
@@ -71,6 +88,24 @@ describe('OpenFeature', () => {
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(provider);
         expect(spy).toHaveBeenCalledWith({}, undefined);
+      });
+
+      it('initializes legacy single-argument providers when bound to a domain', async () => {
+        const domain = 'my-domain';
+        const context = { targetingKey: 'user' };
+        const provider = legacyInitializeProvider();
+        OpenFeature.setContext(context);
+
+        await expect(OpenFeature.setProviderAndWait(domain, provider)).resolves.toBeUndefined();
+        expect(provider.lastContext).toEqual(context);
+        expect(OpenFeature.getClient(domain).providerStatus).toEqual(ProviderStatus.READY);
+      });
+
+      it('initializes legacy single-argument providers as the default provider', async () => {
+        const provider = legacyInitializeProvider();
+
+        await expect(OpenFeature.setProviderAndWait(provider)).resolves.toBeUndefined();
+        expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.READY);
       });
     });
 

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -60,7 +60,7 @@ describe('OpenFeature', () => {
 
       it('MUST supply the bound domain to initialize when registering a domain-scoped provider', () => {
         const domain = 'my-domain';
-        const provider = mockProvider();
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(domain, provider);
         expect(spy).toHaveBeenCalledWith({}, domain);

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -1,7 +1,8 @@
-import type { Paradigm, EvaluationContext } from '@openfeature/core';
+import type { Paradigm } from '@openfeature/core';
 import type { Provider } from '../src';
 import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
+import { legacyInitializeProvider } from '../../shared/test/legacy-initialize-provider';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
   return {
@@ -16,23 +17,6 @@ const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradi
       return Promise.resolve('closed');
     }),
   } as unknown as Provider;
-};
-
-/** Provider with a single-argument initialize that ignores any extra arguments. */
-const legacyInitializeProvider = (): Provider & { lastContext?: EvaluationContext } => {
-  const provider = {
-    metadata: { name: 'legacy-init' },
-    runsOn: 'server',
-    lastContext: undefined as EvaluationContext | undefined,
-    async initialize(context?: EvaluationContext): Promise<void> {
-      provider.lastContext = context;
-    },
-    resolveBooleanEvaluation: jest.fn().mockResolvedValue({ value: false }),
-    resolveStringEvaluation: jest.fn().mockResolvedValue({ value: '' }),
-    resolveNumberEvaluation: jest.fn().mockResolvedValue({ value: 0 }),
-    resolveObjectEvaluation: jest.fn().mockResolvedValue({ value: {} }),
-  };
-  return provider as Provider & { lastContext?: EvaluationContext };
 };
 
 describe('OpenFeature', () => {
@@ -93,18 +77,20 @@ describe('OpenFeature', () => {
       it('initializes legacy single-argument providers when bound to a domain', async () => {
         const domain = 'my-domain';
         const context = { targetingKey: 'user' };
-        const provider = legacyInitializeProvider();
+        const legacyProvider = legacyInitializeProvider({ runsOn: 'server', asyncResolvers: true });
         OpenFeature.setContext(context);
 
-        await expect(OpenFeature.setProviderAndWait(domain, provider)).resolves.toBeUndefined();
-        expect(provider.lastContext).toEqual(context);
+        await expect(
+          OpenFeature.setProviderAndWait(domain, legacyProvider as unknown as Provider),
+        ).resolves.toBeUndefined();
+        expect(legacyProvider.lastContext).toEqual(context);
         expect(OpenFeature.getClient(domain).providerStatus).toEqual(ProviderStatus.READY);
       });
 
       it('initializes legacy single-argument providers as the default provider', async () => {
-        const provider = legacyInitializeProvider();
+        const legacyProvider = legacyInitializeProvider({ runsOn: 'server', asyncResolvers: true });
 
-        await expect(OpenFeature.setProviderAndWait(provider)).resolves.toBeUndefined();
+        await expect(OpenFeature.setProviderAndWait(legacyProvider as unknown as Provider)).resolves.toBeUndefined();
         expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.READY);
       });
     });

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -57,6 +57,21 @@ describe('OpenFeature', () => {
         expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
         expect(provider.initialize).toHaveBeenCalled();
       });
+
+      it('MUST supply the bound domain to initialize when registering a domain-scoped provider', () => {
+        const domain = 'my-domain';
+        const provider = mockProvider();
+        const spy = jest.spyOn(provider, 'initialize');
+        OpenFeature.setProvider(domain, provider);
+        expect(spy).toHaveBeenCalledWith({}, domain);
+      });
+
+      it('MUST not supply a domain to initialize for the default provider', () => {
+        const provider = mockProvider();
+        const spy = jest.spyOn(provider, 'initialize');
+        OpenFeature.setProvider(provider);
+        expect(spy).toHaveBeenCalledWith({}, undefined);
+      });
     });
 
     describe('Requirement 1.1.2.3', () => {
@@ -66,6 +81,30 @@ describe('OpenFeature', () => {
         OpenFeature.setProvider(provider);
         OpenFeature.setProvider(fakeProvider);
         expect(provider.onClose).toHaveBeenCalled();
+      });
+    });
+
+    describe('Condition 1.1.8', () => {
+      it('MUST NOT bind a domain-scoped provider instance to more than one domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider('domain-a', provider);
+        expect(() => OpenFeature.setProvider('domain-b', provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(OpenFeature.getProvider('domain-b').metadata.name).not.toBe(provider.metadata.name);
+      });
+
+      it('allows a non-domain-scoped provider to back multiple domains', async () => {
+        const provider = { ...mockProvider(), onClose: jest.fn() };
+
+        await OpenFeature.setProviderAndWait('domain1', provider);
+        await OpenFeature.setProviderAndWait('domain2', provider);
+
+        expect(OpenFeature.getProvider('domain1')).toBe(provider);
+        expect(OpenFeature.getProvider('domain2')).toBe(provider);
+        expect(provider.initialize).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -117,6 +117,27 @@ describe('OpenFeature', () => {
         expect(OpenFeature.getProvider('domain-b').metadata.name).not.toBe(provider.metadata.name);
       });
 
+      it('MUST NOT bind a domain-scoped default provider to a named domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider(provider);
+        expect(() => OpenFeature.setProvider('domain-a', provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider()).toBe(provider);
+        expect(OpenFeature.getProvider('domain-a').metadata.name).not.toBe(provider.metadata.name);
+      });
+
+      it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider('domain-a', provider);
+        expect(() => OpenFeature.setProvider(provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+      });
+
       it('allows a non-domain-scoped provider to back multiple domains', async () => {
         const provider = { ...mockProvider(), onClose: jest.fn() };
 

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -153,6 +153,17 @@ describe('OpenFeature', () => {
         expect(OpenFeature.getProvider('domain2')).toBe(provider);
         expect(provider.initialize).toHaveBeenCalledTimes(1);
       });
+
+      it('allows re-binding a domain-scoped provider to its own domain as a no-op', async () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
+
+        await OpenFeature.setProviderAndWait('domain-a', provider);
+        expect(() => OpenFeature.setProvider('domain-a', provider)).not.toThrow();
+
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -127,7 +127,7 @@ describe('OpenFeature', () => {
         );
         expect(OpenFeature.getProvider()).toBe(provider);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith({}, undefined);
+        expect(spy).toHaveBeenCalledWith(expect.anything(), undefined);
       });
 
       it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
@@ -140,7 +140,7 @@ describe('OpenFeature', () => {
         );
         expect(OpenFeature.getProvider('domain-a')).toBe(provider);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith({}, 'domain-a');
+        expect(spy).toHaveBeenCalledWith(expect.anything(), 'domain-a');
       });
 
       it('allows a non-domain-scoped provider to back multiple domains', async () => {

--- a/packages/server/test/open-feature.spec.ts
+++ b/packages/server/test/open-feature.spec.ts
@@ -119,23 +119,28 @@ describe('OpenFeature', () => {
 
       it('MUST NOT bind a domain-scoped default provider to a named domain', () => {
         const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
 
         OpenFeature.setProvider(provider);
         expect(() => OpenFeature.setProvider('domain-a', provider)).toThrow(
           "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
         );
         expect(OpenFeature.getProvider()).toBe(provider);
-        expect(OpenFeature.getProvider('domain-a').metadata.name).not.toBe(provider.metadata.name);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith({}, undefined);
       });
 
       it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
         const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
 
         OpenFeature.setProvider('domain-a', provider);
         expect(() => OpenFeature.setProvider(provider)).toThrow(
           "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
         );
         expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith({}, 'domain-a');
       });
 
       it('allows a non-domain-scoped provider to back multiple domains', async () => {

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -241,6 +241,10 @@ export abstract class OpenFeatureCommonAPI<
       throw new GeneralError(`Provider '${provider.metadata.name}' is intended for use on the ${provider.runsOn}.`);
     }
 
+    if (provider.domainScoped && this.allProviders.includes(provider)) {
+      throw new GeneralError(`Cannot bind domain-scoped provider '${provider.metadata.name}' to more than one domain.`);
+    }
+
     const emitters = this.getAssociatedEventEmitters(domain);
 
     let initializationPromise: Promise<void> | void = undefined;
@@ -252,8 +256,9 @@ export abstract class OpenFeatureCommonAPI<
 
     // initialize the provider if it implements "initialize" and it's not already registered
     if (typeof provider.initialize === 'function' && !this.allProviders.includes(provider)) {
+      const initContext = domain ? (this._domainScopedContext.get(domain) ?? this._context) : this._context;
       initializationPromise = provider
-        .initialize?.(domain ? (this._domainScopedContext.get(domain) ?? this._context) : this._context)
+        .initialize?.(initContext, domain)
         ?.then(() => {
           wrappedProvider.status = this._statusEnumType.READY;
           // fetch the most recent event emitters, some may have been added during init

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -231,6 +231,12 @@ export abstract class OpenFeatureCommonAPI<
 
     // ignore no-ops
     if (oldProvider === provider) {
+      // domain-scoped providers may already be the default; an explicit domain bind is not a no-op
+      if (provider.domainScoped && domain && this._domainScopedProviders.get(domain)?.provider !== provider) {
+        throw new GeneralError(
+          `Cannot bind domain-scoped provider '${provider.metadata.name}' to more than one domain.`,
+        );
+      }
       this._logger.debug('Provider is already set, ignoring setProvider call');
       return;
     }

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -434,6 +434,7 @@ export abstract class OpenFeatureCommonAPI<
 
   private getProviderInstanceBinding(provider: P): string | null {
     if (this._defaultProvider.provider === provider) {
+      // Empty string represents the default (unbound) provider.
       return '';
     }
 

--- a/packages/shared/src/open-feature.ts
+++ b/packages/shared/src/open-feature.ts
@@ -229,14 +229,10 @@ export abstract class OpenFeatureCommonAPI<
     const oldProvider = this.getProviderForClient(domain);
     const providerName = provider.metadata.name;
 
+    this.assertDomainScopedBindingAllowed(provider, domain);
+
     // ignore no-ops
     if (oldProvider === provider) {
-      // domain-scoped providers may already be the default; an explicit domain bind is not a no-op
-      if (provider.domainScoped && domain && this._domainScopedProviders.get(domain)?.provider !== provider) {
-        throw new GeneralError(
-          `Cannot bind domain-scoped provider '${provider.metadata.name}' to more than one domain.`,
-        );
-      }
       this._logger.debug('Provider is already set, ignoring setProvider call');
       return;
     }
@@ -245,10 +241,6 @@ export abstract class OpenFeatureCommonAPI<
       this._logger.debug(`Provider '${provider.metadata.name}' has not defined its intended use.`);
     } else if (provider.runsOn !== this._runsOn) {
       throw new GeneralError(`Provider '${provider.metadata.name}' is intended for use on the ${provider.runsOn}.`);
-    }
-
-    if (provider.domainScoped && this.allProviders.includes(provider)) {
-      throw new GeneralError(`Cannot bind domain-scoped provider '${provider.metadata.name}' to more than one domain.`);
     }
 
     const emitters = this.getAssociatedEventEmitters(domain);
@@ -438,6 +430,38 @@ export abstract class OpenFeatureCommonAPI<
         this._statusEnumType,
       );
     }
+  }
+
+  private getProviderInstanceBinding(provider: P): string | null {
+    if (this._defaultProvider.provider === provider) {
+      return '';
+    }
+
+    for (const [domain, wrapper] of this._domainScopedProviders) {
+      if (wrapper.provider === provider) {
+        return domain;
+      }
+    }
+
+    return null;
+  }
+
+  private assertDomainScopedBindingAllowed(provider: P, domain?: string): void {
+    if (!provider.domainScoped) {
+      return;
+    }
+
+    const existingBinding = this.getProviderInstanceBinding(provider);
+    if (existingBinding === null) {
+      return;
+    }
+
+    const requestedBinding = domain ?? '';
+    if (existingBinding === requestedBinding) {
+      return;
+    }
+
+    throw new GeneralError(`Cannot bind domain-scoped provider '${provider.metadata.name}' to more than one domain.`);
   }
 
   private get allProviders(): P[] {

--- a/packages/shared/src/provider/provider.ts
+++ b/packages/shared/src/provider/provider.ts
@@ -96,6 +96,12 @@ export interface CommonProvider<S extends ClientProviderStatus | ServerProviderS
    */
   readonly runsOn?: Paradigm;
 
+  /**
+   * When true, the provider maintains state specific to a single domain (such as a
+   * persistent cache) and the SDK will bind it to at most one domain.
+   */
+  readonly domainScoped?: boolean;
+
   // TODO: in the future we could make this a never to force provider to remove it.
   /**
    * @deprecated the SDK now maintains the provider's state; there's no need for providers to implement this field.
@@ -123,9 +129,10 @@ export interface CommonProvider<S extends ClientProviderStatus | ServerProviderS
    * When the returned promise resolves, the SDK fires the ProviderEvents.Ready event.
    * If the returned promise rejects, the SDK fires the ProviderEvents.Error event.
    * Use this function to perform any context-dependent setup within the provider.
-   * @param context
+   * @param context the global evaluation context
+   * @param domain the bound domain, if any
    */
-  initialize?(context?: EvaluationContext): Promise<void>;
+  initialize?(context?: EvaluationContext, domain?: string): Promise<void>;
 
   /**
    * Track a user action or application state, usually representing a business objective or outcome.

--- a/packages/shared/test/legacy-initialize-provider.ts
+++ b/packages/shared/test/legacy-initialize-provider.ts
@@ -1,0 +1,90 @@
+import type { EvaluationContext, Paradigm } from '../src';
+
+export interface LegacyInitializeProviderTracker {
+  lastContext?: EvaluationContext;
+  initializeCalls: number;
+}
+
+type LegacyInitializeProviderOptions = {
+  runsOn: Paradigm;
+  name?: string;
+  /** When true, resolution stubs return promises (server SDK). Default false (web SDK). */
+  asyncResolvers?: boolean;
+};
+
+type LegacyInitializeProviderResolvers = {
+  resolveBooleanEvaluation: jest.Mock;
+  resolveStringEvaluation: jest.Mock;
+  resolveNumberEvaluation: jest.Mock;
+  resolveObjectEvaluation: jest.Mock;
+};
+
+export type LegacyInitializeProvider = LegacyInitializeProviderTracker &
+  LegacyInitializeProviderResolvers & {
+    metadata: { name: string };
+    runsOn: Paradigm;
+    initialize: (context?: EvaluationContext) => Promise<void>;
+  };
+
+function createResolverStubs(asyncResolvers: boolean): LegacyInitializeProviderResolvers {
+  if (asyncResolvers) {
+    return {
+      resolveBooleanEvaluation: jest.fn().mockResolvedValue({ value: false }),
+      resolveStringEvaluation: jest.fn().mockResolvedValue({ value: '' }),
+      resolveNumberEvaluation: jest.fn().mockResolvedValue({ value: 0 }),
+      resolveObjectEvaluation: jest.fn().mockResolvedValue({ value: {} }),
+    };
+  }
+
+  return {
+    resolveBooleanEvaluation: jest.fn().mockReturnValue({ value: false }),
+    resolveStringEvaluation: jest.fn().mockReturnValue({ value: '' }),
+    resolveNumberEvaluation: jest.fn().mockReturnValue({ value: 0 }),
+    resolveObjectEvaluation: jest.fn().mockReturnValue({ value: {} }),
+  };
+}
+
+/**
+ * Provider with a single-argument initialize that ignores any extra arguments passed by the SDK.
+ */
+export function legacyInitializeProvider(options: LegacyInitializeProviderOptions): LegacyInitializeProvider {
+  const tracker: LegacyInitializeProviderTracker = {
+    initializeCalls: 0,
+  };
+
+  return {
+    metadata: { name: options.name ?? 'legacy-init' },
+    runsOn: options.runsOn,
+    get lastContext() {
+      return tracker.lastContext;
+    },
+    get initializeCalls() {
+      return tracker.initializeCalls;
+    },
+    async initialize(context?: EvaluationContext): Promise<void> {
+      tracker.lastContext = context;
+      tracker.initializeCalls++;
+    },
+    ...createResolverStubs(options.asyncResolvers ?? false),
+  };
+}
+
+type LegacyInitTestProviderExtras = {
+  events: unknown;
+  hooks?: unknown[];
+  track?: jest.Mock;
+};
+
+/**
+ * Legacy initialize provider with the stubs MultiProvider expects on child providers.
+ */
+export function legacyInitTestProvider(
+  options: LegacyInitializeProviderOptions,
+  extras: LegacyInitTestProviderExtras,
+): LegacyInitializeProvider & LegacyInitTestProviderExtras {
+  return Object.assign(legacyInitializeProvider(options), {
+    events: extras.events,
+    hooks: extras.hooks ?? [],
+    track: extras.track ?? jest.fn(),
+  });
+}

--- a/packages/shared/test/legacy-initialize-provider.ts
+++ b/packages/shared/test/legacy-initialize-provider.ts
@@ -44,6 +44,9 @@ function createResolverStubs(asyncResolvers: boolean): LegacyInitializeProviderR
 /**
  * Provider with a single-argument initialize that ignores any extra arguments passed by the SDK.
  * Pass optional extras when MultiProvider needs events, hooks, or track stubs on the child.
+ * @param options provider configuration (paradigm, name, resolver mode)
+ * @param extras optional MultiProvider child stubs (events, hooks, track)
+ * @returns a single-argument-initialize provider
  */
 export function legacyInitializeProvider(
   options: LegacyInitializeProviderOptions,

--- a/packages/shared/test/legacy-initialize-provider.ts
+++ b/packages/shared/test/legacy-initialize-provider.ts
@@ -1,15 +1,16 @@
 import type { EvaluationContext, Paradigm } from '../src';
 
-export interface LegacyInitializeProviderTracker {
-  lastContext?: EvaluationContext;
-  initializeCalls: number;
-}
-
 type LegacyInitializeProviderOptions = {
   runsOn: Paradigm;
   name?: string;
   /** When true, resolution stubs return promises (server SDK). Default false (web SDK). */
   asyncResolvers?: boolean;
+};
+
+type LegacyInitializeProviderExtras = {
+  events: unknown;
+  hooks?: unknown[];
+  track?: jest.Mock;
 };
 
 type LegacyInitializeProviderResolvers = {
@@ -19,72 +20,54 @@ type LegacyInitializeProviderResolvers = {
   resolveObjectEvaluation: jest.Mock;
 };
 
-export type LegacyInitializeProvider = LegacyInitializeProviderTracker &
-  LegacyInitializeProviderResolvers & {
-    metadata: { name: string };
-    runsOn: Paradigm;
-    initialize: (context?: EvaluationContext) => Promise<void>;
-  };
+export type LegacyInitializeProvider = LegacyInitializeProviderResolvers & {
+  metadata: { name: string };
+  runsOn: Paradigm;
+  lastContext?: EvaluationContext;
+  initializeCalls: number;
+  initialize: (context?: EvaluationContext) => Promise<void>;
+};
 
 function createResolverStubs(asyncResolvers: boolean): LegacyInitializeProviderResolvers {
-  if (asyncResolvers) {
-    return {
-      resolveBooleanEvaluation: jest.fn().mockResolvedValue({ value: false }),
-      resolveStringEvaluation: jest.fn().mockResolvedValue({ value: '' }),
-      resolveNumberEvaluation: jest.fn().mockResolvedValue({ value: 0 }),
-      resolveObjectEvaluation: jest.fn().mockResolvedValue({ value: {} }),
-    };
-  }
+  const mockValue = asyncResolvers
+    ? <T>(value: T) => jest.fn().mockResolvedValue(value)
+    : <T>(value: T) => jest.fn().mockReturnValue(value);
 
   return {
-    resolveBooleanEvaluation: jest.fn().mockReturnValue({ value: false }),
-    resolveStringEvaluation: jest.fn().mockReturnValue({ value: '' }),
-    resolveNumberEvaluation: jest.fn().mockReturnValue({ value: 0 }),
-    resolveObjectEvaluation: jest.fn().mockReturnValue({ value: {} }),
+    resolveBooleanEvaluation: mockValue({ value: false }),
+    resolveStringEvaluation: mockValue({ value: '' }),
+    resolveNumberEvaluation: mockValue({ value: 0 }),
+    resolveObjectEvaluation: mockValue({ value: {} }),
   };
 }
 
 /**
  * Provider with a single-argument initialize that ignores any extra arguments passed by the SDK.
+ * Pass optional extras when MultiProvider needs events, hooks, or track stubs on the child.
  */
-export function legacyInitializeProvider(options: LegacyInitializeProviderOptions): LegacyInitializeProvider {
-  const tracker: LegacyInitializeProviderTracker = {
-    initializeCalls: 0,
-  };
-
-  return {
+export function legacyInitializeProvider(
+  options: LegacyInitializeProviderOptions,
+  extras?: LegacyInitializeProviderExtras,
+): LegacyInitializeProvider {
+  const provider: LegacyInitializeProvider = {
     metadata: { name: options.name ?? 'legacy-init' },
     runsOn: options.runsOn,
-    get lastContext() {
-      return tracker.lastContext;
-    },
-    get initializeCalls() {
-      return tracker.initializeCalls;
-    },
+    lastContext: undefined,
+    initializeCalls: 0,
     async initialize(context?: EvaluationContext): Promise<void> {
-      tracker.lastContext = context;
-      tracker.initializeCalls++;
+      this.lastContext = context;
+      this.initializeCalls++;
     },
     ...createResolverStubs(options.asyncResolvers ?? false),
   };
-}
 
-type LegacyInitTestProviderExtras = {
-  events: unknown;
-  hooks?: unknown[];
-  track?: jest.Mock;
-};
+  if (extras) {
+    Object.assign(provider, {
+      events: extras.events,
+      hooks: extras.hooks ?? [],
+      track: extras.track ?? jest.fn(),
+    });
+  }
 
-/**
- * Legacy initialize provider with the stubs MultiProvider expects on child providers.
- */
-export function legacyInitTestProvider(
-  options: LegacyInitializeProviderOptions,
-  extras: LegacyInitTestProviderExtras,
-): LegacyInitializeProvider & LegacyInitTestProviderExtras {
-  return Object.assign(legacyInitializeProvider(options), {
-    events: extras.events,
-    hooks: extras.hooks ?? [],
-    track: extras.track ?? jest.fn(),
-  });
+  return provider;
 }

--- a/packages/web/src/provider/multi-provider/multi-provider-web.ts
+++ b/packages/web/src/provider/multi-provider/multi-provider-web.ts
@@ -103,9 +103,9 @@ export class MultiProvider implements Provider {
     Object.freeze(this.providerEntriesByName);
   }
 
-  async initialize(context?: EvaluationContext): Promise<void> {
+  async initialize(context?: EvaluationContext, domain?: string): Promise<void> {
     const result = await Promise.allSettled(
-      this.providerEntries.map((provider) => provider.provider.initialize?.(context)),
+      this.providerEntries.map((provider) => provider.provider.initialize?.(context, domain)),
     );
     throwAggregateErrorFromPromiseResults(result, this.providerEntries);
   }

--- a/packages/web/test/evaluation-context.spec.ts
+++ b/packages/web/test/evaluation-context.spec.ts
@@ -84,7 +84,7 @@ describe('Evaluation Context', () => {
         const context: EvaluationContext = { property1: false };
         const provider = new MockProvider();
         await OpenFeature.setProviderAndWait(provider, context);
-        expect(initializeMock).toHaveBeenCalledWith(context);
+        expect(initializeMock).toHaveBeenCalledWith(context, undefined);
         expect(OpenFeature.getContext()).toEqual(context);
       });
 
@@ -95,7 +95,7 @@ describe('Evaluation Context', () => {
         await OpenFeature.setProviderAndWait(domain, provider, context);
         expect(OpenFeature.getContext()).toEqual({});
         expect(OpenFeature.getContext(domain)).toEqual(context);
-        expect(initializeMock).toHaveBeenCalledWith(context);
+        expect(initializeMock).toHaveBeenCalledWith(context, domain);
       });
     });
 

--- a/packages/web/test/multi-provider-web.spec.ts
+++ b/packages/web/test/multi-provider-web.spec.ts
@@ -23,6 +23,7 @@ import {
   FirstSuccessfulStrategy,
   ComparisonStrategy,
 } from '../src';
+import { legacyInitTestProvider } from '../../shared/test/legacy-initialize-provider';
 
 class TestProvider implements Provider {
   public metadata: ProviderMetadata = {
@@ -42,28 +43,6 @@ class TestProvider implements Provider {
   emitEvent(type: ProviderEmittableEvents) {
     this.events.emit(type, { providerName: this.metadata.name });
   }
-}
-
-/** Child provider with a single-argument initialize that ignores any extra arguments. */
-class LegacyInitTestProvider implements Provider {
-  public metadata: ProviderMetadata = {
-    name: 'LegacyInitTestProvider',
-  };
-  public events = new OpenFeatureEventEmitter();
-  public hooks: Hook[] = [];
-  public track = jest.fn();
-  public initializeCalls = 0;
-  public lastContext?: EvaluationContext;
-
-  async initialize(context?: EvaluationContext): Promise<void> {
-    this.lastContext = context;
-    this.initializeCalls++;
-  }
-
-  resolveBooleanEvaluation = jest.fn().mockReturnValue({ value: false });
-  resolveStringEvaluation = jest.fn().mockReturnValue({ value: 'default' });
-  resolveObjectEvaluation = jest.fn().mockReturnValue({ value: {} });
-  resolveNumberEvaluation = jest.fn().mockReturnValue({ value: 0 });
 }
 
 const callEvaluation = (multi: MultiProvider, context: EvaluationContext) => {
@@ -185,16 +164,25 @@ describe('MultiProvider', () => {
     });
 
     it('forwards domain to legacy single-argument child providers without error', async () => {
-      const provider1 = new LegacyInitTestProvider();
-      const provider2 = new LegacyInitTestProvider();
-      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+      const legacyProvider1 = legacyInitTestProvider(
+        { runsOn: 'client', name: 'LegacyInitTestProvider' },
+        { events: new OpenFeatureEventEmitter() },
+      );
+      const legacyProvider2 = legacyInitTestProvider(
+        { runsOn: 'client', name: 'LegacyInitTestProvider' },
+        { events: new OpenFeatureEventEmitter() },
+      );
+      const multiProvider = new MultiProvider([
+        { provider: legacyProvider1 as unknown as Provider },
+        { provider: legacyProvider2 as unknown as Provider },
+      ]);
 
       await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
 
-      expect(provider1.initializeCalls).toBe(1);
-      expect(provider2.initializeCalls).toBe(1);
-      expect(provider1.lastContext).toEqual({ targetingKey: 'user' });
-      expect(provider2.lastContext).toEqual({ targetingKey: 'user' });
+      expect(legacyProvider1.initializeCalls).toBe(1);
+      expect(legacyProvider2.initializeCalls).toBe(1);
+      expect(legacyProvider1.lastContext).toEqual({ targetingKey: 'user' });
+      expect(legacyProvider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
     it('throws error if a provider errors on initialization', async () => {

--- a/packages/web/test/multi-provider-web.spec.ts
+++ b/packages/web/test/multi-provider-web.spec.ts
@@ -44,6 +44,28 @@ class TestProvider implements Provider {
   }
 }
 
+/** Child provider with a single-argument initialize that ignores any extra arguments. */
+class LegacyInitTestProvider implements Provider {
+  public metadata: ProviderMetadata = {
+    name: 'LegacyInitTestProvider',
+  };
+  public events = new OpenFeatureEventEmitter();
+  public hooks: Hook[] = [];
+  public track = jest.fn();
+  public initializeCalls = 0;
+  public lastContext?: EvaluationContext;
+
+  async initialize(context?: EvaluationContext): Promise<void> {
+    this.lastContext = context;
+    this.initializeCalls++;
+  }
+
+  resolveBooleanEvaluation = jest.fn().mockReturnValue({ value: false });
+  resolveStringEvaluation = jest.fn().mockReturnValue({ value: 'default' });
+  resolveObjectEvaluation = jest.fn().mockReturnValue({ value: {} });
+  resolveNumberEvaluation = jest.fn().mockReturnValue({ value: 0 });
+}
+
 const callEvaluation = (multi: MultiProvider, context: EvaluationContext) => {
   callBeforeHook(multi, context, 'flag', 'boolean', false);
   return multi.resolveBooleanEvaluation('flag', false, context);
@@ -160,6 +182,19 @@ describe('MultiProvider', () => {
       provider2.initialize.mockImplementation(() => initializations++);
       await multiProvider.initialize();
       expect(initializations).toBe(2);
+    });
+
+    it('forwards domain to legacy single-argument child providers without error', async () => {
+      const provider1 = new LegacyInitTestProvider();
+      const provider2 = new LegacyInitTestProvider();
+      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+
+      await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
+
+      expect(provider1.initializeCalls).toBe(1);
+      expect(provider2.initializeCalls).toBe(1);
+      expect(provider1.lastContext).toEqual({ targetingKey: 'user' });
+      expect(provider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
     it('throws error if a provider errors on initialization', async () => {

--- a/packages/web/test/multi-provider-web.spec.ts
+++ b/packages/web/test/multi-provider-web.spec.ts
@@ -185,6 +185,17 @@ describe('MultiProvider', () => {
       expect(legacyProvider2.lastContext).toEqual({ targetingKey: 'user' });
     });
 
+    it('forwards domain to child provider initialize', async () => {
+      const provider1 = new TestProvider();
+      const provider2 = new TestProvider();
+      const multiProvider = new MultiProvider([{ provider: provider1 }, { provider: provider2 }]);
+
+      await multiProvider.initialize({ targetingKey: 'user' }, 'my-domain');
+
+      expect(provider1.initialize).toHaveBeenCalledWith({ targetingKey: 'user' }, 'my-domain');
+      expect(provider2.initialize).toHaveBeenCalledWith({ targetingKey: 'user' }, 'my-domain');
+    });
+
     it('throws error if a provider errors on initialization', async () => {
       const provider1 = new TestProvider();
       const provider2 = new TestProvider();

--- a/packages/web/test/multi-provider-web.spec.ts
+++ b/packages/web/test/multi-provider-web.spec.ts
@@ -23,7 +23,7 @@ import {
   FirstSuccessfulStrategy,
   ComparisonStrategy,
 } from '../src';
-import { legacyInitTestProvider } from '../../shared/test/legacy-initialize-provider';
+import { legacyInitializeProvider } from '../../shared/test/legacy-initialize-provider';
 
 class TestProvider implements Provider {
   public metadata: ProviderMetadata = {
@@ -164,11 +164,11 @@ describe('MultiProvider', () => {
     });
 
     it('forwards domain to legacy single-argument child providers without error', async () => {
-      const legacyProvider1 = legacyInitTestProvider(
+      const legacyProvider1 = legacyInitializeProvider(
         { runsOn: 'client', name: 'LegacyInitTestProvider' },
         { events: new OpenFeatureEventEmitter() },
       );
-      const legacyProvider2 = legacyInitTestProvider(
+      const legacyProvider2 = legacyInitializeProvider(
         { runsOn: 'client', name: 'LegacyInitTestProvider' },
         { events: new OpenFeatureEventEmitter() },
       );

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -58,6 +58,21 @@ describe('OpenFeature', () => {
         expect(OpenFeature.providerMetadata.name).toBe('mock-events-success');
         expect(provider.initialize).toHaveBeenCalled();
       });
+
+      it('MUST supply the bound domain to initialize when registering a domain-scoped provider', () => {
+        const domain = 'my-domain';
+        const provider = mockProvider();
+        const spy = jest.spyOn(provider, 'initialize');
+        OpenFeature.setProvider(domain, provider);
+        expect(spy).toHaveBeenCalledWith({}, domain);
+      });
+
+      it('MUST not supply a domain to initialize for the default provider', () => {
+        const provider = mockProvider();
+        const spy = jest.spyOn(provider, 'initialize');
+        OpenFeature.setProvider(provider);
+        expect(spy).toHaveBeenCalledWith({}, undefined);
+      });
     });
 
     describe('Requirement 1.1.2.3', () => {
@@ -67,6 +82,30 @@ describe('OpenFeature', () => {
         OpenFeature.setProvider(provider);
         OpenFeature.setProvider(fakeProvider);
         expect(provider.onClose).toHaveBeenCalled();
+      });
+    });
+
+    describe('Condition 1.1.8', () => {
+      it('MUST NOT bind a domain-scoped provider instance to more than one domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider('domain-a', provider);
+        expect(() => OpenFeature.setProvider('domain-b', provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(OpenFeature.getProvider('domain-b').metadata.name).not.toBe(provider.metadata.name);
+      });
+
+      it('allows a non-domain-scoped provider to back multiple domains', async () => {
+        const provider = { ...mockProvider(), onClose: jest.fn() };
+
+        await OpenFeature.setProviderAndWait('domain1', provider);
+        await OpenFeature.setProviderAndWait('domain2', provider);
+
+        expect(OpenFeature.getProvider('domain1')).toBe(provider);
+        expect(OpenFeature.getProvider('domain2')).toBe(provider);
+        expect(provider.initialize).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -240,7 +279,7 @@ describe('OpenFeature', () => {
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(domain, provider);
 
-        expect(spy).toHaveBeenCalledWith({ user: 'mike' });
+        expect(spy).toHaveBeenCalledWith({ user: 'mike' }, domain);
       });
 
       it('should use the default context', async () => {
@@ -252,7 +291,7 @@ describe('OpenFeature', () => {
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(provider);
 
-        expect(spy).toHaveBeenCalledWith({ name: 'todd' });
+        expect(spy).toHaveBeenCalledWith({ name: 'todd' }, undefined);
       });
     });
   });

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -61,7 +61,7 @@ describe('OpenFeature', () => {
 
       it('MUST supply the bound domain to initialize when registering a domain-scoped provider', () => {
         const domain = 'my-domain';
-        const provider = mockProvider();
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(domain, provider);
         expect(spy).toHaveBeenCalledWith({}, domain);

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -1,4 +1,4 @@
-import type { Paradigm } from '@openfeature/core';
+import type { EvaluationContext, Paradigm } from '@openfeature/core';
 import type { Provider } from '../src';
 import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
@@ -17,6 +17,23 @@ const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradi
       return Promise.resolve('closed');
     }),
   } as unknown as Provider;
+};
+
+/** Provider with a single-argument initialize that ignores any extra arguments. */
+const legacyInitializeProvider = (): Provider & { lastContext?: EvaluationContext } => {
+  const provider = {
+    metadata: { name: 'legacy-init' },
+    runsOn: 'client',
+    lastContext: undefined as EvaluationContext | undefined,
+    async initialize(context?: EvaluationContext): Promise<void> {
+      provider.lastContext = context;
+    },
+    resolveBooleanEvaluation: jest.fn(() => ({ value: false })),
+    resolveStringEvaluation: jest.fn(() => ({ value: '' })),
+    resolveNumberEvaluation: jest.fn(() => ({ value: 0 })),
+    resolveObjectEvaluation: jest.fn(() => ({ value: {} })),
+  };
+  return provider as Provider & { lastContext?: EvaluationContext };
 };
 
 describe('OpenFeature', () => {
@@ -72,6 +89,23 @@ describe('OpenFeature', () => {
         const spy = jest.spyOn(provider, 'initialize');
         OpenFeature.setProvider(provider);
         expect(spy).toHaveBeenCalledWith({}, undefined);
+      });
+
+      it('initializes legacy single-argument providers when bound to a domain', async () => {
+        const domain = 'my-domain';
+        const context = { targetingKey: 'user' };
+        const provider = legacyInitializeProvider();
+
+        await expect(OpenFeature.setProviderAndWait(domain, provider, context)).resolves.toBeUndefined();
+        expect(provider.lastContext).toEqual(context);
+        expect(OpenFeature.getClient(domain).providerStatus).toEqual(ProviderStatus.READY);
+      });
+
+      it('initializes legacy single-argument providers as the default provider', async () => {
+        const provider = legacyInitializeProvider();
+
+        await expect(OpenFeature.setProviderAndWait(provider)).resolves.toBeUndefined();
+        expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.READY);
       });
     });
 

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -1,7 +1,8 @@
-import type { EvaluationContext, Paradigm } from '@openfeature/core';
+import type { Paradigm } from '@openfeature/core';
 import type { Provider } from '../src';
 import { OpenFeature, OpenFeatureAPI, ProviderStatus } from '../src';
 import { OpenFeatureClient } from '../src/client/internal/open-feature-client';
+import { legacyInitializeProvider } from '../../shared/test/legacy-initialize-provider';
 
 const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradigm }) => {
   return {
@@ -17,23 +18,6 @@ const mockProvider = (config?: { initialStatus?: ProviderStatus; runsOn?: Paradi
       return Promise.resolve('closed');
     }),
   } as unknown as Provider;
-};
-
-/** Provider with a single-argument initialize that ignores any extra arguments. */
-const legacyInitializeProvider = (): Provider & { lastContext?: EvaluationContext } => {
-  const provider = {
-    metadata: { name: 'legacy-init' },
-    runsOn: 'client',
-    lastContext: undefined as EvaluationContext | undefined,
-    async initialize(context?: EvaluationContext): Promise<void> {
-      provider.lastContext = context;
-    },
-    resolveBooleanEvaluation: jest.fn(() => ({ value: false })),
-    resolveStringEvaluation: jest.fn(() => ({ value: '' })),
-    resolveNumberEvaluation: jest.fn(() => ({ value: 0 })),
-    resolveObjectEvaluation: jest.fn(() => ({ value: {} })),
-  };
-  return provider as Provider & { lastContext?: EvaluationContext };
 };
 
 describe('OpenFeature', () => {
@@ -94,17 +78,19 @@ describe('OpenFeature', () => {
       it('initializes legacy single-argument providers when bound to a domain', async () => {
         const domain = 'my-domain';
         const context = { targetingKey: 'user' };
-        const provider = legacyInitializeProvider();
+        const legacyProvider = legacyInitializeProvider({ runsOn: 'client' });
 
-        await expect(OpenFeature.setProviderAndWait(domain, provider, context)).resolves.toBeUndefined();
-        expect(provider.lastContext).toEqual(context);
+        await expect(
+          OpenFeature.setProviderAndWait(domain, legacyProvider as unknown as Provider, context),
+        ).resolves.toBeUndefined();
+        expect(legacyProvider.lastContext).toEqual(context);
         expect(OpenFeature.getClient(domain).providerStatus).toEqual(ProviderStatus.READY);
       });
 
       it('initializes legacy single-argument providers as the default provider', async () => {
-        const provider = legacyInitializeProvider();
+        const legacyProvider = legacyInitializeProvider({ runsOn: 'client' });
 
-        await expect(OpenFeature.setProviderAndWait(provider)).resolves.toBeUndefined();
+        await expect(OpenFeature.setProviderAndWait(legacyProvider as unknown as Provider)).resolves.toBeUndefined();
         expect(OpenFeature.getClient().providerStatus).toEqual(ProviderStatus.READY);
       });
     });

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -117,6 +117,27 @@ describe('OpenFeature', () => {
         expect(OpenFeature.getProvider('domain-b').metadata.name).not.toBe(provider.metadata.name);
       });
 
+      it('MUST NOT bind a domain-scoped default provider to a named domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider(provider);
+        expect(() => OpenFeature.setProvider('domain-a', provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider()).toBe(provider);
+        expect(OpenFeature.getProvider('domain-a').metadata.name).not.toBe(provider.metadata.name);
+      });
+
+      it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+
+        OpenFeature.setProvider('domain-a', provider);
+        expect(() => OpenFeature.setProvider(provider)).toThrow(
+          "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
+        );
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+      });
+
       it('allows a non-domain-scoped provider to back multiple domains', async () => {
         const provider = { ...mockProvider(), onClose: jest.fn() };
 

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -153,6 +153,17 @@ describe('OpenFeature', () => {
         expect(OpenFeature.getProvider('domain2')).toBe(provider);
         expect(provider.initialize).toHaveBeenCalledTimes(1);
       });
+
+      it('allows re-binding a domain-scoped provider to its own domain as a no-op', async () => {
+        const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
+
+        await OpenFeature.setProviderAndWait('domain-a', provider);
+        expect(() => OpenFeature.setProvider('domain-a', provider)).not.toThrow();
+
+        expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -127,7 +127,7 @@ describe('OpenFeature', () => {
         );
         expect(OpenFeature.getProvider()).toBe(provider);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith({}, undefined);
+        expect(spy).toHaveBeenCalledWith(expect.anything(), undefined);
       });
 
       it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
@@ -140,7 +140,7 @@ describe('OpenFeature', () => {
         );
         expect(OpenFeature.getProvider('domain-a')).toBe(provider);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith({}, 'domain-a');
+        expect(spy).toHaveBeenCalledWith(expect.anything(), 'domain-a');
       });
 
       it('allows a non-domain-scoped provider to back multiple domains', async () => {

--- a/packages/web/test/open-feature.spec.ts
+++ b/packages/web/test/open-feature.spec.ts
@@ -119,23 +119,28 @@ describe('OpenFeature', () => {
 
       it('MUST NOT bind a domain-scoped default provider to a named domain', () => {
         const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
 
         OpenFeature.setProvider(provider);
         expect(() => OpenFeature.setProvider('domain-a', provider)).toThrow(
           "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
         );
         expect(OpenFeature.getProvider()).toBe(provider);
-        expect(OpenFeature.getProvider('domain-a').metadata.name).not.toBe(provider.metadata.name);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith({}, undefined);
       });
 
       it('MUST NOT bind a domain-scoped provider as default when already bound to a domain', () => {
         const provider = { ...mockProvider(), domainScoped: true } as Provider;
+        const spy = jest.spyOn(provider, 'initialize');
 
         OpenFeature.setProvider('domain-a', provider);
         expect(() => OpenFeature.setProvider(provider)).toThrow(
           "Cannot bind domain-scoped provider 'mock-events-success' to more than one domain.",
         );
         expect(OpenFeature.getProvider('domain-a')).toBe(provider);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith({}, 'domain-a');
       });
 
       it('allows a non-domain-scoped provider to back multiple domains', async () => {


### PR DESCRIPTION
## Summary

- Add optional `domain` parameter to provider `initialize` and pass the bound domain from the provider mutator (spec 1.1.2.2, 2.4.1)
- Add `domainScoped` provider declaration and reject binding a domain-scoped instance to more than one domain (spec 2.4.3, 1.1.8.1)
- Forward `domain` through web and server MultiProvider `initialize`
- Add conformance tests in web and server SDK test suites, including legacy single-argument `initialize` backward compatibility

## Motivation

Unblocks OFREP static-context providers that need the bound `domain` at init time to scope persisted cache keys per [open-feature/spec#393](https://github.com/open-feature/spec/pull/393) and [protocol ADR 0009](https://github.com/open-feature/protocol/blob/main/service/adrs/0009-local-storage-for-static-context-providers.md).

### Notes

- Non-breaking: `domain` is an optional second parameter to `initialize`
- Non-domain-scoped providers retain existing behavior (single instance can back multiple domains; `initialize` runs once)
- Legacy providers that only implement `initialize(context)` remain compatible; the extra `domain` argument is ignored if unused

### Related Issues

Closes #1434

Relates to: [open-feature/spec#393](https://github.com/open-feature/spec/pull/393)

## Test plan

- [x] `npx jest --selectProjects=shared --selectProjects=web --selectProjects=server`
