### PR TITLE
feat(svelte): add @openfeature/svelte-sdk

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Test Angular SDK
         run: npm run test:angular
 
+      - name: Test Svelte SDK
+        run: npm run test:svelte
+
   format-lint:
     runs-on: ubuntu-latest
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "plugins": ["prettier-plugin-svelte"]
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/web": "1.10.0",
   "packages/server": "1.23.0",
   "packages/shared": "1.12.0",
-  "packages/angular/projects/angular-sdk": "1.3.2"
+  "packages/angular/projects/angular-sdk": "1.3.2",
+  "packages/svelte": "0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For details, including API documentation, see the respective README files.
   - [NestJS SDK](./packages/nest/README.md), a distribution of the Server SDK with built-in NestJS-specific features.
 - [Web SDK](./packages/web/README.md), for use in the web browser.
   - [React SDK](./packages/react//README.md), a distribution of the Web SDK with built-in React-specific features.
+  - [Svelte SDK](./packages/svelte/README.md), a distribution of the Web SDK with built-in Svelte-specific features.
 
 Each have slightly different APIs, but share many underlying types and components.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "packages/react",
         "packages/angular",
         "packages/angular/projects/angular-sdk",
-        "packages/nest"
+        "packages/nest",
+        "packages/svelte"
       ],
       "devDependencies": {
         "@angular/compiler": "^21.2.19",
@@ -47,6 +48,7 @@
         "jest-junit": "^17.0.0",
         "lint-staged": "^16.2.7",
         "prettier": "^3.7.4",
+        "prettier-plugin-svelte": "^4.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rollup": "^4.0.0",
@@ -3698,6 +3700,10 @@
       "resolved": "packages/server",
       "link": true
     },
+    "node_modules/@openfeature/svelte-sdk": {
+      "resolved": "packages/svelte",
+      "link": true
+    },
     "node_modules/@openfeature/web-sdk": {
       "resolved": "packages/web",
       "link": true
@@ -5265,13 +5271,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
+      "integrity": "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5292,7 +5307,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5350,6 +5364,46 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.2.tgz",
+      "integrity": "sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.1.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.3.tgz",
+      "integrity": "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -5431,8 +5485,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6311,6 +6364,160 @@
       },
       "peerDependencies": {
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abab": {
@@ -7486,6 +7693,16 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -8037,6 +8254,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devalue": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -8113,8 +8337,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9088,6 +9311,13 @@
         "node": "*"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -9131,6 +9361,24 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/esrap": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.7.tgz",
+      "integrity": "sha512-n2nf7fZR3c9yXf0BPEuHuXqT+KW0SJVj4cN5FMEkpCZ3scLjOQWpiccyCxVzCC2q1wubTghuEGzngJY/7Ah0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -10963,6 +11211,16 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -13379,6 +13637,13 @@
         "node": ">=13.2.0"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -13592,7 +13857,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15138,13 +15402,26 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^5.0.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15160,7 +15437,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15417,8 +15693,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -17026,6 +17301,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svelte": {
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.57.0.tgz",
+      "integrity": "sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte/node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -18561,6 +18873,116 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -19008,6 +19430,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.5.tgz",
+      "integrity": "sha512-msJxIvYDYcoNL+PJsu+7qmpDWsYmAxTY+2TNYXXF0hzBzBk0BMecOqDOG/EckUoKCuKwObfbugIl8QpqHDXeFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",
@@ -21637,6 +22066,141 @@
       "version": "1.12.0",
       "license": "Apache-2.0",
       "devDependencies": {}
+    },
+    "packages/svelte": {
+      "name": "@openfeature/svelte-sdk",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@openfeature/core": "*",
+        "@openfeature/web-sdk": "*",
+        "@sveltejs/vite-plugin-svelte": "^6.2.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/svelte": "^5.4.2",
+        "@vitest/coverage-v8": "^4.1.10",
+        "jsdom": "^26.1.0",
+        "svelte": "^5.57.0",
+        "vitest": "^4.1.10"
+      },
+      "peerDependencies": {
+        "@openfeature/web-sdk": "^1.9.0",
+        "svelte": "^5.7.0"
+      }
+    },
+    "packages/svelte/node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
+      "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
+        "deepmerge": "^4.3.1",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.0",
+        "vitefu": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
+      }
+    },
+    "packages/svelte/node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-5.0.2.tgz",
+      "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obug": "^2.1.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.3.0 || ^7.0.0"
+      }
+    },
+    "packages/svelte/node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
     },
     "packages/web": {
       "name": "@openfeature/web-sdk",

--- a/package.json
+++ b/package.json
@@ -7,20 +7,21 @@
   "private": true,
   "description": "OpenFeature SDK for JavaScript",
   "scripts": {
-    "test": "npm run test:jest && npm run test:angular",
+    "test": "npm run test:jest && npm run test:angular && npm run test:svelte",
     "test:jest": "jest --selectProjects=shared --selectProjects=server --selectProjects=web --selectProjects=react --selectProjects=nest --silent",
     "test:angular": "npm run test:coverage --workspace=packages/angular",
+    "test:svelte": "npm run test:coverage --workspace=packages/svelte",
     "test:package-exports": "node scripts/test-package-exports.mjs",
     "e2e-server": "git submodule update --init --recursive && shx cp spec/specification/assets/gherkin/evaluation.feature packages/server/e2e/features && jest --selectProjects=server-e2e --verbose",
     "e2e-web": "git submodule update --init --recursive && shx cp spec/specification/assets/gherkin/evaluation.feature packages/web/e2e/features && jest --selectProjects=web-e2e --verbose",
     "e2e": "npm run e2e-server && npm run e2e-web",
-    "lint": "npm run lint --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
-    "lint:fix": "npm run lint:fix --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
+    "lint": "npm run lint --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest --workspace=packages/svelte",
+    "lint:fix": "npm run lint:fix --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest --workspace=packages/svelte",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "clean": "shx rm -rf ./dist",
-    "build": "npm run build --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
-    "publish-all": "npm run publish-if-not-exists --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest",
+    "build": "npm run build --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest --workspace=packages/svelte",
+    "publish-all": "npm run publish-if-not-exists --workspace=packages/shared --workspace=packages/server --workspace=packages/web --workspace=packages/react --workspace=packages/angular --workspace=packages/nest --workspace=packages/svelte",
     "docs": "typedoc",
     "prepare": "husky || true"
   },
@@ -70,6 +71,7 @@
     "jest-junit": "^17.0.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.7.4",
+    "prettier-plugin-svelte": "^4.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^4.0.0",
@@ -90,6 +92,7 @@
     "packages/react",
     "packages/angular",
     "packages/angular/projects/angular-sdk",
-    "packages/nest"
+    "packages/nest",
+    "packages/svelte"
   ]
 }

--- a/packages/shared/src/client/client.ts
+++ b/packages/shared/src/client/client.ts
@@ -21,7 +21,7 @@ export interface ClientMetadata {
    * `@openfeature/server-sdk` will leave `framework` undefined, even when
    * used inside a framework application.
    */
-  readonly framework?: 'react' | 'angular' | 'nest';
+  readonly framework?: 'react' | 'angular' | 'nest' | 'svelte';
   readonly providerMetadata: ProviderMetadata;
 }
 

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,454 @@
+<!-- markdownlint-disable MD033 -->
+<!-- x-hide-in-docs-start -->
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/white/openfeature-horizontal-white.svg" />
+    <img align="center" alt="OpenFeature Logo" src="https://raw.githubusercontent.com/open-feature/community/0e23508c163a6a1ac8c0ced3e4bd78faafe627c7/assets/logo/horizontal/black/openfeature-horizontal-black.svg" />
+  </picture>
+</p>
+
+<h2 align="center">OpenFeature Svelte SDK</h2>
+
+<!-- x-hide-in-docs-end -->
+<!-- The 'github-badges' class is used in the docs -->
+<p align="center" class="github-badges">
+  <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.8.0&color=yellow&style=for-the-badge" />
+  </a>
+  <!-- x-release-please-start-version -->
+  <a href="https://github.com/open-feature/js-sdk/releases/tag/svelte-sdk-v0.0.0">
+    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.0.0&color=blue&style=for-the-badge" />
+  </a>
+  <!-- x-release-please-end -->
+  <br/>
+  <a href="https://codecov.io/gh/open-feature/js-sdk">
+    <img alt="codecov" src="https://codecov.io/gh/open-feature/js-sdk/branch/main/graph/badge.svg?token=3DC5XOEHMY" />
+  </a>
+  <a href="https://www.npmjs.com/package/@openfeature/svelte-sdk">
+    <img alt="NPM Download" src="https://img.shields.io/npm/dm/%40openfeature%2Fsvelte-sdk" />
+  </a>
+</p>
+<!-- x-hide-in-docs-start -->
+
+[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool or in-house solution.
+
+<!-- x-hide-in-docs-end -->
+
+## Overview
+
+The OpenFeature Svelte SDK adds Svelte-specific functionality to the [OpenFeature Web SDK](https://openfeature.dev/docs/reference/technologies/client/web).
+
+In addition to the feature provided by the [web sdk](https://openfeature.dev/docs/reference/technologies/client/web), capabilities include:
+
+- [Overview](#overview)
+- [Quick start](#quick-start)
+  - [Requirements](#requirements)
+  - [Install](#install)
+    - [npm](#npm)
+    - [yarn](#yarn)
+    - [Required peer dependencies](#required-peer-dependencies)
+  - [Usage](#usage)
+    - [Scope](#scope)
+    - [Evaluation functions](#evaluation-functions)
+    - [Reactivity](#reactivity)
+    - [Multiple Providers and Domains](#multiple-providers-and-domains)
+    - [Updating with Context Changes](#updating-with-context-changes)
+    - [Updating with Flag Configuration Changes](#updating-with-flag-configuration-changes)
+    - [Provider Readiness and Status](#provider-readiness-and-status)
+    - [Tracking](#tracking)
+    - [Observability Considerations](#observability-considerations)
+    - [Type-Safe Flag Keys](#type-safe-flag-keys)
+  - [Testing](#testing)
+- [FAQ and troubleshooting](#faq-and-troubleshooting)
+- [Resources](#resources)
+
+## Quick start
+
+### Requirements
+
+- ES2015-compatible web browser (Chrome, Edge, Firefox, etc)
+- Svelte version 5.7+
+
+### Install
+
+#### npm
+
+```sh
+npm install --save @openfeature/svelte-sdk
+```
+
+#### yarn
+
+```sh
+# yarn requires manual installation of the peer dependencies (see below)
+yarn add @openfeature/svelte-sdk @openfeature/web-sdk @openfeature/core
+```
+
+#### Required peer dependencies
+
+The following list contains the peer dependencies of `@openfeature/svelte-sdk`.
+See the [package.json](./package.json) for the required versions.
+
+- `@openfeature/web-sdk`
+- `svelte`
+
+### Usage
+
+#### Scope
+
+`setOpenFeatureScope` binds an OpenFeature client to a component and all of its descendants using [Svelte context](https://svelte.dev/docs/svelte/context).
+It represents a scope for feature flag evaluations within a Svelte application, and is the equivalent of the `<OpenFeatureProvider>` in the React SDK.
+Call it during component initialization, typically in the script of your root component or layout.
+The example below shows how to use `setOpenFeatureScope` with OpenFeature's `TypedInMemoryProvider`.
+
+```svelte
+<!-- App.svelte, or src/routes/+layout.svelte in SvelteKit -->
+<script lang="ts">
+  import {
+    OpenFeature,
+    TypedInMemoryProvider,
+    setOpenFeatureScope,
+    type EvaluationContext,
+  } from '@openfeature/svelte-sdk';
+
+  const flagConfig = {
+    'new-message': {
+      disabled: false,
+      variants: {
+        on: true,
+        off: false,
+      },
+      defaultVariant: 'on',
+      contextEvaluator: (context: EvaluationContext) => {
+        if (context.silly) {
+          return 'on';
+        }
+        return 'off';
+      },
+    },
+  } as const;
+
+  // Instantiate and set our provider (be sure this only happens once)!
+  // Note: there's no need to await its initialization, the Svelte SDK updates your components for you!
+  OpenFeature.setProvider(new TypedInMemoryProvider(flagConfig));
+
+  // Bind a client to this component and its descendants
+  setOpenFeatureScope();
+
+  let { children } = $props();
+</script>
+
+{@render children()}
+```
+
+Setting a scope is optional: components (and modules) without an enclosing scope use the default client.
+A scope is useful to bind a [domain](#multiple-providers-and-domains) or to set default [evaluation options](#updating-with-context-changes) for a subtree.
+
+#### Evaluation functions
+
+Within the scope, you can use the various evaluation functions to evaluate flags.
+They return objects whose properties are reactive: read them in your template, in `$derived` or in `$effect` and your component updates when the flag value changes.
+
+```svelte
+<script lang="ts">
+  import { useFlag } from '@openfeature/svelte-sdk';
+
+  // Use the "query-style" flag evaluation function, specifying a flag-key and a default value.
+  const newMessage = useFlag('new-message', true);
+</script>
+
+<header>
+  {#if newMessage.value}
+    <p>Welcome to this OpenFeature-enabled Svelte app!</p>
+  {:else}
+    <p>Welcome to this Svelte app.</p>
+  {/if}
+</header>
+```
+
+You can use the strongly typed flag value and flag evaluation detail functions as well if you prefer.
+Because a primitive can't be reactive on its own, the value functions return a `{ current }` box, following the convention of Svelte's own [reactive classes](https://svelte.dev/docs/svelte/svelte-reactivity).
+
+```ts
+import { useBooleanFlagValue } from '@openfeature/svelte-sdk';
+
+// boolean flag evaluation
+const showNewMessage = useBooleanFlagValue('new-message', false);
+// read `showNewMessage.current` in your template
+```
+
+```ts
+import { useBooleanFlagDetails } from '@openfeature/svelte-sdk';
+
+// "detailed" boolean flag evaluation
+const details = useBooleanFlagDetails('new-message', false);
+// read `details.value`, `details.variant`, `details.reason`, `details.flagMetadata`, etc.
+```
+
+> [!NOTE]
+> Don't destructure the returned objects (`const { value } = useFlag(...)`); destructuring copies the value at that moment and loses reactivity.
+> Read the properties where you need them instead, or wrap them: `const value = $derived(flag.value)`.
+
+#### Reactivity
+
+The evaluation functions don't use runes internally, so they can be called anywhere: in a component's script, in a `.svelte.ts` module, or at module scope.
+They start listening to the provider only while a template, `$derived` or `$effect` depends on them, and stop listening automatically when the last dependency is destroyed, so there's nothing to clean up.
+Reads outside of effects (for example in an event handler) are served from the event-driven cache while something is listening, and re-evaluate the flag when nothing is.
+
+```ts
+// flags.svelte.ts - a module shared across components
+import { useFlag } from '@openfeature/svelte-sdk';
+
+export const newMessage = useFlag('new-message', false);
+```
+
+#### Multiple Providers and Domains
+
+Multiple providers can be used by passing a `domain` to `setOpenFeatureScope`:
+
+```svelte
+<script lang="ts">
+  import { setOpenFeatureScope } from '@openfeature/svelte-sdk';
+
+  // Flags within this domain will use the client/provider associated with `my-domain`,
+  setOpenFeatureScope({ domain: 'my-domain' });
+</script>
+```
+
+This is analogous to:
+
+```ts
+OpenFeature.getClient('my-domain');
+```
+
+Alternatively, a pre-configured `Client` instance can be passed directly via the `client` option:
+
+```svelte
+<script lang="ts">
+  import { OpenFeature, setOpenFeatureScope } from '@openfeature/svelte-sdk';
+
+  const client = OpenFeature.getClient('my-domain');
+  setOpenFeatureScope({ client });
+</script>
+```
+
+The `domain` and `client` options are mutually exclusive.
+
+For more information about `domains`, refer to the [web SDK](https://github.com/open-feature/js-sdk/blob/main/packages/web/README.md).
+
+#### Updating with Context Changes
+
+By default, if the OpenFeature [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) is modified, flags are re-evaluated and dependent components update.
+This is useful in cases where flag values are dependent on user-attributes or other application state (user logged in, items in card, etc).
+You can disable this feature in the evaluation options (or in the [scope](#scope), for all evaluations within it):
+
+```svelte
+<script lang="ts">
+  import { useFlag } from '@openfeature/svelte-sdk';
+
+  const newMessage = useFlag('new-message', false, { updateOnContextChanged: false });
+</script>
+```
+
+To modify the evaluation context associated with the enclosing scope's domain, use `useContextMutator`:
+
+```svelte
+<script lang="ts">
+  import { useContextMutator } from '@openfeature/svelte-sdk';
+
+  const { setContext } = useContextMutator();
+</script>
+
+<button onclick={() => setContext({ silly: true })}>Be silly</button>
+```
+
+For more information about how evaluation context works in the Svelte SDK, see the documentation on OpenFeature's [static context SDK paradigm](https://openfeature.dev/specification/glossary/#static-context-paradigm).
+
+#### Updating with Flag Configuration Changes
+
+By default, if the underlying provider emits a `ConfigurationChanged` event, flags are re-evaluated and dependent components update.
+This is useful if you want your UI to immediately reflect changes in the backend flag configuration.
+You can disable this feature in the evaluation options (or in the [scope](#scope), for all evaluations within it):
+
+```svelte
+<script lang="ts">
+  import { useFlag } from '@openfeature/svelte-sdk';
+
+  const newMessage = useFlag('new-message', false, { updateOnConfigurationChanged: false });
+</script>
+```
+
+If your provider doesn't support updates, this configuration has no impact.
+
+> [!NOTE]
+> If your provider includes a list of [flags changed](https://open-feature.github.io/js-sdk/types/_openfeature_server_sdk.ConfigChangeEvent.html) in its `PROVIDER_CONFIGURATION_CHANGED` event, that list of flags is used to decide which flags should be re-evaluated.
+> If your provider event does not the include the `flags changed` list, then the SDK re-evaluates all flags.
+> In both cases, components only update if the evaluation details actually changed.
+
+#### Provider Readiness and Status
+
+Frequently, providers need to perform some initial startup tasks.
+It may be desirable not to display components with feature flags until this is complete.
+`useWhenProviderReady` returns a reactive boolean you can use to render a loader until the provider is ready:
+
+```svelte
+<script lang="ts">
+  import { useWhenProviderReady } from '@openfeature/svelte-sdk';
+
+  const ready = useWhenProviderReady();
+</script>
+
+{#if ready.current}
+  <Content />
+{:else}
+  <p>Waiting for provider to be ready...</p>
+{/if}
+```
+
+`useWhenProviderReady` is a boolean gate: it's `false` both while the provider is `NOT_READY` and after a terminal `ERROR` or `FATAL` state.
+To distinguish a provider that is still starting from one that failed to start, use `useOpenFeatureClientStatus` and handle terminal states explicitly:
+
+```svelte
+<script lang="ts">
+  import { ProviderStatus, useOpenFeatureClientStatus } from '@openfeature/svelte-sdk';
+
+  const status = useOpenFeatureClientStatus();
+</script>
+
+{#if status.current === ProviderStatus.NOT_READY}
+  <Spinner />
+{:else if status.current === ProviderStatus.ERROR || status.current === ProviderStatus.FATAL}
+  <!-- Evaluation functions continue with their code defaults. -->
+  <Sidebar featureProviderUnavailable />
+{:else}
+  <Sidebar />
+{/if}
+```
+
+#### Tracking
+
+The tracking API allows you to use OpenFeature abstractions and objects to associate user actions with feature flag evaluations.
+This is essential for robust experimentation powered by feature flags.
+For example, a flag enhancing the appearance of a UI component might drive user engagement to a new feature; to test this hypothesis, telemetry collected by a [hook](https://openfeature.dev/docs/reference/technologies/client/web/#hooks) or [provider](https://openfeature.dev/docs/reference/technologies/client/web/#providers) can be associated with telemetry reported in the client's `track` function.
+
+The Svelte SDK includes a function for firing tracking events in the enclosing scope:
+
+```svelte
+<script lang="ts">
+  import { useTrack } from '@openfeature/svelte-sdk';
+
+  // get a tracking function for the enclosing scope.
+  const { track } = useTrack();
+</script>
+
+<!-- call the tracking event, for example in an event handler -->
+<button onclick={() => track('checkout-clicked', { value: 99.99 })}>Checkout</button>
+```
+
+#### Observability Considerations
+
+Flags may be evaluated more than once as a user interacts with a page, for example when the provider becomes ready, or when a flag object is read outside of an effect.
+If you are using an OpenFeature hook for telemetry, this can result in inflated evaluation metrics.
+The [OpenFeature debounce hook](https://github.com/open-feature/js-sdk-contrib/tree/main/libs/hooks/debounce) can help to reduce the amount of redundant evaluations reported to your observability platform by limiting the frequency at which evaluation metrics are reported.
+
+#### Type-Safe Flag Keys
+
+For enhanced type safety and autocompletion, you can override flag key types using TypeScript module augmentation. See the [`@openfeature/core` README](../shared/README.md#type-safe-flag-keys) for details.
+
+### Testing
+
+The Svelte SDK includes a built-in helper for testing.
+This allows you to easily test components that use evaluation functions (such as `useFlag`).
+`setOpenFeatureTestScope` configures a test provider and, when called during component initialization, binds it to that component's subtree like `setOpenFeatureScope` does.
+It can also be called directly in a test (for example in `beforeEach`), in which case it configures the provider used by components without a scope.
+
+```ts
+import { setOpenFeatureTestScope } from '@openfeature/svelte-sdk';
+import { render, screen } from '@testing-library/svelte';
+
+// use default values for all evaluations
+setOpenFeatureTestScope();
+render(MyComponent);
+```
+
+The basic configuration above will simply use the default value provided in code.
+If you'd like to control the values returned by the evaluation functions, you can pass a map of flag keys and values:
+
+```ts
+// return `true` for all evaluations of `'my-boolean-flag'`
+setOpenFeatureTestScope({ flagValueMap: { 'my-boolean-flag': true } });
+render(MyComponent);
+```
+
+Additionally, you can pass an artificial delay for the provider startup to test your loaders/spinners impacted by feature flags:
+
+```ts
+// delay the provider start by 1000ms and then return `true` for all evaluations of `'my-boolean-flag'`
+setOpenFeatureTestScope({ delayMs: 1000, flagValueMap: { 'my-boolean-flag': true } });
+render(MyComponent);
+```
+
+For maximum control, you can also pass your own mock provider implementation.
+The type of this option is `Partial<Provider>`, so you can pass an incomplete implementation:
+
+```ts
+import type { Provider, ResolutionDetails } from '@openfeature/svelte-sdk';
+
+class MyTestProvider implements Partial<Provider> {
+  // implement the relevant resolver
+  resolveBooleanEvaluation(): ResolutionDetails<boolean> {
+    return {
+      value: true,
+      variant: 'my-variant',
+      reason: 'MY_REASON',
+    };
+  }
+}
+```
+
+```ts
+// use your custom testing provider
+setOpenFeatureTestScope({ provider: new MyTestProvider() });
+render(MyComponent);
+```
+
+To scope the test provider to a subtree instead, call `setOpenFeatureTestScope` in the script of a wrapper component that renders the component under test.
+
+## FAQ and troubleshooting
+
+> Does the Svelte SDK support server-side rendering (SvelteKit SSR)?
+
+The Svelte SDK, like the web SDK it's built on, is designed for client-side evaluation: the `OpenFeature` singleton holds a single evaluation context, which isn't appropriate for a server handling many requests.
+On the server, use the [Server SDK](https://openfeature.dev/docs/reference/technologies/server/javascript) in your `load` functions or hooks, and pass the resolved values to your components as data.
+Flag objects created during SSR simply return the default value (or whatever the provider resolves) without subscribing to anything.
+
+> Can I use the Svelte SDK with Svelte 4, or with stores?
+
+The reactivity of the Svelte SDK is built on `createSubscriber` from `svelte/reactivity`, which requires Svelte 5.7 or later.
+If you prefer stores, you can wrap any reactive property with [`toStore`](https://svelte.dev/docs/svelte/svelte-store#toStore):
+
+```ts
+import { toStore } from 'svelte/store';
+
+const newMessage = useFlag('new-message', false);
+const newMessageStore = toStore(() => newMessage.value);
+```
+
+> I get an error that says something like: `lifecycle_outside_component`.
+
+`setOpenFeatureScope` (and `setOpenFeatureTestScope`, when used to bind a subtree) uses Svelte context, so it must be called during component initialization: at the top level of a component's `<script>`, not in an event handler, effect, or after an `await`.
+The evaluation functions themselves don't have this restriction.
+
+> I am using multiple scopes, but they share the same provider or evaluation context. Why?
+
+`setOpenFeatureScope` binds a `client` to a component subtree, but the provider and context associated with that client is controlled by the `domain` parameter.
+This is consistent with all OpenFeature SDKs.
+To scope a subtree to a particular provider/context, set the `domain` parameter on your scope:
+
+```ts
+setOpenFeatureScope({ domain: 'my-domain' });
+```
+
+## Resources
+
+- [Example repo](https://github.com/open-feature/js-sdk-examples)

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@openfeature/svelte-sdk",
+  "version": "0.0.0",
+  "description": "OpenFeature Svelte SDK",
+  "main": "./dist/esm/index.js",
+  "files": [
+    "dist/"
+  ],
+  "exports": {
+    "types": "./dist/types.d.ts",
+    "import": "./dist/esm/index.js",
+    "default": "./dist/esm/index.js"
+  },
+  "types": "./dist/types.d.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint ./",
+    "lint:fix": "eslint ./ --fix",
+    "clean": "shx rm -rf ./dist",
+    "build:svelte-esm": "esbuild src/index.ts --bundle --external:svelte --external:svelte/* --external:@openfeature/web-sdk --sourcemap --target=es2015 --platform=browser --format=esm --outfile=./dist/esm/index.js --analyze",
+    "build:rollup-types": "rollup -c ../../rollup.config.mjs",
+    "build": "npm run clean && npm run build:svelte-esm && npm run build:rollup-types",
+    "postbuild": "shx cp ./../../package.esm.json ./dist/esm/package.json",
+    "current-version": "echo $npm_package_version",
+    "prepack": "shx cp ./../../LICENSE ./LICENSE",
+    "publish-if-not-exists": "cp $NPM_CONFIG_USERCONFIG .npmrc && if [ \"$(npm show $npm_package_name@$npm_package_version version)\" = \"$(npm run current-version -s)\" ]; then echo 'already published, skipping'; else npm publish --access public; fi"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-feature/js-sdk.git"
+  },
+  "keywords": [
+    "openfeature",
+    "feature",
+    "flags",
+    "toggles",
+    "browser",
+    "web",
+    "svelte"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/open-feature/js-sdk/issues"
+  },
+  "homepage": "https://github.com/open-feature/js-sdk#readme",
+  "peerDependencies": {
+    "@openfeature/web-sdk": "^1.9.0",
+    "svelte": "^5.7.0"
+  },
+  "devDependencies": {
+    "@openfeature/core": "*",
+    "@openfeature/web-sdk": "*",
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.4.2",
+    "@vitest/coverage-v8": "^4.1.10",
+    "jsdom": "^26.1.0",
+    "svelte": "^5.57.0",
+    "vitest": "^4.1.10"
+  },
+  "sideEffects": false
+}

--- a/packages/svelte/src/context/index.ts
+++ b/packages/svelte/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from './use-context-mutator';

--- a/packages/svelte/src/context/use-context-mutator.ts
+++ b/packages/svelte/src/context/use-context-mutator.ts
@@ -1,0 +1,68 @@
+import type { EvaluationContext } from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { cloneContext } from '../internal/clone-context';
+import { isEqual } from '../internal/is-equal';
+import { getScope } from '../internal/scope';
+
+export type ContextMutationOptions = {
+  /**
+   * Mutate the default context instead of the domain scoped context applied with `setOpenFeatureScope`.
+   * By default, will use the domain set with `setOpenFeatureScope` (or the domain associated with the client set with `setOpenFeatureScope`).
+   * See the {@link https://openfeature.dev/docs/reference/technologies/client/web/#manage-evaluation-context-for-domains|documentation} for more information.
+   * @default false
+   */
+  defaultContext?: boolean;
+};
+
+export type ContextMutation = {
+  /**
+   * Context-aware function to set the desired context (see: {@link ContextMutationOptions} for details).
+   * There's generally no need to await the result of this function; reactive flag evaluations update when the context is updated.
+   * This promise never rejects.
+   * @param updatedContext New context object or method to generate it from the current context
+   * @returns Promise for awaiting the context update
+   */
+  setContext: (
+    updatedContext: EvaluationContext | ((currentContext: EvaluationContext) => EvaluationContext),
+  ) => Promise<void>;
+};
+
+/**
+ * Get context-aware function(s) for mutating the evaluation context associated with the domain of the enclosing scope,
+ * or the default context if `defaultContext: true`.
+ * See the {@link https://openfeature.dev/docs/reference/technologies/client/web/#targeting-and-context|documentation} for more information.
+ * @param {ContextMutationOptions} options options for the generated function
+ * @returns {ContextMutation} context-aware function(s) to mutate evaluation context
+ */
+export function useContextMutator(options: ContextMutationOptions = { defaultContext: false }): ContextMutation {
+  const domain = getScope()?.client.metadata.domain;
+
+  // TODO: Replace this warning with a thrown error in a future major release,
+  //       when `defaultContext` isn't explicitly set to true.
+  if (!options.defaultContext && !domain) {
+    console.warn(
+      '[useContextMutator] No domain available from the OpenFeature scope; are you using setOpenFeatureScope? setContext will mutate the default context, as if `defaultContext: true` were set. This may result in a thrown error in the future.',
+    );
+  }
+
+  const setContext = async (
+    updatedContext: EvaluationContext | ((currentContext: EvaluationContext) => EvaluationContext),
+  ): Promise<void> => {
+    const previousContext = OpenFeature.getContext(options?.defaultContext ? undefined : domain);
+    // the updater gets an independent copy, so in-place mutations (even of nested values) are still detected as changes
+    const resolvedContext =
+      typeof updatedContext === 'function' ? updatedContext(cloneContext(previousContext)) : updatedContext;
+
+    if (!isEqual(previousContext, resolvedContext)) {
+      if (!domain || options?.defaultContext) {
+        await OpenFeature.setContext(resolvedContext);
+      } else {
+        await OpenFeature.setContext(domain, resolvedContext);
+      }
+    }
+  };
+
+  return {
+    setContext,
+  };
+}

--- a/packages/svelte/src/evaluation/index.ts
+++ b/packages/svelte/src/evaluation/index.ts
@@ -1,0 +1,1 @@
+export * from './use-feature-flag';

--- a/packages/svelte/src/evaluation/use-feature-flag.ts
+++ b/packages/svelte/src/evaluation/use-feature-flag.ts
@@ -1,0 +1,260 @@
+import type {
+  BooleanFlagKey,
+  ConstrainedFlagKey,
+  EvaluationDetails,
+  FlagValue,
+  JsonValue,
+  NumberFlagKey,
+  ObjectFlagKey,
+  StringFlagKey,
+} from '@openfeature/web-sdk';
+import { DEFAULT_OPTIONS, normalizeOptions } from '../internal';
+import { resolveClient, resolveScopeOptions } from '../internal/client';
+import { ReactiveFlagQuery } from '../internal/flag-query';
+import type { EvaluationResolver } from '../internal/reactive-evaluation';
+import { ReactiveEvaluationDetails } from '../internal/reactive-evaluation';
+import type { SvelteFlagEvaluationOptions } from '../options';
+import type { FlagQuery } from '../query';
+import type { ReactiveValue } from '../reactive';
+
+// This type is a bit wild-looking, but I think we need it.
+// We have to use the conditional, because otherwise useFlag('key', false) would return false, not boolean (too constrained).
+type ConstrainedFlagQuery<T> = FlagQuery<
+  T extends boolean
+    ? boolean
+    : T extends number
+      ? number
+      : T extends string
+        ? string
+        : T extends JsonValue
+          ? T
+          : JsonValue
+>;
+
+/**
+ * Evaluates a feature flag generically, returning a reactive, queryable object.
+ * The resolver method to use is based on the type of the defaultValue.
+ * For type-specific functions, use {@link useBooleanFlagValue}, {@link useBooleanFlagDetails} and equivalents.
+ * By default, templates and effects reading the result update when the flag value changes.
+ * @param {ConstrainedFlagKey<T>} flagKey the flag identifier
+ * @template {FlagValue} T A optional generic argument constraining the default.
+ * @param {T} defaultValue the default value; used to determine what resolved type should be used.
+ * @param {SvelteFlagEvaluationOptions} options for this evaluation
+ * @returns { FlagQuery } a reactive, queryable object containing useful information about the flag.
+ */
+export function useFlag<T extends FlagValue = FlagValue>(
+  flagKey: ConstrainedFlagKey<T>,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): FlagQuery<
+  T extends boolean
+    ? boolean
+    : T extends number
+      ? number
+      : T extends string
+        ? string
+        : T extends JsonValue
+          ? T
+          : JsonValue
+> {
+  // use the default value to determine the resolver to call
+  const query =
+    typeof defaultValue === 'boolean'
+      ? new ReactiveFlagQuery<boolean>(useBooleanFlagDetails(flagKey, defaultValue, options))
+      : typeof defaultValue === 'number'
+        ? new ReactiveFlagQuery<number>(useNumberFlagDetails(flagKey, defaultValue, options))
+        : typeof defaultValue === 'string'
+          ? new ReactiveFlagQuery<string>(useStringFlagDetails(flagKey, defaultValue, options))
+          : new ReactiveFlagQuery<JsonValue>(useObjectFlagDetails(flagKey, defaultValue, options));
+  // TS sees this as ReactiveFlagQuery<JsonValue>, because the compiler isn't aware of the `typeof` checks above.
+  return query as unknown as ConstrainedFlagQuery<T>;
+}
+
+/**
+ * Evaluates a feature flag, returning a reactive boolean.
+ * By default, templates and effects reading `current` update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {BooleanFlagKey} flagKey the flag identifier
+ * @param {boolean} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { ReactiveValue<boolean>} a reactive boolean for this evaluation
+ */
+export function useBooleanFlagValue(
+  flagKey: BooleanFlagKey,
+  defaultValue: boolean,
+  options?: SvelteFlagEvaluationOptions,
+): ReactiveValue<boolean> {
+  return toReactiveValue(useBooleanFlagDetails(flagKey, defaultValue, options));
+}
+
+/**
+ * Evaluates a feature flag, returning reactive evaluation details.
+ * By default, templates and effects reading the details update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {BooleanFlagKey} flagKey the flag identifier
+ * @param {boolean} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { EvaluationDetails<boolean>} a reactive EvaluationDetails object for this evaluation
+ */
+export function useBooleanFlagDetails(
+  flagKey: BooleanFlagKey,
+  defaultValue: boolean,
+  options?: SvelteFlagEvaluationOptions,
+): EvaluationDetails<boolean> {
+  return attachHandlersAndResolve(
+    flagKey,
+    defaultValue,
+    (client) => {
+      return client.getBooleanDetails;
+    },
+    options,
+  );
+}
+
+/**
+ * Evaluates a feature flag, returning a reactive string.
+ * By default, templates and effects reading `current` update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {StringFlagKey} flagKey the flag identifier
+ * @template {string} [T=string] A optional generic argument constraining the string
+ * @param {T} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { ReactiveValue<string>} a reactive string for this evaluation
+ */
+export function useStringFlagValue<T extends string = string>(
+  flagKey: StringFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): ReactiveValue<string> {
+  return toReactiveValue(useStringFlagDetails(flagKey, defaultValue, options));
+}
+
+/**
+ * Evaluates a feature flag, returning reactive evaluation details.
+ * By default, templates and effects reading the details update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {StringFlagKey} flagKey the flag identifier
+ * @template {string} [T=string] A optional generic argument constraining the string
+ * @param {T} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { EvaluationDetails<string>} a reactive EvaluationDetails object for this evaluation
+ */
+export function useStringFlagDetails<T extends string = string>(
+  flagKey: StringFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): EvaluationDetails<string> {
+  return attachHandlersAndResolve(
+    flagKey,
+    defaultValue,
+    (client) => {
+      return client.getStringDetails<T>;
+    },
+    options,
+  );
+}
+
+/**
+ * Evaluates a feature flag, returning a reactive number.
+ * By default, templates and effects reading `current` update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {NumberFlagKey} flagKey the flag identifier
+ * @template {number} [T=number] A optional generic argument constraining the number
+ * @param {T} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { ReactiveValue<number>} a reactive number for this evaluation
+ */
+export function useNumberFlagValue<T extends number = number>(
+  flagKey: NumberFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): ReactiveValue<number> {
+  return toReactiveValue(useNumberFlagDetails(flagKey, defaultValue, options));
+}
+
+/**
+ * Evaluates a feature flag, returning reactive evaluation details.
+ * By default, templates and effects reading the details update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {NumberFlagKey} flagKey the flag identifier
+ * @template {number} [T=number] A optional generic argument constraining the number
+ * @param {T} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { EvaluationDetails<number>} a reactive EvaluationDetails object for this evaluation
+ */
+export function useNumberFlagDetails<T extends number = number>(
+  flagKey: NumberFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): EvaluationDetails<number> {
+  return attachHandlersAndResolve(
+    flagKey,
+    defaultValue,
+    (client) => {
+      return client.getNumberDetails<T>;
+    },
+    options,
+  );
+}
+
+/**
+ * Evaluates a feature flag, returning a reactive object.
+ * By default, templates and effects reading `current` update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {ObjectFlagKey} flagKey the flag identifier
+ * @template {JsonValue} [T=JsonValue] A optional generic argument describing the structure
+ * @param {T} defaultValue the default value
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { ReactiveValue<T>} a reactive object for this evaluation
+ */
+export function useObjectFlagValue<T extends JsonValue = JsonValue>(
+  flagKey: ObjectFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): ReactiveValue<T> {
+  return toReactiveValue(useObjectFlagDetails<T>(flagKey, defaultValue, options));
+}
+
+/**
+ * Evaluates a feature flag, returning reactive evaluation details.
+ * By default, templates and effects reading the details update when the flag value changes.
+ * For a generic function returning a queryable interface, see {@link useFlag}.
+ * @param {ObjectFlagKey} flagKey the flag identifier
+ * @param {T} defaultValue the default value
+ * @template {JsonValue} [T=JsonValue] A optional generic argument describing the structure
+ * @param {SvelteFlagEvaluationOptions} options options for this evaluation
+ * @returns { EvaluationDetails<T>} a reactive EvaluationDetails object for this evaluation
+ */
+export function useObjectFlagDetails<T extends JsonValue = JsonValue>(
+  flagKey: ObjectFlagKey,
+  defaultValue: T,
+  options?: SvelteFlagEvaluationOptions,
+): EvaluationDetails<T> {
+  return attachHandlersAndResolve(
+    flagKey,
+    defaultValue,
+    (client) => {
+      return client.getObjectDetails<T>;
+    },
+    options,
+  );
+}
+
+function toReactiveValue<T extends FlagValue>(details: EvaluationDetails<T>): ReactiveValue<T> {
+  return {
+    get current() {
+      return details.value;
+    },
+  };
+}
+
+function attachHandlersAndResolve<T extends FlagValue>(
+  flagKey: string,
+  defaultValue: T,
+  resolver: EvaluationResolver<T>,
+  options?: SvelteFlagEvaluationOptions,
+): EvaluationDetails<T> {
+  // highest priority > evaluation options > scope options > default options > lowest priority
+  const defaultedOptions = { ...DEFAULT_OPTIONS, ...resolveScopeOptions(), ...normalizeOptions(options) };
+  return new ReactiveEvaluationDetails(resolveClient(), flagKey, defaultValue, resolver, options, defaultedOptions);
+}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,9 @@
+export * from './evaluation';
+export * from './query';
+export * from './provider';
+export * from './context';
+export * from './tracking';
+export * from './options';
+export * from './reactive';
+// re-export the web-sdk so consumers can access that API from the svelte-sdk
+export * from '@openfeature/web-sdk';

--- a/packages/svelte/src/internal/client.ts
+++ b/packages/svelte/src/internal/client.ts
@@ -1,0 +1,23 @@
+import type { Client } from '@openfeature/web-sdk';
+import { OpenFeature, withFrameworkMetadata } from '@openfeature/web-sdk';
+import type { NormalizedOptions } from '../options';
+import { normalizeOptions } from './options';
+import { getScope } from './scope';
+
+/**
+ * Resolves the client for the current scope, falling back to the default client.
+ * @internal
+ * @returns {Client} svelte-aware client
+ */
+export function resolveClient(): Client {
+  return getScope()?.client ?? withFrameworkMetadata(OpenFeature.getClient(), 'svelte');
+}
+
+/**
+ * Normalized options of the enclosing scope, see {@link normalizeOptions}.
+ * @internal
+ * @returns {NormalizedOptions} normalized scope options
+ */
+export function resolveScopeOptions(): NormalizedOptions {
+  return normalizeOptions(getScope()?.options);
+}

--- a/packages/svelte/src/internal/clone-context.ts
+++ b/packages/svelte/src/internal/clone-context.ts
@@ -1,0 +1,35 @@
+import type { EvaluationContext, EvaluationContextValue } from '@openfeature/web-sdk';
+
+/**
+ * Deep-copies an evaluation context so that in-place mutations of the copy never affect the original.
+ * Supports the value types allowed in an {@link EvaluationContext}: primitives, dates, arrays and nested objects.
+ * @internal
+ * @param {EvaluationContext} context context to copy
+ * @returns {EvaluationContext} independent copy of the context
+ */
+export function cloneContext(context: EvaluationContext): EvaluationContext {
+  return cloneValue(context) as EvaluationContext;
+}
+
+function cloneValue(value: EvaluationContextValue): EvaluationContextValue {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+  if (typeof value === 'object' && value !== null) {
+    const copy: { [key: string]: EvaluationContextValue } = {};
+    for (const key of Object.keys(value)) {
+      // define an own property so that keys like "__proto__" are copied as data, not treated as the prototype
+      Object.defineProperty(copy, key, {
+        value: cloneValue(value[key]),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return copy;
+  }
+  return value;
+}

--- a/packages/svelte/src/internal/flag-query.ts
+++ b/packages/svelte/src/internal/flag-query.ts
@@ -1,0 +1,55 @@
+import type { EvaluationDetails, FlagValue } from '@openfeature/web-sdk';
+import { StandardResolutionReasons } from '@openfeature/web-sdk';
+import type { FlagQuery } from '../query';
+
+/**
+ * FlagQuery implementation backed by reactive evaluation details.
+ * @internal
+ */
+export class ReactiveFlagQuery<T extends FlagValue = FlagValue> implements FlagQuery<T> {
+  constructor(private readonly _details: EvaluationDetails<T>) {}
+
+  get details() {
+    return this._details;
+  }
+
+  get value() {
+    return this._details.value;
+  }
+
+  get variant() {
+    return this._details.variant;
+  }
+
+  get flagMetadata() {
+    return this._details.flagMetadata;
+  }
+
+  get reason() {
+    return this._details.reason;
+  }
+
+  get isError() {
+    return !!this._details.errorCode || this._details.reason == StandardResolutionReasons.ERROR;
+  }
+
+  get errorCode() {
+    return this._details.errorCode;
+  }
+
+  get errorMessage() {
+    return this._details.errorMessage;
+  }
+
+  get isAuthoritative() {
+    return (
+      !this.isError &&
+      this._details.reason != StandardResolutionReasons.STALE &&
+      this._details.reason != StandardResolutionReasons.DISABLED
+    );
+  }
+
+  get type() {
+    return typeof this._details.value;
+  }
+}

--- a/packages/svelte/src/internal/index.ts
+++ b/packages/svelte/src/internal/index.ts
@@ -1,0 +1,2 @@
+export * from './is-equal';
+export * from './options';

--- a/packages/svelte/src/internal/is-equal.ts
+++ b/packages/svelte/src/internal/is-equal.ts
@@ -1,0 +1,49 @@
+/**
+ * Deeply compare two values to determine if they are equal.
+ * Supports primitives and serializable objects.
+ *
+ * Note: Does not handle RegExp, Map, Set, or circular references.
+ * Suitable for comparing EvaluationDetails, EvaluationContext and other JSON-serializable data.
+ * @param {unknown} value First value to compare
+ * @param {unknown} other Second value to compare
+ * @returns {boolean} True if the values are equal
+ */
+export function isEqual(value: unknown, other: unknown): boolean {
+  if (value === other) {
+    return true;
+  }
+
+  if (typeof value !== typeof other) {
+    return false;
+  }
+
+  if (value instanceof Date || other instanceof Date) {
+    return value instanceof Date && other instanceof Date && value.getTime() === other.getTime();
+  }
+
+  if (Array.isArray(value) || Array.isArray(other)) {
+    if (!Array.isArray(value) || !Array.isArray(other) || value.length !== other.length) {
+      return false;
+    }
+  }
+
+  if (typeof value === 'object' && value !== null && typeof other === 'object' && other !== null) {
+    const valueKeys = Object.keys(value);
+    const otherKeys = Object.keys(other);
+
+    if (valueKeys.length !== otherKeys.length) {
+      return false;
+    }
+
+    for (const key of valueKeys) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (!isEqual((value as any)[key], (other as any)[key])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/packages/svelte/src/internal/options.ts
+++ b/packages/svelte/src/internal/options.ts
@@ -1,0 +1,27 @@
+import type { NormalizedOptions, SvelteFlagEvaluationOptions } from '../options';
+
+/**
+ * Default options.
+ * @internal
+ */
+export const DEFAULT_OPTIONS: Required<NormalizedOptions> = {
+  updateOnContextChanged: true,
+  updateOnConfigurationChanged: true,
+};
+
+/**
+ * Returns only the update flags that are explicitly set, so the result can be spread over other option layers.
+ * @internal
+ * @param {SvelteFlagEvaluationOptions} options options to normalize
+ * @returns {NormalizedOptions} normalized options
+ */
+export const normalizeOptions: (options?: SvelteFlagEvaluationOptions) => NormalizedOptions = (
+  options: SvelteFlagEvaluationOptions = {},
+) => {
+  const { updateOnContextChanged, updateOnConfigurationChanged } = options;
+
+  return {
+    ...(typeof updateOnContextChanged === 'boolean' && { updateOnContextChanged }),
+    ...(typeof updateOnConfigurationChanged === 'boolean' && { updateOnConfigurationChanged }),
+  };
+};

--- a/packages/svelte/src/internal/reactive-evaluation.ts
+++ b/packages/svelte/src/internal/reactive-evaluation.ts
@@ -1,0 +1,124 @@
+import { createSubscriber } from 'svelte/reactivity';
+import type { Client, EvaluationDetails, FlagEvaluationOptions, FlagValue } from '@openfeature/web-sdk';
+import { ProviderEvents } from '@openfeature/web-sdk';
+import type { NormalizedOptions, SvelteFlagEvaluationOptions } from '../options';
+import { isEqual } from './is-equal';
+
+/**
+ * Selects the client method used to resolve a flag of a given type.
+ * @internal
+ */
+export type EvaluationResolver<T extends FlagValue> = (
+  client: Client,
+) => (flagKey: string, defaultValue: T, options?: FlagEvaluationOptions) => EvaluationDetails<T>;
+
+/**
+ * Evaluation details which re-evaluate on provider readiness, context changes and configuration changes.
+ * Reading a property inside a template, `$derived` or `$effect` registers a dependency; client event handlers
+ * are attached only while such dependencies exist. Outside of effects, reads re-evaluate the flag.
+ * @internal
+ */
+export class ReactiveEvaluationDetails<T extends FlagValue> implements EvaluationDetails<T> {
+  private current: EvaluationDetails<T>;
+  // true while event handlers keep `current` up to date (createSubscriber detaches them in a microtask after the last effect is destroyed)
+  private listening = false;
+  private readonly subscribe: () => void;
+
+  constructor(
+    private readonly client: Client,
+    readonly flagKey: string,
+    private readonly defaultValue: T,
+    private readonly resolver: EvaluationResolver<T>,
+    private readonly options: SvelteFlagEvaluationOptions | undefined,
+    updateOptions: Required<NormalizedOptions>,
+  ) {
+    this.current = this.evaluate();
+
+    this.subscribe = createSubscriber((update) => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      // the subscribing effect is still running while handlers are attached, so it reads any refreshed value itself
+      let starting = true;
+      const refresh = () => {
+        if (this.refresh() && !starting) {
+          update();
+        }
+      };
+
+      this.listening = true;
+      // the client runs the Ready handler immediately if the provider is already ready,
+      // which catches anything that changed between construction and subscription
+      client.addHandler(ProviderEvents.Ready, refresh, { signal });
+
+      if (updateOptions.updateOnContextChanged) {
+        client.addHandler(ProviderEvents.ContextChanged, refresh, { signal });
+      }
+
+      if (updateOptions.updateOnConfigurationChanged) {
+        client.addHandler(
+          ProviderEvents.ConfigurationChanged,
+          (eventDetails) => {
+            // without a flagsChanged list we can't tell what changed, so re-evaluate
+            if (!eventDetails?.flagsChanged || eventDetails.flagsChanged.includes(this.flagKey)) {
+              refresh();
+            }
+          },
+          { signal },
+        );
+      }
+
+      starting = false;
+
+      return () => {
+        controller.abort();
+        this.listening = false;
+      };
+    });
+  }
+
+  get details(): EvaluationDetails<T> {
+    this.subscribe();
+    if (!this.listening) {
+      this.refresh();
+    }
+    return this.current;
+  }
+
+  get value(): T {
+    return this.details.value;
+  }
+
+  get variant() {
+    return this.details.variant;
+  }
+
+  get reason() {
+    return this.details.reason;
+  }
+
+  get errorCode() {
+    return this.details.errorCode;
+  }
+
+  get errorMessage() {
+    return this.details.errorMessage;
+  }
+
+  get flagMetadata() {
+    return this.details.flagMetadata;
+  }
+
+  private evaluate(): EvaluationDetails<T> {
+    return this.resolver(this.client).call(this.client, this.flagKey, this.defaultValue, this.options);
+  }
+
+  // re-evaluates the flag, returning true if the details changed
+  private refresh(): boolean {
+    const next = this.evaluate();
+    if (isEqual(next, this.current)) {
+      return false;
+    }
+    this.current = next;
+    return true;
+  }
+}

--- a/packages/svelte/src/internal/scope.ts
+++ b/packages/svelte/src/internal/scope.ts
@@ -1,0 +1,51 @@
+import { getContext, setContext } from 'svelte';
+import type { Client } from '@openfeature/web-sdk';
+import type { SvelteFlagEvaluationOptions } from '../options';
+
+const SCOPE_KEY = Symbol('@openfeature/svelte-sdk');
+
+/**
+ * The client and default options bound to a component subtree.
+ * @internal
+ */
+export type OpenFeatureScope = {
+  client: Client;
+  options: SvelteFlagEvaluationOptions;
+};
+
+/**
+ * Stores the scope in the Svelte context of the current component (must be called during component initialization).
+ * @internal
+ * @param {OpenFeatureScope} scope scope to bind to the current component subtree
+ */
+export function setScope(scope: OpenFeatureScope): void {
+  setContext(SCOPE_KEY, scope);
+}
+
+/**
+ * Reads the scope from the Svelte context.
+ * Svelte throws when no component context is available, and offers no way to check for it, hence the try/catch.
+ * @internal
+ * @returns {OpenFeatureScope | undefined} the scope for the current component subtree, if any
+ */
+export function getScope(): OpenFeatureScope | undefined {
+  try {
+    return getContext<OpenFeatureScope | undefined>(SCOPE_KEY);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Indicates whether Svelte context is currently accessible.
+ * @internal
+ * @returns {boolean} true if Svelte context can be accessed
+ */
+export function hasComponentContext(): boolean {
+  try {
+    getContext(SCOPE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/svelte/src/options.ts
+++ b/packages/svelte/src/options.ts
@@ -1,0 +1,23 @@
+import type { FlagEvaluationOptions } from '@openfeature/web-sdk';
+
+export type SvelteFlagEvaluationOptions = {
+  /**
+   * Re-evaluate the flag if the provider emits a ConfigurationChanged event.
+   * Set to false to prevent effects and templates from updating when flag value changes
+   * are received by the associated provider.
+   * Defaults to true.
+   */
+  updateOnConfigurationChanged?: boolean;
+  /**
+   * Re-evaluate the flag when the OpenFeature evaluation context changes.
+   * Set to false to prevent effects and templates from updating when attributes which
+   * may be factors in flag evaluation change.
+   * Defaults to true.
+   */
+  updateOnContextChanged?: boolean;
+} & FlagEvaluationOptions;
+
+export type NormalizedOptions = Pick<
+  SvelteFlagEvaluationOptions,
+  'updateOnConfigurationChanged' | 'updateOnContextChanged'
+>;

--- a/packages/svelte/src/provider/index.ts
+++ b/packages/svelte/src/provider/index.ts
@@ -1,0 +1,6 @@
+export * from './scope';
+export * from './test-scope';
+export * from './use-open-feature-client';
+export * from './use-open-feature-client-status';
+export * from './use-open-feature-provider';
+export * from './use-when-provider-ready';

--- a/packages/svelte/src/provider/scope.ts
+++ b/packages/svelte/src/provider/scope.ts
@@ -1,0 +1,38 @@
+import type { Client } from '@openfeature/web-sdk';
+import { OpenFeature, withFrameworkMetadata } from '@openfeature/web-sdk';
+import { setScope } from '../internal/scope';
+import type { SvelteFlagEvaluationOptions } from '../options';
+
+type ClientOrDomain =
+  | {
+      /**
+       * An identifier which logically binds clients with providers
+       * @see OpenFeature.setProvider() and overloads.
+       */
+      domain?: string;
+      client?: never;
+    }
+  | {
+      /**
+       * OpenFeature client to use.
+       */
+      client?: Client;
+      domain?: never;
+    };
+
+export type OpenFeatureScopeOptions = ClientOrDomain & SvelteFlagEvaluationOptions;
+
+/**
+ * Provides a scope for evaluating feature flags by binding a client to the current component and all of its descendants.
+ * Must be called during component initialization (for example in the script of a root layout).
+ * Descendants can use the evaluation functions without specifying a client or domain;
+ * without a scope, they use the default client.
+ * @param {OpenFeatureScopeOptions} options a domain or client to bind, and default evaluation options for the scope
+ */
+export function setOpenFeatureScope(options: OpenFeatureScopeOptions = {}): void {
+  const { client, domain, ...evaluationOptions } = options;
+  setScope({
+    client: withFrameworkMetadata(client ?? OpenFeature.getClient(domain), 'svelte'),
+    options: evaluationOptions,
+  });
+}

--- a/packages/svelte/src/provider/test-scope.ts
+++ b/packages/svelte/src/provider/test-scope.ts
@@ -1,0 +1,116 @@
+import type { InMemoryFlagConfiguration, JsonValue, Provider } from '@openfeature/web-sdk';
+import { NOOP_PROVIDER, OpenFeature, TypedInMemoryProvider } from '@openfeature/web-sdk';
+import { hasComponentContext } from '../internal/scope';
+import type { OpenFeatureScopeOptions } from './scope';
+import { setOpenFeatureScope } from './scope';
+
+type FlagValueMap = { [flagKey: string]: JsonValue };
+
+export type OpenFeatureTestScopeOptions = Omit<OpenFeatureScopeOptions, 'client'> &
+  (
+    | {
+        provider?: never;
+        /**
+         * Optional map of flagKeys to flagValues for this test scope.
+         * If not supplied, all flag evaluations will default.
+         */
+        flagValueMap?: FlagValueMap;
+        /**
+         * Optional delay for the underlying test provider's readiness and reconciliation.
+         * Defaults to 0.
+         */
+        delayMs?: number;
+      }
+    | {
+        /**
+         * An optional partial provider to pass for full control over the flag resolution for this test scope.
+         * Any un-implemented methods or properties will no-op.
+         */
+        provider?: Partial<Provider>;
+        flagValueMap?: never;
+        delayMs?: never;
+      }
+  );
+
+const TEST_VARIANT = 'test-variant';
+const TEST_PROVIDER = 'test-provider';
+
+// internal provider which is basically the in-memory provider with a simpler config and some optional fake delays
+class TestProvider extends TypedInMemoryProvider {
+  initialize: Provider['initialize'] = undefined;
+
+  private delayedInitialize = async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, this.delay));
+  };
+
+  constructor(
+    flagValueMap: FlagValueMap,
+    private delay = 0,
+  ) {
+    // convert the simple flagValueMap into an in-memory config
+    const flagConfig = Object.entries(flagValueMap).reduce(
+      (acc: InMemoryFlagConfiguration, flag): InMemoryFlagConfiguration => {
+        return {
+          ...acc,
+          [flag[0]]: {
+            variants: {
+              [TEST_VARIANT]: flag[1],
+            },
+            defaultVariant: TEST_VARIANT,
+            disabled: false,
+          },
+        };
+      },
+      {},
+    );
+    super(flagConfig);
+    // only delay initialization if a delay is specified
+    this.initialize = this.delay ? this.delayedInitialize.bind(this) : undefined;
+  }
+
+  async onContextChange() {
+    return new Promise<void>((resolve) => setTimeout(resolve, this.delay));
+  }
+}
+
+/**
+ * Configures a provider based on the {@link TypedInMemoryProvider}, specifically built for testing, and binds
+ * it to the current component subtree like `setOpenFeatureScope` does.
+ * Use this for testing components that use flag evaluation functions.
+ *
+ * Call it during component initialization (for example in a wrapper component around the component under test)
+ * to scope it to that subtree, or directly in a test (for example in `beforeEach`) to configure the provider
+ * for the default client used by components without a scope.
+ * @param {OpenFeatureTestScopeOptions} testScopeOptions options for the test scope
+ */
+export function setOpenFeatureTestScope(testScopeOptions: OpenFeatureTestScopeOptions = {}): void {
+  const { flagValueMap, provider, delayMs, ...scopeOptions } = testScopeOptions;
+  const effectiveProvider = (
+    flagValueMap ? new TestProvider(flagValueMap, delayMs) : mixInNoop(provider) || NOOP_PROVIDER
+  ) as Provider;
+  scopeOptions.domain
+    ? OpenFeature.setProvider(scopeOptions.domain, effectiveProvider)
+    : OpenFeature.setProvider(effectiveProvider);
+
+  if (hasComponentContext()) {
+    setOpenFeatureScope(scopeOptions);
+  }
+}
+
+// mix in the no-op provider when the partial is passed
+function mixInNoop(provider: Partial<Provider> = {}) {
+  // fill in any missing methods with no-ops
+  for (const prop of Object.getOwnPropertyNames(Object.getPrototypeOf(NOOP_PROVIDER)).filter(
+    (prop) => prop !== 'constructor',
+  )) {
+    const patchedProvider = provider as { [key: string]: keyof Provider };
+    if (!Object.getPrototypeOf(patchedProvider)[prop] && !patchedProvider[prop]) {
+      patchedProvider[prop] = Object.getPrototypeOf(NOOP_PROVIDER)[prop];
+    }
+  }
+  // fill in the metadata if missing
+  if (!provider.metadata || !provider.metadata.name) {
+    (provider.metadata as unknown) = { name: TEST_PROVIDER };
+  }
+  return provider;
+}

--- a/packages/svelte/src/provider/use-open-feature-client-status.ts
+++ b/packages/svelte/src/provider/use-open-feature-client-status.ts
@@ -1,0 +1,46 @@
+import { createSubscriber } from 'svelte/reactivity';
+import type { ProviderStatus } from '@openfeature/web-sdk';
+import { ProviderEvents } from '@openfeature/web-sdk';
+import type { ReactiveValue } from '../reactive';
+import { useOpenFeatureClient } from './use-open-feature-client';
+
+const STATUS_EVENTS = [
+  ProviderEvents.Ready,
+  ProviderEvents.Error,
+  ProviderEvents.Stale,
+  ProviderEvents.Reconciling,
+  ProviderEvents.ContextChanged,
+  ProviderEvents.ConfigurationChanged,
+] as const;
+
+/**
+ * Get the {@link ProviderStatus} for the OpenFeature client of the enclosing scope.
+ * `current` reacts to changes in provider status when read in a template, `$derived` or `$effect`.
+ * @returns {ReactiveValue<ProviderStatus>} reactive status of the client for this scope
+ */
+export function useOpenFeatureClientStatus(): ReactiveValue<ProviderStatus> {
+  const client = useOpenFeatureClient();
+
+  const subscribe = createSubscriber((update) => {
+    const controller = new AbortController();
+    // not every event changes the status, so only notify effects when it did
+    let last = client.providerStatus;
+    const onEvent = () => {
+      if (client.providerStatus !== last) {
+        last = client.providerStatus;
+        update();
+      }
+    };
+    for (const event of STATUS_EVENTS) {
+      client.addHandler(event, onEvent, { signal: controller.signal });
+    }
+    return () => controller.abort();
+  });
+
+  return {
+    get current() {
+      subscribe();
+      return client.providerStatus;
+    },
+  };
+}

--- a/packages/svelte/src/provider/use-open-feature-client.ts
+++ b/packages/svelte/src/provider/use-open-feature-client.ts
@@ -1,0 +1,12 @@
+import type { Client } from '@openfeature/web-sdk';
+import { resolveClient } from '../internal/client';
+
+/**
+ * Get the {@link Client} instance for the enclosing scope (see `setOpenFeatureScope`).
+ * Note that the provider to which this is bound is determined by the scope's domain.
+ * Falls back to the default client when called without a scope, or outside a component.
+ * @returns {Client} client for this scope
+ */
+export function useOpenFeatureClient(): Client {
+  return resolveClient();
+}

--- a/packages/svelte/src/provider/use-open-feature-provider.ts
+++ b/packages/svelte/src/provider/use-open-feature-provider.ts
@@ -1,0 +1,13 @@
+import type { Provider } from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { useOpenFeatureClient } from './use-open-feature-client';
+
+/**
+ * Get the {@link Provider} bound to the domain of the enclosing scope (see `setOpenFeatureScope`).
+ * Note that it isn't recommended to interact with the provider directly, but rather through
+ * an OpenFeature client.
+ * @returns {Provider} provider for this scope
+ */
+export function useOpenFeatureProvider(): Provider {
+  return OpenFeature.getProvider(useOpenFeatureClient().metadata.domain);
+}

--- a/packages/svelte/src/provider/use-when-provider-ready.ts
+++ b/packages/svelte/src/provider/use-when-provider-ready.ts
@@ -1,0 +1,21 @@
+import { ProviderStatus } from '@openfeature/web-sdk';
+import type { ReactiveValue } from '../reactive';
+import { useOpenFeatureClientStatus } from './use-open-feature-client-status';
+
+/**
+ * Utility indicating whether the provider is {@link ProviderStatus.READY}, without evaluating any flags.
+ * Useful for showing loaders until the provider is ready, for example with `{#if ready.current}`.
+ *
+ * NOTE: `current` is true only when the provider status is {@link ProviderStatus.READY}.
+ * For other statuses (ERROR, STALE, FATAL, RECONCILING), use {@link useOpenFeatureClientStatus}.
+ * @returns {ReactiveValue<boolean>} reactive boolean indicating if the provider is {@link ProviderStatus.READY}
+ */
+export function useWhenProviderReady(): ReactiveValue<boolean> {
+  const status = useOpenFeatureClientStatus();
+
+  return {
+    get current() {
+      return status.current === ProviderStatus.READY;
+    },
+  };
+}

--- a/packages/svelte/src/query/index.ts
+++ b/packages/svelte/src/query/index.ts
@@ -1,0 +1,1 @@
+export * from './query';

--- a/packages/svelte/src/query/query.ts
+++ b/packages/svelte/src/query/query.ts
@@ -1,0 +1,65 @@
+import type {
+  ErrorCode,
+  EvaluationDetails,
+  FlagMetadata,
+  FlagValue,
+  ResolutionReason,
+  StandardResolutionReasons,
+} from '@openfeature/web-sdk';
+
+export interface FlagQuery<T extends FlagValue = FlagValue> {
+  /**
+   * A structure representing the result of the flag evaluation process
+   */
+  readonly details: EvaluationDetails<T>;
+
+  /**
+   * The flag value
+   */
+  readonly value: T;
+
+  /**
+   * A variant is a semantic identifier for a value.
+   * Not available from all providers.
+   */
+  readonly variant: string | undefined;
+
+  /**
+   * Arbitrary data associated with this flag or evaluation.
+   * Not available from all providers.
+   */
+  readonly flagMetadata: FlagMetadata;
+
+  /**
+   * The reason the evaluation resolved to the particular value.
+   * Not available from all providers.
+   */
+  readonly reason: ResolutionReason | undefined;
+
+  /**
+   * Indicates if this flag defaulted due to an error.
+   * Specifically, indicates reason equals {@link StandardResolutionReasons.ERROR} or the errorCode is set, this field is truthy.
+   */
+  readonly isError: boolean;
+
+  /**
+   * The error code, see {@link ErrorCode}.
+   */
+  readonly errorCode: ErrorCode | undefined;
+
+  /**
+   * A message associated with the error.
+   */
+  readonly errorMessage: string | undefined;
+
+  /**
+   * Indicates this flag is up-to-date and in sync with the source of truth.
+   * Specifically, indicates the evaluation did not default due to error, and the reason is neither {@link StandardResolutionReasons.STALE} or {@link StandardResolutionReasons.DISABLED}.
+   */
+  readonly isAuthoritative: boolean;
+
+  /**
+   * The type of the value, as returned by "typeof" operator.
+   */
+  readonly type: 'string' | 'number' | 'bigint' | 'boolean' | 'symbol' | 'undefined' | 'object' | 'function';
+}

--- a/packages/svelte/src/reactive.ts
+++ b/packages/svelte/src/reactive.ts
@@ -1,0 +1,9 @@
+/**
+ * A reactive box around a value.
+ * Reading `current` inside a template, `$derived` or `$effect` registers a dependency,
+ * so the consumer updates when the value changes.
+ * Outside of effects, `current` simply returns the latest value.
+ */
+export interface ReactiveValue<T> {
+  readonly current: T;
+}

--- a/packages/svelte/src/tracking/index.ts
+++ b/packages/svelte/src/tracking/index.ts
@@ -1,0 +1,1 @@
+export * from './use-track';

--- a/packages/svelte/src/tracking/use-track.ts
+++ b/packages/svelte/src/tracking/use-track.ts
@@ -1,0 +1,28 @@
+import type { Tracking, TrackingEventDetails } from '@openfeature/web-sdk';
+import { useOpenFeatureClient } from '../provider/use-open-feature-client';
+
+export type Track = {
+  /**
+   * Context-aware tracking function for the enclosing scope (see `setOpenFeatureScope`).
+   * Track a user action or application state, usually representing a business objective or outcome.
+   * @param trackingEventName an identifier for the event
+   * @param trackingEventDetails the details of the tracking event
+   */
+  track: Tracking['track'];
+};
+
+/**
+ * Get a context-aware tracking function.
+ * @returns {Track} context-aware tracking
+ */
+export function useTrack(): Track {
+  const client = useOpenFeatureClient();
+
+  const track = (trackingEventName: string, trackingEventDetails?: TrackingEventDetails) => {
+    client.track(trackingEventName, trackingEventDetails);
+  };
+
+  return {
+    track,
+  };
+}

--- a/packages/svelte/test/clone-context.test.ts
+++ b/packages/svelte/test/clone-context.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { cloneContext } from '../src/internal/clone-context';
+
+describe('cloneContext', () => {
+  it('should copy a JSON-parsed "__proto__" attribute as an own property', () => {
+    const original = JSON.parse('{"__proto__": {"admin": true}, "user": "a"}');
+    const copy = cloneContext(original);
+
+    expect(Object.getOwnPropertyDescriptor(copy, '__proto__')?.value).toEqual({ admin: true });
+    expect(Object.getPrototypeOf(copy)).toBe(Object.prototype);
+    expect(copy).toEqual(original);
+  });
+
+  it('should produce an equal but independent copy', () => {
+    const original = { user: { id: 'a', roles: ['viewer'] }, since: new Date(0), count: 1, flag: true, none: null };
+    const copy = cloneContext(original);
+
+    expect(copy).toEqual(original);
+    expect(copy).not.toBe(original);
+    expect(copy.user).not.toBe(original.user);
+    expect((copy.user as { roles: string[] }).roles).not.toBe(original.user.roles);
+    expect(copy.since).not.toBe(original.since);
+
+    (copy.user as { roles: string[] }).roles.push('editor');
+    (copy.since as Date).setFullYear(2000);
+    expect(original.user.roles).toEqual(['viewer']);
+    expect(original.since.getTime()).toBe(0);
+  });
+});

--- a/packages/svelte/test/context.test.ts
+++ b/packages/svelte/test/context.test.ts
@@ -1,0 +1,119 @@
+import { InMemoryProvider, OpenFeature } from '@openfeature/web-sdk';
+import { render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ContextMutation } from '../src';
+import { useContextMutator } from '../src';
+import ContextMutatorProbe from './fixtures/ContextMutatorProbe.svelte';
+
+const DOMAIN = 'context-mutator';
+
+describe('useContextMutator', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+    await OpenFeature.clearContexts();
+    vi.restoreAllMocks();
+  });
+
+  describe('outside a scope', () => {
+    it('should update the default context', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { setContext } = useContextMutator();
+      await setContext({ user: 'a' });
+
+      expect(OpenFeature.getContext()).toEqual({ user: 'a' });
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not warn when defaultContext is explicitly true', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { setContext } = useContextMutator({ defaultContext: true });
+      await setContext({ user: 'a' });
+
+      expect(OpenFeature.getContext()).toEqual({ user: 'a' });
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('should accept a method taking the previous context', async () => {
+      await OpenFeature.setContext({ user: 'a', count: 1 });
+      const { setContext } = useContextMutator({ defaultContext: true });
+      await setContext((previous) => ({ ...previous, count: 2 }));
+
+      expect(OpenFeature.getContext()).toEqual({ user: 'a', count: 2 });
+    });
+
+    it('should detect in-place mutations of the previous context', async () => {
+      await OpenFeature.setContext({ user: 'a' });
+      const { setContext } = useContextMutator({ defaultContext: true });
+      await setContext((previous) => {
+        previous.user = 'b';
+        return previous;
+      });
+
+      expect(OpenFeature.getContext()).toEqual({ user: 'b' });
+    });
+
+    it('should detect in-place mutations of nested values in the previous context', async () => {
+      await OpenFeature.setContext({ user: { id: 'a', roles: ['viewer'] }, since: new Date(0) });
+      const { setContext } = useContextMutator({ defaultContext: true });
+      await setContext((previous) => {
+        (previous.user as { roles: string[] }).roles.push('editor');
+        return previous;
+      });
+
+      expect(OpenFeature.getContext()).toEqual({ user: { id: 'a', roles: ['viewer', 'editor'] }, since: new Date(0) });
+    });
+
+    it('should noop if the previous context is passed in unchanged', async () => {
+      await OpenFeature.setContext({ user: 'a' });
+      const spy = vi.spyOn(OpenFeature, 'setContext');
+      const { setContext } = useContextMutator({ defaultContext: true });
+      await setContext((previous) => previous);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('inside a scope', () => {
+    it('should update the context of the scope domain', async () => {
+      await OpenFeature.setProviderAndWait(DOMAIN, new InMemoryProvider({}));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      let mutation: ContextMutation | undefined;
+      render(ContextMutatorProbe, { scope: { domain: DOMAIN }, onReady: (m: ContextMutation) => (mutation = m) });
+
+      await mutation?.setContext({ user: 'scoped' });
+
+      expect(OpenFeature.getContext(DOMAIN)).toEqual({ user: 'scoped' });
+      expect(OpenFeature.getContext()).toEqual({});
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('should update the context of the scope client', async () => {
+      await OpenFeature.setProviderAndWait(DOMAIN, new InMemoryProvider({}));
+      let mutation: ContextMutation | undefined;
+      render(ContextMutatorProbe, {
+        scope: { client: OpenFeature.getClient(DOMAIN) },
+        onReady: (m: ContextMutation) => (mutation = m),
+      });
+
+      await mutation?.setContext({ user: 'scoped' });
+
+      expect(OpenFeature.getContext(DOMAIN)).toEqual({ user: 'scoped' });
+      expect(OpenFeature.getContext()).toEqual({});
+    });
+
+    it('should update the default context when defaultContext is true', async () => {
+      await OpenFeature.setProviderAndWait(DOMAIN, new InMemoryProvider({}));
+      let mutation: ContextMutation | undefined;
+      render(ContextMutatorProbe, {
+        scope: { domain: DOMAIN },
+        options: { defaultContext: true },
+        onReady: (m: ContextMutation) => (mutation = m),
+      });
+
+      await mutation?.setContext({ user: 'global' });
+
+      expect(OpenFeature.getContext()).toEqual({ user: 'global' });
+      expect(OpenFeature.getContext(DOMAIN)).toEqual({ user: 'global' });
+    });
+  });
+});

--- a/packages/svelte/test/evaluation-component.test.ts
+++ b/packages/svelte/test/evaluation-component.test.ts
@@ -1,0 +1,68 @@
+import type { EvaluationContext } from '@openfeature/web-sdk';
+import { OpenFeature, StandardResolutionReasons, TypedInMemoryProvider } from '@openfeature/web-sdk';
+import { render, screen } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import FlagValue from './fixtures/FlagValue.svelte';
+import OptionsWrapper from './fixtures/OptionsWrapper.svelte';
+
+const FLAG_KEY = 'context-sensitive-flag';
+const FLAG_CONFIG = {
+  [FLAG_KEY]: {
+    disabled: false,
+    defaultVariant: 'off',
+    variants: { off: false, on: true },
+    contextEvaluator(ctx: EvaluationContext) {
+      return ctx.change ? 'on' : 'off';
+    },
+  },
+} as const;
+
+describe('evaluation in components', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+    await OpenFeature.clearContexts();
+  });
+
+  it('renders the flag value and updates it when the context changes', async () => {
+    await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+    render(FlagValue, { flagKey: FLAG_KEY, defaultValue: false });
+
+    expect(screen.getByTestId('value')).toHaveTextContent('false');
+    expect(screen.getByTestId('variant')).toHaveTextContent('off');
+    expect(screen.getByTestId('reason')).toHaveTextContent(StandardResolutionReasons.TARGETING_MATCH);
+    expect(screen.getByTestId('type')).toHaveTextContent('boolean');
+
+    await OpenFeature.setContext({ change: true });
+    flushSync();
+    expect(screen.getByTestId('value')).toHaveTextContent('true');
+    expect(screen.getByTestId('variant')).toHaveTextContent('on');
+  });
+
+  it('applies scope options to descendants', async () => {
+    await OpenFeature.setProviderAndWait('scoped', new TypedInMemoryProvider(FLAG_CONFIG));
+    render(OptionsWrapper, {
+      scope: { domain: 'scoped', updateOnContextChanged: false },
+      flagKey: FLAG_KEY,
+      defaultValue: false,
+    });
+
+    await OpenFeature.setContext('scoped', { change: true });
+    flushSync();
+    expect(screen.getByTestId('value')).toHaveTextContent('false');
+  });
+
+  it('lets evaluation options override scope options', async () => {
+    await OpenFeature.setProviderAndWait('scoped', new TypedInMemoryProvider(FLAG_CONFIG));
+    render(OptionsWrapper, {
+      scope: { domain: 'scoped', updateOnContextChanged: false },
+      flagKey: FLAG_KEY,
+      defaultValue: false,
+      options: { updateOnContextChanged: true },
+    });
+
+    await OpenFeature.setContext('scoped', { change: true });
+    flushSync();
+    expect(screen.getByTestId('value')).toHaveTextContent('true');
+  });
+});

--- a/packages/svelte/test/evaluation.test.ts
+++ b/packages/svelte/test/evaluation.test.ts
@@ -1,0 +1,334 @@
+import type {
+  EvaluationContext,
+  EventContext,
+  InMemoryFlagConfiguration,
+  InMemoryFlagVariants,
+  ProviderEmittableEvents,
+} from '@openfeature/web-sdk';
+import {
+  ErrorCode,
+  OpenFeature,
+  ProviderEvents,
+  StandardResolutionReasons,
+  TypedInMemoryProvider,
+} from '@openfeature/web-sdk';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  useBooleanFlagDetails,
+  useBooleanFlagValue,
+  useFlag,
+  useNumberFlagDetails,
+  useNumberFlagValue,
+  useObjectFlagDetails,
+  useObjectFlagValue,
+  useStringFlagDetails,
+  useStringFlagValue,
+} from '../src';
+import { TestingProvider } from './helpers/testing-provider';
+import { flush, watch } from './helpers/watch.svelte';
+
+// custom provider to have better control over the emitted events
+class CustomEventInMemoryProvider extends TypedInMemoryProvider {
+  putConfigurationWithCustomEvent<
+    T extends Record<string, InMemoryFlagVariants<string>> = Record<string, InMemoryFlagVariants<string>>,
+  >(flagConfiguration: InMemoryFlagConfiguration<T>, event: ProviderEmittableEvents, eventContext: EventContext) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this as any)['_flagConfiguration'] = { ...flagConfiguration }; // private access hack
+    this.events.emit(event, eventContext);
+  }
+}
+
+const BOOL_FLAG_KEY = 'boolean-flag';
+const CONTEXT_BOOL_FLAG_KEY = 'context-sensitive-flag';
+const STRING_FLAG_KEY = 'string-flag';
+const NUMBER_FLAG_KEY = 'number-flag';
+const OBJECT_FLAG_KEY = 'object-flag';
+const OBJECT_FLAG_VALUE = { factor: 'x1000' };
+
+const FLAG_CONFIG = {
+  [BOOL_FLAG_KEY]: {
+    disabled: false,
+    variants: { on: true, off: false },
+    defaultVariant: 'on',
+  },
+  [STRING_FLAG_KEY]: {
+    disabled: false,
+    variants: { greeting: 'hi', parting: 'bye' },
+    defaultVariant: 'greeting',
+  },
+  [NUMBER_FLAG_KEY]: {
+    disabled: false,
+    variants: { '2^10': 1024, '2^1': 2 },
+    defaultVariant: '2^10',
+  },
+  [OBJECT_FLAG_KEY]: {
+    disabled: false,
+    variants: { template: OBJECT_FLAG_VALUE, empty: {} },
+    defaultVariant: 'template',
+  },
+  [CONTEXT_BOOL_FLAG_KEY]: {
+    disabled: false,
+    defaultVariant: 'off',
+    variants: { off: false, on: true },
+    contextEvaluator(ctx: EvaluationContext) {
+      return ctx.change ? 'on' : 'off';
+    },
+  },
+} as const;
+
+describe('evaluation', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+    await OpenFeature.clearContexts();
+  });
+
+  describe('evaluation functions', () => {
+    it('useFlag should evaluate flags of every type', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+
+      const bool = useFlag(BOOL_FLAG_KEY, false);
+      expect(bool.value).toBe(true);
+      expect(bool.variant).toBe('on');
+      expect(bool.reason).toBe(StandardResolutionReasons.STATIC);
+      expect(bool.type).toBe('boolean');
+      expect(bool.isError).toBe(false);
+      expect(bool.isAuthoritative).toBe(true);
+      expect(bool.details.flagKey).toBe(BOOL_FLAG_KEY);
+
+      expect(useFlag(STRING_FLAG_KEY, 'default').value).toBe('hi');
+      expect(useFlag(NUMBER_FLAG_KEY, 0).value).toBe(1024);
+      expect(useFlag(OBJECT_FLAG_KEY, {}).value).toEqual(OBJECT_FLAG_VALUE);
+    });
+
+    it('useFlag should report errors for missing flags', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+
+      const missing = useFlag('missing-flag', 'default');
+      expect(missing.value).toBe('default');
+      expect(missing.isError).toBe(true);
+      expect(missing.errorCode).toBe(ErrorCode.FLAG_NOT_FOUND);
+      expect(missing.errorMessage).toBeDefined();
+      expect(missing.isAuthoritative).toBe(false);
+      expect(missing.flagMetadata).toEqual({});
+    });
+
+    it('typed value functions should evaluate flags', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+
+      expect(useBooleanFlagValue(BOOL_FLAG_KEY, false).current).toBe(true);
+      expect(useStringFlagValue(STRING_FLAG_KEY, 'default').current).toBe('hi');
+      expect(useNumberFlagValue(NUMBER_FLAG_KEY, 0).current).toBe(1024);
+      expect(useObjectFlagValue(OBJECT_FLAG_KEY, {}).current).toEqual(OBJECT_FLAG_VALUE);
+    });
+
+    it('typed details functions should evaluate flags', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+
+      const bool = useBooleanFlagDetails(BOOL_FLAG_KEY, false);
+      expect(bool.flagKey).toBe(BOOL_FLAG_KEY);
+      expect(bool.value).toBe(true);
+      expect(bool.variant).toBe('on');
+      expect(bool.reason).toBe(StandardResolutionReasons.STATIC);
+      expect(bool.flagMetadata).toEqual({});
+      expect(bool.errorCode).toBeUndefined();
+      expect(bool.errorMessage).toBeUndefined();
+
+      expect(useStringFlagDetails(STRING_FLAG_KEY, 'default').value).toBe('hi');
+      expect(useNumberFlagDetails(NUMBER_FLAG_KEY, 0).value).toBe(1024);
+      expect(useObjectFlagDetails(OBJECT_FLAG_KEY, {}).value).toEqual(OBJECT_FLAG_VALUE);
+    });
+
+    it('should pass key, default, and options to the client resolver', async () => {
+      const provider = new TypedInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const hook = { before: vi.fn() };
+
+      useFlag(BOOL_FLAG_KEY, false, { hooks: [hook], hookHints: { hint: 'value' } });
+
+      expect(hook.before).toHaveBeenCalledWith(
+        expect.objectContaining({ flagKey: BOOL_FLAG_KEY, defaultValue: false }),
+        { hint: 'value' },
+      );
+    });
+  });
+
+  describe('updates', () => {
+    it('should update when the provider becomes ready', async () => {
+      const ready = OpenFeature.setProviderAndWait(new TestingProvider(FLAG_CONFIG, 10));
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      const watched = watch(() => [flag.value, flag.reason]);
+
+      expect(watched.values).toEqual([[false, StandardResolutionReasons.ERROR]]);
+      await ready;
+      flush();
+      expect(watched.values).toEqual([
+        [false, StandardResolutionReasons.ERROR],
+        [true, StandardResolutionReasons.STATIC],
+      ]);
+      watched.stop();
+    });
+
+    it('should reflect changes that happened between construction and subscription, without extra runs', async () => {
+      const ready = OpenFeature.setProviderAndWait(new TestingProvider(FLAG_CONFIG, 10));
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      // the provider becomes ready while nothing is listening
+      await ready;
+
+      const watched = watch(() => flag.value);
+      expect(watched.values).toEqual([true]);
+      watched.stop();
+    });
+
+    it('should update on context change when the evaluated value changed', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+      const flag = useFlag(CONTEXT_BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+
+      await OpenFeature.setContext({ change: true });
+      flush();
+      expect(watched.values).toEqual([false, true]);
+      watched.stop();
+    });
+
+    it('should not update on context change when the evaluated value did not change', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+      const flag = useFlag(CONTEXT_BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+
+      await OpenFeature.setContext({ unrelated: true });
+      flush();
+      expect(watched.values).toEqual([false]);
+      watched.stop();
+    });
+
+    it('should not update on context change when updateOnContextChanged is false', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+      const flag = useFlag(CONTEXT_BOOL_FLAG_KEY, false, { updateOnContextChanged: false });
+      const watched = watch(() => flag.value);
+
+      await OpenFeature.setContext({ change: true });
+      flush();
+      expect(watched.values).toEqual([false]);
+      watched.stop();
+    });
+
+    it('should not update on flag change when the provider change event has empty flagsChanged', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+
+      provider.putConfigurationWithCustomEvent(
+        { ...FLAG_CONFIG, [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'off' } },
+        ProviderEvents.ConfigurationChanged,
+        { flagsChanged: [] },
+      );
+      flush();
+      expect(watched.values).toEqual([true]);
+      watched.stop();
+    });
+
+    it('should update on flag change when the provider change event has falsy flagsChanged', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+
+      provider.putConfigurationWithCustomEvent(
+        { ...FLAG_CONFIG, [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'off' } },
+        ProviderEvents.ConfigurationChanged,
+        { flagsChanged: undefined },
+      );
+      flush();
+      expect(watched.values).toEqual([true, false]);
+      watched.stop();
+    });
+
+    it('should not update on flag change when the evaluated value did not change', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const resolverSpy = vi.spyOn(provider, 'resolveBooleanEvaluation');
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+      resolverSpy.mockClear();
+
+      provider.putConfiguration({
+        ...FLAG_CONFIG,
+        'new-flag': { disabled: false, defaultVariant: 'off', variants: { off: false, on: true } },
+      });
+      flush();
+      // the in-memory provider reports every key in flagsChanged, so the flag is re-evaluated...
+      expect(resolverSpy).toHaveBeenCalledTimes(1);
+      // ...but effects do not re-run because the evaluation details did not change
+      expect(watched.values).toEqual([true]);
+      watched.stop();
+    });
+
+    it('should update on flag change when the evaluated value changed', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+
+      provider.putConfiguration({
+        ...FLAG_CONFIG,
+        [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'off' },
+      });
+      flush();
+      provider.putConfiguration({
+        ...FLAG_CONFIG,
+        [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'on' },
+      });
+      flush();
+      expect(watched.values).toEqual([true, false, true]);
+      watched.stop();
+    });
+
+    it('should not update on flag change when updateOnConfigurationChanged is false', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const flag = useFlag(BOOL_FLAG_KEY, false, { updateOnConfigurationChanged: false });
+      const watched = watch(() => flag.value);
+
+      provider.putConfiguration({
+        ...FLAG_CONFIG,
+        [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'off' },
+      });
+      flush();
+      expect(watched.values).toEqual([true]);
+      watched.stop();
+    });
+
+    it('should re-evaluate on read when nothing is listening', async () => {
+      const provider = new CustomEventInMemoryProvider(FLAG_CONFIG);
+      await OpenFeature.setProviderAndWait(provider);
+      const flag = useFlag(BOOL_FLAG_KEY, false);
+      expect(flag.value).toBe(true);
+
+      // change the configuration without emitting any event
+      provider.putConfigurationWithCustomEvent(
+        { ...FLAG_CONFIG, [BOOL_FLAG_KEY]: { ...FLAG_CONFIG[BOOL_FLAG_KEY], defaultVariant: 'off' } },
+        ProviderEvents.Stale,
+        {},
+      );
+      expect(flag.value).toBe(false);
+    });
+
+    it('should stop listening once the last effect is destroyed', async () => {
+      await OpenFeature.setProviderAndWait(new TypedInMemoryProvider(FLAG_CONFIG));
+      const client = OpenFeature.getClient();
+      const initialHandlers = client.getHandlers(ProviderEvents.ContextChanged).length;
+      const flag = useFlag(CONTEXT_BOOL_FLAG_KEY, false);
+      const watched = watch(() => flag.value);
+      expect(client.getHandlers(ProviderEvents.ContextChanged).length).toBe(initialHandlers + 1);
+
+      watched.stop();
+      await OpenFeature.setContext({ change: true });
+      flush();
+      expect(watched.values).toEqual([false]);
+      expect(client.getHandlers(ProviderEvents.ContextChanged).length).toBe(initialHandlers);
+      // still readable, and fresh, outside effects
+      expect(flag.value).toBe(true);
+    });
+  });
+});

--- a/packages/svelte/test/fixtures/ContextMutatorProbe.svelte
+++ b/packages/svelte/test/fixtures/ContextMutatorProbe.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import {
+    setOpenFeatureScope,
+    useContextMutator,
+    type ContextMutation,
+    type ContextMutationOptions,
+    type OpenFeatureScopeOptions,
+  } from '../../src';
+
+  let {
+    scope,
+    options,
+    onReady,
+  }: {
+    scope?: OpenFeatureScopeOptions;
+    options?: ContextMutationOptions;
+    onReady: (mutation: ContextMutation) => void;
+  } = $props();
+
+  // svelte-ignore state_referenced_locally
+  if (scope) {
+    setOpenFeatureScope(scope);
+  }
+  // svelte-ignore state_referenced_locally
+  onReady(useContextMutator(options));
+</script>

--- a/packages/svelte/test/fixtures/FlagValue.svelte
+++ b/packages/svelte/test/fixtures/FlagValue.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { useFlag, type SvelteFlagEvaluationOptions } from '../../src';
+
+  let {
+    flagKey,
+    defaultValue,
+    options,
+  }: { flagKey: string; defaultValue: boolean | string | number; options?: SvelteFlagEvaluationOptions } = $props();
+
+  // svelte-ignore state_referenced_locally
+  const flag = useFlag(flagKey, defaultValue, options);
+</script>
+
+<span data-testid="value">{String(flag.value)}</span>
+<span data-testid="variant">{flag.variant ?? 'none'}</span>
+<span data-testid="reason">{flag.reason ?? 'none'}</span>
+<span data-testid="type">{flag.type}</span>

--- a/packages/svelte/test/fixtures/OptionsWrapper.svelte
+++ b/packages/svelte/test/fixtures/OptionsWrapper.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { setOpenFeatureScope, type OpenFeatureScopeOptions, type SvelteFlagEvaluationOptions } from '../../src';
+  import FlagValue from './FlagValue.svelte';
+
+  let {
+    scope,
+    flagKey,
+    defaultValue,
+    options,
+  }: {
+    scope: OpenFeatureScopeOptions;
+    flagKey: string;
+    defaultValue: boolean | string | number;
+    options?: SvelteFlagEvaluationOptions;
+  } = $props();
+
+  // svelte-ignore state_referenced_locally
+  setOpenFeatureScope(scope);
+</script>
+
+<FlagValue {flagKey} {defaultValue} {options} />

--- a/packages/svelte/test/fixtures/ScopeProbe.svelte
+++ b/packages/svelte/test/fixtures/ScopeProbe.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { useOpenFeatureClient, useOpenFeatureProvider } from '../../src';
+
+  // svelte-ignore state_referenced_locally
+  const client = useOpenFeatureClient();
+  const provider = useOpenFeatureProvider();
+</script>
+
+<span data-testid="domain">{client.metadata.domain ?? 'default'}</span>
+<span data-testid="framework">{client.metadata.framework ?? 'none'}</span>
+<span data-testid="provider">{provider.metadata.name}</span>

--- a/packages/svelte/test/fixtures/ScopeWrapper.svelte
+++ b/packages/svelte/test/fixtures/ScopeWrapper.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { setOpenFeatureScope, type OpenFeatureScopeOptions } from '../../src';
+  import ScopeProbe from './ScopeProbe.svelte';
+
+  let { scope }: { scope?: OpenFeatureScopeOptions } = $props();
+
+  // svelte-ignore state_referenced_locally
+  setOpenFeatureScope(scope);
+</script>
+
+<ScopeProbe />

--- a/packages/svelte/test/fixtures/TestScopeWrapper.svelte
+++ b/packages/svelte/test/fixtures/TestScopeWrapper.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { setOpenFeatureTestScope, type OpenFeatureTestScopeOptions } from '../../src';
+  import FlagValue from './FlagValue.svelte';
+
+  let {
+    testScope,
+    flagKey,
+    defaultValue,
+  }: { testScope?: OpenFeatureTestScopeOptions; flagKey: string; defaultValue: boolean | string | number } = $props();
+
+  // svelte-ignore state_referenced_locally
+  setOpenFeatureTestScope(testScope);
+</script>
+
+<FlagValue {flagKey} {defaultValue} />

--- a/packages/svelte/test/fixtures/TrackProbe.svelte
+++ b/packages/svelte/test/fixtures/TrackProbe.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { setOpenFeatureScope, useTrack, type OpenFeatureScopeOptions, type Track } from '../../src';
+
+  let { scope, onReady }: { scope?: OpenFeatureScopeOptions; onReady: (track: Track) => void } = $props();
+
+  // svelte-ignore state_referenced_locally
+  if (scope) {
+    setOpenFeatureScope(scope);
+  }
+  // svelte-ignore state_referenced_locally
+  onReady(useTrack());
+</script>

--- a/packages/svelte/test/helpers/testing-provider.ts
+++ b/packages/svelte/test/helpers/testing-provider.ts
@@ -1,0 +1,23 @@
+import { type InMemoryFlagConfiguration, type InMemoryFlagVariants, TypedInMemoryProvider } from '@openfeature/web-sdk';
+
+/**
+ * In-memory provider with configurable delays for initialization and context changes.
+ */
+export class TestingProvider<
+  T extends Record<string, InMemoryFlagVariants<string>> = Record<string, InMemoryFlagVariants<string>>,
+> extends TypedInMemoryProvider<T> {
+  constructor(
+    flagConfiguration: InMemoryFlagConfiguration<T>,
+    private delay: number,
+  ) {
+    super(flagConfiguration);
+  }
+
+  async initialize(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, this.delay));
+  }
+
+  async onContextChange(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, this.delay));
+  }
+}

--- a/packages/svelte/test/helpers/watch.svelte.ts
+++ b/packages/svelte/test/helpers/watch.svelte.ts
@@ -1,0 +1,26 @@
+import { flushSync } from 'svelte';
+
+/**
+ * Runs `read` inside a root effect and records every value it produces.
+ * The effect re-runs whenever a reactive dependency read by `read` changes,
+ * which is exactly what a template or `$derived` would do.
+ * @param {Function} read function reading reactive values
+ * @returns {object} recorded values and a function to destroy the effect
+ */
+export function watch<T>(read: () => T): { readonly values: T[]; stop: () => void } {
+  const values: T[] = [];
+  const stop = $effect.root(() => {
+    $effect(() => {
+      values.push(read());
+    });
+  });
+  flushSync();
+  return { values, stop };
+}
+
+/**
+ * Flushes pending effects synchronously.
+ */
+export function flush(): void {
+  flushSync();
+}

--- a/packages/svelte/test/is-equal.test.ts
+++ b/packages/svelte/test/is-equal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { isEqual } from '../src/internal/is-equal';
+
+describe('isEqual', () => {
+  it('should return true for equal primitive values', () => {
+    expect(isEqual(5, 5)).toBe(true);
+    expect(isEqual('hello', 'hello')).toBe(true);
+    expect(isEqual(true, true)).toBe(true);
+  });
+
+  it('should return false for different primitive values', () => {
+    expect(isEqual(5, 10)).toBe(false);
+    expect(isEqual('hello', 'world')).toBe(false);
+    expect(isEqual(true, false)).toBe(false);
+  });
+
+  it('should return true for equal serializable objects', () => {
+    const obj1 = { name: 'John', age: 30 };
+    const obj2 = { name: 'John', age: 30 };
+    expect(isEqual(obj1, obj2)).toBe(true);
+  });
+
+  it('should return false for different serializable objects', () => {
+    const obj1 = { name: 'John', age: 30 };
+    const obj2 = { name: 'Jane', age: 25 };
+    expect(isEqual(obj1, obj2)).toBe(false);
+  });
+
+  it('should return true for equal deep objects', () => {
+    const obj1 = { name: 'John', age: 30, address: { city: 'New York', country: 'USA' } };
+    const obj2 = { name: 'John', age: 30, address: { city: 'New York', country: 'USA' } };
+    expect(isEqual(obj1, obj2)).toBe(true);
+  });
+
+  it('should return true for equal deep objects with properties in a different order', () => {
+    const obj1 = { name: 'John', age: 30, address: { city: 'New York', country: 'USA' } };
+    const obj2 = { address: { country: 'USA', city: 'New York' }, age: 30, name: 'John' };
+    expect(isEqual(obj1, obj2)).toBe(true);
+  });
+  it('should compare dates by value', () => {
+    expect(isEqual(new Date(0), new Date(0))).toBe(true);
+    expect(isEqual(new Date(0), new Date(1))).toBe(false);
+    expect(isEqual(new Date(0), {})).toBe(false);
+  });
+
+  it('should return true for equal arrays', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2, 3];
+    expect(isEqual(arr1, arr2)).toBe(true);
+  });
+
+  it('should distinguish arrays from objects and sparse arrays from empty ones', () => {
+    expect(isEqual([], {})).toBe(false);
+    expect(isEqual({}, [])).toBe(false);
+    expect(isEqual([], new Array(1))).toBe(false);
+  });
+
+  it('should return false for different arrays', () => {
+    const arr1 = [1, 2, 3];
+    const arr2 = [3, 2, 1];
+    expect(isEqual(arr1, arr2)).toBe(false);
+  });
+});

--- a/packages/svelte/test/options.test.ts
+++ b/packages/svelte/test/options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeOptions } from '../src/internal/options';
+
+describe('normalizeOptions', () => {
+  // we spread results from this function, so we never want to return null
+  describe('undefined options', () => {
+    it('should return empty object', () => {
+      const normalized = normalizeOptions();
+      expect(normalized).toEqual({});
+    });
+  });
+
+  // we spread results from this function, so we want to remove anything but explicit booleans
+  describe('undefined removal', () => {
+    it('should remove undefined props and maintain boolean props', () => {
+      const normalized = normalizeOptions({
+        updateOnConfigurationChanged: undefined,
+        updateOnContextChanged: true,
+      });
+      expect(normalized).not.toHaveProperty('updateOnConfigurationChanged');
+      expect(normalized).toHaveProperty('updateOnContextChanged');
+      expect(normalized.updateOnContextChanged).toEqual(true);
+    });
+
+    it('should drop evaluation options that are not update flags', () => {
+      const normalized = normalizeOptions({
+        updateOnConfigurationChanged: false,
+        hookHints: { some: 'hint' },
+      });
+      expect(normalized).toEqual({ updateOnConfigurationChanged: false });
+    });
+  });
+});

--- a/packages/svelte/test/scope.test.ts
+++ b/packages/svelte/test/scope.test.ts
@@ -1,0 +1,68 @@
+import { InMemoryProvider, OpenFeature } from '@openfeature/web-sdk';
+import { render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setOpenFeatureScope, useOpenFeatureClient, useOpenFeatureProvider } from '../src';
+import ScopeProbe from './fixtures/ScopeProbe.svelte';
+import ScopeWrapper from './fixtures/ScopeWrapper.svelte';
+
+function namedProvider(name: string) {
+  return Object.assign(new InMemoryProvider({}), { metadata: { name } });
+}
+
+describe('scope', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  describe('setOpenFeatureScope', () => {
+    it('binds a domain-scoped, svelte-aware client to child components', async () => {
+      await OpenFeature.setProviderAndWait('scoped', namedProvider('scoped-provider'));
+      render(ScopeWrapper, { scope: { domain: 'scoped' } });
+
+      expect(screen.getByTestId('domain')).toHaveTextContent('scoped');
+      expect(screen.getByTestId('framework')).toHaveTextContent('svelte');
+      expect(screen.getByTestId('provider')).toHaveTextContent('scoped-provider');
+    });
+
+    it('binds an explicit client to child components', async () => {
+      await OpenFeature.setProviderAndWait('explicit', namedProvider('explicit-provider'));
+      render(ScopeWrapper, { scope: { client: OpenFeature.getClient('explicit') } });
+
+      expect(screen.getByTestId('domain')).toHaveTextContent('explicit');
+      expect(screen.getByTestId('framework')).toHaveTextContent('svelte');
+      expect(screen.getByTestId('provider')).toHaveTextContent('explicit-provider');
+    });
+
+    it('throws when called outside of component initialization', () => {
+      expect(() => setOpenFeatureScope()).toThrow(/lifecycle_outside_component/);
+    });
+
+    it('binds the default client when called without arguments', async () => {
+      await OpenFeature.setProviderAndWait(namedProvider('default-provider'));
+      render(ScopeWrapper, { scope: undefined });
+
+      expect(screen.getByTestId('domain')).toHaveTextContent('default');
+      expect(screen.getByTestId('provider')).toHaveTextContent('default-provider');
+    });
+  });
+
+  describe('without a scope', () => {
+    it('falls back to the default client inside components', async () => {
+      await OpenFeature.setProviderAndWait(namedProvider('default-provider'));
+      render(ScopeProbe);
+
+      expect(screen.getByTestId('domain')).toHaveTextContent('default');
+      expect(screen.getByTestId('framework')).toHaveTextContent('svelte');
+      expect(screen.getByTestId('provider')).toHaveTextContent('default-provider');
+    });
+
+    it('falls back to the default client outside components', async () => {
+      await OpenFeature.setProviderAndWait(namedProvider('default-provider'));
+
+      const client = useOpenFeatureClient();
+      expect(client.metadata.domain).toBeUndefined();
+      expect(client.metadata.framework).toBe('svelte');
+      expect(useOpenFeatureProvider().metadata.name).toBe('default-provider');
+    });
+  });
+});

--- a/packages/svelte/test/setup.ts
+++ b/packages/svelte/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/svelte/test/status.test.ts
+++ b/packages/svelte/test/status.test.ts
@@ -1,0 +1,75 @@
+import { OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useOpenFeatureClientStatus, useWhenProviderReady } from '../src';
+import { TestingProvider } from './helpers/testing-provider';
+import { flush, watch } from './helpers/watch.svelte';
+
+const DOMAIN = 'status';
+
+describe('status', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  describe('useOpenFeatureClientStatus', () => {
+    it('reflects the provider status reactively', async () => {
+      const provider = new TestingProvider({}, 10);
+      const ready = OpenFeature.setProviderAndWait(provider);
+      const status = useOpenFeatureClientStatus();
+      const watched = watch(() => status.current);
+
+      expect(watched.values).toEqual([ProviderStatus.NOT_READY]);
+      await ready;
+      flush();
+      expect(watched.values).toEqual([ProviderStatus.NOT_READY, ProviderStatus.READY]);
+      watched.stop();
+    });
+
+    it('does not re-run effects when subscribing to an already ready provider', async () => {
+      const provider = new TestingProvider({}, 0);
+      await OpenFeature.setProviderAndWait(provider);
+      const status = useOpenFeatureClientStatus();
+      const watched = watch(() => status.current);
+
+      // a configuration change emits an event, but the status stays READY
+      provider.events.emit(ProviderEvents.ConfigurationChanged, {});
+      flush();
+      expect(watched.values).toEqual([ProviderStatus.READY]);
+      watched.stop();
+    });
+
+    it('reads the current status outside effects', async () => {
+      await OpenFeature.setProviderAndWait(new TestingProvider({}, 0));
+      expect(useOpenFeatureClientStatus().current).toBe(ProviderStatus.READY);
+    });
+
+    it('stops listening once the last effect is destroyed', async () => {
+      const provider = new TestingProvider({}, 10);
+      const ready = OpenFeature.setProviderAndWait(DOMAIN, provider);
+      const client = OpenFeature.getClient(DOMAIN);
+      const initialHandlers = client.getHandlers(ProviderEvents.Ready).length;
+      const status = useOpenFeatureClientStatus();
+      const watched = watch(() => status.current);
+      watched.stop();
+      await ready;
+      // handlers were removed, so no further values were recorded
+      expect(watched.values).toEqual([ProviderStatus.NOT_READY]);
+      expect(client.getHandlers(ProviderEvents.Ready).length).toBe(initialHandlers);
+    });
+  });
+
+  describe('useWhenProviderReady', () => {
+    it('is false until the provider is ready, then true', async () => {
+      const provider = new TestingProvider({}, 10);
+      const ready = OpenFeature.setProviderAndWait(provider);
+      const isReady = useWhenProviderReady();
+      const watched = watch(() => isReady.current);
+
+      expect(watched.values).toEqual([false]);
+      await ready;
+      flush();
+      expect(watched.values).toEqual([false, true]);
+      watched.stop();
+    });
+  });
+});

--- a/packages/svelte/test/test-scope.test.ts
+++ b/packages/svelte/test/test-scope.test.ts
@@ -1,0 +1,108 @@
+import type { Provider, ResolutionDetails } from '@openfeature/web-sdk';
+import { OpenFeature } from '@openfeature/web-sdk';
+import { render, screen } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setOpenFeatureTestScope, useFlag } from '../src';
+import FlagValue from './fixtures/FlagValue.svelte';
+import TestScopeWrapper from './fixtures/TestScopeWrapper.svelte';
+
+const FLAG_KEY = 'my-flag';
+const DEFAULT_VALUE = 'default';
+const FLAG_VALUE = 'from-map';
+
+describe('setOpenFeatureTestScope', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  describe('no args', () => {
+    it('renders default', () => {
+      render(TestScopeWrapper, { flagKey: FLAG_KEY, defaultValue: DEFAULT_VALUE });
+      expect(screen.getByTestId('value')).toHaveTextContent(DEFAULT_VALUE);
+    });
+  });
+
+  describe('flagValueMap set', () => {
+    it('renders value from map', () => {
+      render(TestScopeWrapper, {
+        testScope: { flagValueMap: { [FLAG_KEY]: FLAG_VALUE } },
+        flagKey: FLAG_KEY,
+        defaultValue: DEFAULT_VALUE,
+      });
+      expect(screen.getByTestId('value')).toHaveTextContent(FLAG_VALUE);
+    });
+  });
+
+  describe('delay and flagValueMap set', () => {
+    it('renders value after delay', async () => {
+      const delayMs = 50;
+      render(TestScopeWrapper, {
+        testScope: { flagValueMap: { [FLAG_KEY]: FLAG_VALUE }, delayMs },
+        flagKey: FLAG_KEY,
+        defaultValue: DEFAULT_VALUE,
+      });
+      expect(screen.getByTestId('value')).toHaveTextContent(DEFAULT_VALUE);
+
+      await new Promise((resolve) => setTimeout(resolve, delayMs * 2));
+      flushSync();
+      expect(screen.getByTestId('value')).toHaveTextContent(FLAG_VALUE);
+    });
+  });
+
+  describe('provider set', () => {
+    const PROVIDER_VALUE = 'from-provider';
+    const PROVIDER_VARIANT = 'my-variant';
+    const PROVIDER_REASON = 'MY_REASON';
+
+    class MyTestProvider implements Partial<Provider> {
+      resolveStringEvaluation(): ResolutionDetails<string> {
+        return { value: PROVIDER_VALUE, variant: PROVIDER_VARIANT, reason: PROVIDER_REASON };
+      }
+    }
+
+    it('renders provider-returned value', () => {
+      render(TestScopeWrapper, {
+        testScope: { provider: new MyTestProvider() },
+        flagKey: FLAG_KEY,
+        defaultValue: DEFAULT_VALUE,
+      });
+      expect(screen.getByTestId('value')).toHaveTextContent(PROVIDER_VALUE);
+      expect(screen.getByTestId('variant')).toHaveTextContent(PROVIDER_VARIANT);
+      expect(screen.getByTestId('reason')).toHaveTextContent(PROVIDER_REASON);
+    });
+
+    it('falls back to no-op for missing methods', () => {
+      render(TestScopeWrapper, {
+        testScope: { provider: new MyTestProvider() },
+        flagKey: FLAG_KEY,
+        defaultValue: false,
+      });
+      expect(screen.getByTestId('value')).toHaveTextContent('false');
+      expect(screen.getByTestId('reason')).toHaveTextContent('No-op');
+    });
+  });
+
+  describe('domain set', () => {
+    it('scopes the test provider to the domain', () => {
+      render(TestScopeWrapper, {
+        testScope: { domain: 'test-domain', flagValueMap: { [FLAG_KEY]: FLAG_VALUE } },
+        flagKey: FLAG_KEY,
+        defaultValue: DEFAULT_VALUE,
+      });
+      expect(screen.getByTestId('value')).toHaveTextContent(FLAG_VALUE);
+      expect(OpenFeature.getProviderMetadata('test-domain').name).toBe('in-memory');
+      expect(OpenFeature.getProviderMetadata().name).not.toBe('in-memory');
+    });
+  });
+
+  describe('called outside a component', () => {
+    it('configures the default provider for subsequent evaluations', () => {
+      setOpenFeatureTestScope({ flagValueMap: { [FLAG_KEY]: FLAG_VALUE } });
+
+      expect(useFlag(FLAG_KEY, DEFAULT_VALUE).value).toBe(FLAG_VALUE);
+      render(FlagValue, { flagKey: FLAG_KEY, defaultValue: DEFAULT_VALUE });
+      expect(screen.getByTestId('value')).toHaveTextContent(FLAG_VALUE);
+    });
+  });
+});

--- a/packages/svelte/test/tracking.test.ts
+++ b/packages/svelte/test/tracking.test.ts
@@ -1,0 +1,48 @@
+import { InMemoryProvider, OpenFeature } from '@openfeature/web-sdk';
+import { render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Track } from '../src';
+import { useTrack } from '../src';
+import TrackProbe from './fixtures/TrackProbe.svelte';
+
+const EVENT_NAME = 'my-event';
+const EVENT_DETAILS = { value: 42 };
+
+class TrackingProvider extends InMemoryProvider {
+  track = vi.fn();
+}
+
+describe('useTrack', () => {
+  afterEach(async () => {
+    await OpenFeature.clearProviders();
+  });
+
+  describe('no scope', () => {
+    it('should call the default provider', async () => {
+      const provider = new TrackingProvider({});
+      await OpenFeature.setProviderAndWait(provider);
+
+      const { track } = useTrack();
+      track(EVENT_NAME, EVENT_DETAILS);
+
+      expect(provider.track).toHaveBeenCalledWith(EVENT_NAME, expect.anything(), EVENT_DETAILS);
+    });
+  });
+
+  describe('scope with domain', () => {
+    it('should call the provider for the domain', async () => {
+      const domain = 'tracking';
+      const defaultProvider = new TrackingProvider({});
+      const domainProvider = new TrackingProvider({});
+      await OpenFeature.setProviderAndWait(defaultProvider);
+      await OpenFeature.setProviderAndWait(domain, domainProvider);
+
+      let tracking: Track | undefined;
+      render(TrackProbe, { scope: { domain }, onReady: (t: Track) => (tracking = t) });
+      tracking?.track(EVENT_NAME, EVENT_DETAILS);
+
+      expect(domainProvider.track).toHaveBeenCalledWith(EVENT_NAME, expect.anything(), EVENT_DETAILS);
+      expect(defaultProvider.track).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/svelte/test/tsconfig.json
+++ b/packages/svelte/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM"],
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["."]
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "lib": ["ES2015", "DOM"],
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "paths": {
+      "@openfeature/core": ["../shared/src"],
+      "@openfeature/web-sdk": ["../web/src"],
+      "svelte": ["../../node_modules/svelte/types/index.d.ts"],
+      "svelte/*": ["../../node_modules/svelte/types/index.d.ts"]
+    },
+    "declaration": true,
+    "outDir": "./dist/esm",
+    "stripInternal": true,
+    "declarationDir": "./dist/types",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules", "**/*.test.js"]
+}

--- a/packages/svelte/tsconfig.rollup.json
+++ b/packages/svelte/tsconfig.rollup.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/packages/svelte/typedoc.json
+++ b/packages/svelte/typedoc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "name": "@openfeature/svelte-sdk",
+  "includeVersion": true,
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -1,0 +1,25 @@
+import { resolve } from 'node:path';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [svelte(), svelteTesting()],
+  resolve: {
+    // test against the workspace sources, like the jest projects do for the other packages
+    alias: {
+      '@openfeature/web-sdk': resolve(__dirname, '../web/src'),
+      '@openfeature/core': resolve(__dirname, '../shared/src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts'],
+    setupFiles: ['test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**'],
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -43,6 +43,14 @@
       "extra-files": ["README.md"],
       "versioning": "default"
     },
+    "packages/svelte": {
+      "release-type": "node",
+      "prerelease": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": ["README.md"],
+      "versioning": "default"
+    },
     "packages/shared": {
       "release-type": "node",
       "prerelease": false,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,7 +12,14 @@ export default {
   // function indicating which deps should be considered external: external deps will NOT have their types bundled
   external: (id) => {
     // bundle everything except peer deps (@openfeature/*, @nest/*,  react, rxjs)
-    return id.startsWith('@openfeature') || id.startsWith('@nest') || id === 'rxjs' || id === 'react';
+    return (
+      id.startsWith('@openfeature') ||
+      id.startsWith('@nest') ||
+      id === 'rxjs' ||
+      id === 'react' ||
+      id === 'svelte' ||
+      id.startsWith('svelte/')
+    );
   },
   plugins: [
     // use the rollup override tsconfig (applies equivalent in each sub-packages as well)


### PR DESCRIPTION
## Summary

- Add `@openfeature/svelte-sdk` (`packages/svelte`), an official Svelte binding for the Web SDK that mirrors the surface of `@openfeature/react-sdk`
- Reactive flag evaluation via `useFlag` and the typed `use{Boolean,String,Number,Object}Flag{Value,Details}` functions, re-evaluating on `Ready`, `ContextChanged` and `ConfigurationChanged` (honouring `flagsChanged`) and only notifying effects when the evaluation details actually changed
- `setOpenFeatureScope({ domain | client, ...options })` binds a client and default evaluation options to a component subtree via Svelte context (the `<OpenFeatureProvider>` equivalent); without a scope, the default client is used
- Reactive provider status and readiness (`useOpenFeatureClientStatus`, `useWhenProviderReady`), plus `useContextMutator` and `useTrack`
- `setOpenFeatureTestScope({ flagValueMap, delayMs, provider, domain })` testing helper (the `<OpenFeatureTestProvider>` equivalent)
- Vitest test suite (rune-level reactivity via `$effect.root` and rendered components), README, and workspace/release/CI wiring; `'svelte'` added to the `framework` union in `@openfeature/core`

Usage:

```svelte
<script lang="ts">
  import { OpenFeature, TypedInMemoryProvider, setOpenFeatureScope, useFlag } from '@openfeature/svelte-sdk';

  OpenFeature.setProvider(new TypedInMemoryProvider(flagConfig));
  setOpenFeatureScope({ domain: 'my-domain' });

  const newMessage = useFlag('new-message', false);
</script>

{#if newMessage.value}
  <p>Welcome to this OpenFeature-enabled Svelte app!</p>
{/if}
```

## Motivation

Svelte is on the OpenFeature roadmap but has no framework SDK, so every Svelte app currently hand-rolls the same reactive wrapper around `@openfeature/web-sdk` (re-evaluate on provider/context/config events, gate on readiness). This closes that gap the same way the React and Angular SDKs do for their frameworks. It is distinct from Vercel's Flags SDK SvelteKit adapter, which is server-side only and a different abstraction.

### Notes

- **No runes in library code.** Reactivity is built on [`createSubscriber`](https://svelte.dev/docs/svelte/svelte-reactivity#createSubscriber) from `svelte/reactivity`, the pattern Svelte recommends for external event sources. Getters register effect dependencies; web-sdk handlers are attached while something depends on the object and removed (via `AbortController`) when the last effect is destroyed. The package is therefore plain JS: it builds with the existing esbuild + rollup-dts pipeline, needs no compilation by consumers, ships no `.svelte` files, and flag objects can live in components, `.svelte.ts` modules, or module scope without manual cleanup. Peer dependency is `svelte: ^5.7.0` (when `createSubscriber` landed); Svelte 4 is out of scope, `toStore(() => flag.value)` is documented as the bridge.
- **Primitives are returned as `{ current }` boxes** (`useBooleanFlagValue(...).current`, `useWhenProviderReady().current`), following the convention of Svelte's own reactive classes, since a bare primitive can't be reactive.
- **Scope falls back to the default client** instead of throwing like React's `MissingContextError`, because Svelte 5 code legitimately creates flag objects outside components (module-level state), where no context can exist.
- **Naming:** `setOpenFeatureScope` was chosen over "provider"/"context" to avoid colliding with OpenFeature's own *provider* and *evaluation context* terms. Happy to rename.
- **SvelteKit SSR** is documented as out of scope (as with the web SDK); the README points to the Server SDK for `load` functions.
- Suspense options and the declarative `<FeatureFlag>` component have no counterpart (`{#if flag.value}` is native); a component could follow later if there's demand.
- **ESM-only.** Svelte 5 is ESM-only (no `require` condition on `svelte/reactivity`), so a CommonJS build would fail with `ERR_REQUIRE_ESM` on Node versions without `require(esm)`. Like the Angular SDK, this package publishes ESM only.
- `prettier-plugin-svelte` is added as a root devDependency so the `.svelte` test fixtures are formatted like everything else.
- Tests use Vitest (`@sveltejs/vite-plugin-svelte`, `@testing-library/svelte`, jsdom) like the Angular package, wired in as `npm run test:svelte`. Package version starts at `0.0.0` so the first release-please cut is `0.1.0`.

### Related Issues

<!-- proposal issue, if one is opened -->

### Follow-up Tasks

- Docs site page under `client/web/svelte`, and an example in `js-sdk-examples`

## Test plan

- [x] `npm run build`
- [x] `npm run test:svelte` (58 tests, 98% coverage)
- [x] `npm run test:jest` (612 tests) and `npm run test:package-exports`
- [x] `npm run lint` and `npm run format`
