### PR TITLE
chore: update Node.js CI versions

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
           - 22.x
           - 24.x
+          - 26.x
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- remove Node.js 20 from the CI matrix
- add Node.js 26 to the CI matrix

Node.js 20 is EOL, while Node.js 22, 24, and 26 are officially supported. Testing those versions follows the OpenFeature [platform support recommendations](https://github.com/open-feature/community/blob/main/technical-guidelines.md#platform-support-recommendations), which recommend supporting all officially supported, non-EOL platforms.

This also unblocks the Angular CLI 22 upgrade in the stacked follow-up PR. Angular CLI 22 requires Node.js `^22.22.3 || ^24.15.0 || >=26.0.0` and no longer supports Node.js 20.
