### PR TITLE
fix(web): only settle provider status after all pending context changes

### DIFF
--- a/packages/web/src/open-feature.ts
+++ b/packages/web/src/open-feature.ts
@@ -392,23 +392,29 @@ export class OpenFeatureAPI
           });
           this._apiEmitter?.emit(ProviderEvents.Reconciling, { domain, providerName });
 
-          await maybePromise;
-          wrapper.decrementPendingContextChanges();
+          try {
+            await maybePromise;
+          } finally {
+            // decrement exactly once per increment, even if the handler rejects;
+            // decrementing in the catch below would corrupt the counter for synchronously-thrown errors
+            wrapper.decrementPendingContextChanges();
+          }
         }
       }
-      // only run the event handlers, and update the state if the onContextChange method succeeded
-      wrapper.status = this._statusEnumType.READY;
+      // only update the status and run the event handlers if the onContextChange method succeeded and
+      // all in-flight context changes have settled; otherwise a fast-completing change would report
+      // READY while an earlier change is still reconciling against a different context
       if (wrapper.allContextChangesSettled) {
+        wrapper.status = this._statusEnumType.READY;
         this.getAssociatedEventEmitters(domain).forEach((emitter) => {
           emitter?.emit(ProviderEvents.ContextChanged, { clientName: domain, domain, providerName });
         });
         this._apiEmitter?.emit(ProviderEvents.ContextChanged, { clientName: domain, domain, providerName });
       }
     } catch (err) {
-      // run error handlers instead
-      wrapper.decrementPendingContextChanges();
-      wrapper.status = this._statusEnumType.ERROR;
+      // run error handlers instead, once all in-flight context changes have settled
       if (wrapper.allContextChangesSettled) {
+        wrapper.status = this._statusEnumType.ERROR;
         const error = err as Error | undefined;
         const message = `Error running ${providerName}'s context change handler: ${error?.message}`;
         this._logger?.error(`${message}`, err);

--- a/packages/web/test/events.spec.ts
+++ b/packages/web/test/events.spec.ts
@@ -881,4 +881,79 @@ describe('Events', () => {
       expect(client.providerStatus).toEqual(ProviderStatus.ERROR);
     });
   });
+
+  describe('concurrent context changes', () => {
+    it('does not report READY while an earlier context change is still reconciling', async () => {
+      const resolvers: Array<() => void> = [];
+      const provider = {
+        metadata: { name: 'concurrent-context-change-provider' },
+        runsOn: 'client',
+        onContextChange: jest.fn(() => new Promise<void>((resolve) => resolvers.push(resolve))),
+        resolveBooleanEvaluation: jest.fn(),
+        resolveStringEvaluation: jest.fn(),
+        resolveNumberEvaluation: jest.fn(),
+        resolveObjectEvaluation: jest.fn(),
+      } as unknown as Provider;
+
+      const testDomain = uuid();
+      await OpenFeature.setProviderAndWait(testDomain, provider);
+      const client = OpenFeature.getClient(testDomain);
+      const contextChangedHandler = jest.fn();
+      client.addHandler(ProviderEvents.ContextChanged, contextChangedHandler);
+
+      const firstChange = OpenFeature.setContext(testDomain, { change: 1 });
+      const secondChange = OpenFeature.setContext(testDomain, { change: 2 });
+      expect(resolvers).toHaveLength(2);
+
+      // complete the second (newer) change while the first is still in flight
+      resolvers[1]();
+      await new Promise((resolve) => setTimeout(resolve));
+
+      expect(client.providerStatus).toEqual(ProviderStatus.RECONCILING);
+      expect(contextChangedHandler).not.toHaveBeenCalled();
+
+      // complete the first (older) change
+      resolvers[0]();
+      await Promise.all([firstChange, secondChange]);
+
+      expect(client.providerStatus).toEqual(ProviderStatus.READY);
+      expect(contextChangedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('recovers status and events after onContextChange throws synchronously', async () => {
+      let shouldThrow = true;
+      const provider = {
+        metadata: { name: 'sync-throw-provider' },
+        runsOn: 'client',
+        onContextChange: jest.fn(() => {
+          if (shouldThrow) {
+            throw new Error(ERR_MESSAGE);
+          }
+          return Promise.resolve();
+        }),
+        resolveBooleanEvaluation: jest.fn(),
+        resolveStringEvaluation: jest.fn(),
+        resolveNumberEvaluation: jest.fn(),
+        resolveObjectEvaluation: jest.fn(),
+      } as unknown as Provider;
+
+      const testDomain = uuid();
+      await OpenFeature.setProviderAndWait(testDomain, provider);
+      const client = OpenFeature.getClient(testDomain);
+      const errorHandler = jest.fn();
+      const contextChangedHandler = jest.fn();
+      client.addHandler(ProviderEvents.Error, errorHandler);
+      client.addHandler(ProviderEvents.ContextChanged, contextChangedHandler);
+
+      await OpenFeature.setContext(testDomain, { attempt: 1 });
+      expect(client.providerStatus).toEqual(ProviderStatus.ERROR);
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+
+      // a subsequent successful change must return the provider to READY
+      shouldThrow = false;
+      await OpenFeature.setContext(testDomain, { attempt: 2 });
+      expect(client.providerStatus).toEqual(ProviderStatus.READY);
+      expect(contextChangedHandler).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## This PR

Fixes two related defects in `runProviderContextChangeHandler` (web SDK):

### 1. Provider status settles per-callback instead of per-transition

`wrapper.status = READY` (and `= ERROR`) ran unconditionally as each `onContextChange` completed, while the corresponding `ContextChanged`/`Error` **events** were already gated on `allContextChangesSettled`. With two overlapping `setContext` calls, the faster completion set the status to `READY` while the earlier change was still reconciling:

```
t=0    change #1 starts        → RECONCILING (pending=2 after #2)
t=50   change #2 starts
t=100  #2 completes            → status=READY  ← older change still in flight
t=300  #1 completes            → ContextChanged fires (correct, gated)
```

Anything gating on `providerStatus === READY` (e.g. suspense helpers in the React SDK) could unblock at `t=100` and evaluate against a flag cache that was still mid-transition. This change gates the status writes on `allContextChangesSettled`, exactly mirroring the existing event gating, so status and events can never disagree.

### 2. Pending-changes counter corruption on synchronous throw

The `catch` block decremented `pendingContextChanges` unconditionally. An `onContextChange` implementation that throws **synchronously** never incremented the counter, so the decrement drove it negative — after which `allContextChangesSettled` was permanently false and `ContextChanged`/`Error` events were suppressed for the lifetime of the provider. The decrement now lives in a `finally` around the awaited promise, guaranteeing exactly one decrement per increment.

### Behavior notes

- Single (non-overlapping) context changes are unaffected: pending goes 0→1→0 and status settles as before.
- Synchronous/absent `onContextChange` handlers are unaffected (no increment, `allContextChangesSettled` is true, status settles immediately).
- With concurrent changes, the status is now set once, by the last-settling handler, with that handler's outcome — the same semantics the events already had.

### Tests

Two new tests in `packages/web/test/events.spec.ts`:
- overlapping changes: status stays `RECONCILING` until all changes settle, `ContextChanged` fires once (fails on main with `READY` mid-overlap);
- synchronously-throwing handler: `Error` event fires and a subsequent successful change returns the provider to `READY` (fails on main — the event is suppressed by the corrupted counter).

Full jest matrix (shared/server/web/react/nest, 614 tests) passes.