### PR TITLE
fix(angular): restore spec path aliases

### DIFF
--- a/packages/angular/projects/angular-sdk/tsconfig.spec.json
+++ b/packages/angular/projects/angular-sdk/tsconfig.spec.json
@@ -5,8 +5,8 @@
     "types": ["vitest/globals", "node"],
     "paths": {
       "angular": ["./dist/angular"],
-      "@openfeature/core": ["../../shared/src"],
-      "@openfeature/web-sdk": ["../../web/src"]
+      "@openfeature/core": ["../../../shared/src"],
+      "@openfeature/web-sdk": ["../../../web/src"]
     },
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
## Summary
- restore the Angular spec aliases for `@openfeature/core` and `@openfeature/web-sdk`
- keep their original source targets after removing the deprecated `baseUrl`