### PR TITLE
fix(react): honor default value for missing feature flags

### DIFF
--- a/packages/react/src/declarative/FeatureFlag.tsx
+++ b/packages/react/src/declarative/FeatureFlag.tsx
@@ -101,7 +101,7 @@ export function FeatureFlag<T extends FlagValue = FlagValue>({
   });
 
   // If the flag evaluation failed, we render the fallback
-  if (details.reason === 'ERROR') {
+  if (details.reason === 'ERROR' && details.details?.errorCode !== 'FLAG_NOT_FOUND') {
     const fallbackNode: React.ReactNode =
       typeof fallback === 'function' ? fallback(details.details as EvaluationDetails<T>) : fallback;
     return <>{fallbackNode}</>;

--- a/packages/react/test/declarative.spec.tsx
+++ b/packages/react/test/declarative.spec.tsx
@@ -81,6 +81,17 @@ describe('Feature Component', () => {
 
       expect(screen.queryByText(childText)).toBeInTheDocument();
     });
+    it('should render children when flag is missing and defaultValue is true', () => {
+      render(
+        <OpenFeatureProvider domain={EVALUATION}>
+          <FeatureFlag flagKey={MISSING_FLAG_KEY} defaultValue={true}>
+            <ChildComponent />
+          </FeatureFlag>
+        </OpenFeatureProvider>,
+      );
+
+      expect(screen.queryByText(childText)).toBeInTheDocument();
+    });
 
     it('should not show a non-boolean feature flag without match', () => {
       render(


### PR DESCRIPTION
 ## Description

Fixes an issue where `FeatureFlag` treated a missing flag as an error and rendered the fallback instead of using the provided `defaultValue`.

When the evaluation reason is `ERROR` with `FLAG_NOT_FOUND`, the component now continues through the normal matching logic so boolean flags can correctly use their default value.

## Testing

- 7 test suites passed
- 86 tests passed
- `git diff --check` passed

Fixes #1447