### PR TITLE
test: update spec requirement test names

### DIFF
--- a/packages/server/test/client.spec.ts
+++ b/packages/server/test/client.spec.ts
@@ -317,7 +317,7 @@ describe('OpenFeatureClient', () => {
     });
   });
 
-  describe('Requirement 1.4.1', () => {
+  describe('Requirement 1.4.1.1', () => {
     let client: Client;
 
     beforeEach(() => {
@@ -375,7 +375,7 @@ describe('OpenFeatureClient', () => {
     });
   });
 
-  describe('Requirement 1.4.3.1', () => {
+  describe('Requirement 1.4.4.1', () => {
     describe('generic support', () => {
       it('should support generics', async () => {
         // No generic information exists at runtime, but this test has some value in ensuring the generic args still exist in the typings.
@@ -400,7 +400,7 @@ describe('OpenFeatureClient', () => {
         expect(details).toBeDefined();
       });
 
-      describe('Requirement 1.4.2, 1.4.3', () => {
+      describe('Requirement 1.4.3', () => {
         it('should contain flag value', () => {
           expect(details.value).toEqual(NUMBER_VALUE);
         });


### PR DESCRIPTION
 ## Summary

Updates outdated OpenFeature specification requirement references in
`packages/server/test/client.spec.ts` to match the revised specification
numbering around the static-vs-dynamic context requirements.

## Changes

- `Requirement 1.4.1` → `Requirement 1.4.1.1`
- `Requirement 1.4.3.1` → `Requirement 1.4.4.1`
- `Requirement 1.4.2, 1.4.3` → `Requirement 1.4.3`

No SDK implementation behavior or test assertions were changed.

 ## Verification

Focused server client test:

`npm exec jest -- --selectProjects=server --runInBand packages/server/test/client.spec.ts`

Result:

- Test Suites: 1 passed
- Tests: 45 passed
- Snapshots: 0

Also verified with `git diff --check`.

