### PR TITLE
fix: preserve common MultiProvider error codes

### DIFF
--- a/packages/server/test/multi-provider.spec.ts
+++ b/packages/server/test/multi-provider.spec.ts
@@ -21,6 +21,8 @@ import {
   FirstMatchStrategy,
   FirstSuccessfulStrategy,
   ComparisonStrategy,
+  InMemoryProvider,
+  OpenFeature,
 } from '../src';
 import { legacyInitializeProvider } from '../../shared/test/legacy-initialize-provider';
 
@@ -73,6 +75,36 @@ const callBeforeHook = async (
 
 describe('MultiProvider', () => {
   const logger = new DefaultLogger();
+
+  describe('public client error details', () => {
+    afterEach(async () => {
+      await OpenFeature.clearProviders();
+    });
+
+    it.each([1, 2])('reports FLAG_NOT_FOUND when all %i providers lack the flag', async (count) => {
+      await OpenFeature.setProviderAndWait(
+        new MultiProvider(Array.from({ length: count }, () => ({ provider: new InMemoryProvider() }))),
+      );
+
+      await expect(OpenFeature.getClient().getStringDetails('missing', 'fallback')).resolves.toMatchObject({
+        value: 'fallback',
+        errorCode: ErrorCode.FLAG_NOT_FOUND,
+      });
+    });
+
+    it.each([new FirstMatchStrategy(), new FirstSuccessfulStrategy()])(
+      'preserves TYPE_MISMATCH through %p',
+      async (strategy) => {
+        const flags = { string: { variants: { on: 'hi' }, defaultVariant: 'on', disabled: false } };
+        await OpenFeature.setProviderAndWait(new MultiProvider([{ provider: new InMemoryProvider(flags) }], strategy));
+
+        await expect(OpenFeature.getClient().getNumberDetails('string', -1)).resolves.toMatchObject({
+          value: -1,
+          errorCode: ErrorCode.TYPE_MISMATCH,
+        });
+      },
+    );
+  });
 
   describe('unique names', () => {
     it('uses provider names for unique types', () => {

--- a/packages/shared/src/provider/multi-provider/errors.ts
+++ b/packages/shared/src/provider/multi-provider/errors.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode } from '../../evaluation';
+import { ErrorCode } from '../../evaluation';
 import { GeneralError, OpenFeatureError } from '../../errors';
 import type { RegisteredProvider } from './types';
 
@@ -19,6 +19,14 @@ export class AggregateError extends GeneralError {
     super(message);
     Object.setPrototypeOf(this, AggregateError.prototype);
     this.name = 'AggregateError';
+    const code = (originalErrors[0]?.error as OpenFeatureError)?.code;
+    // Preserve an unambiguous code without selecting between different provider failures.
+    if (
+      Object.values(ErrorCode).includes(code) &&
+      originalErrors.every(({ error }) => (error as OpenFeatureError)?.code === code)
+    ) {
+      this.code = code;
+    }
   }
 }
 

--- a/packages/shared/test/multi-provider-errors.spec.ts
+++ b/packages/shared/test/multi-provider-errors.spec.ts
@@ -4,9 +4,56 @@ import {
   AggregateError,
 } from '../src/provider/multi-provider/errors';
 import type { RegisteredProvider } from '../src/provider/multi-provider/types';
+import { ErrorCode, FlagNotFoundError, TypeMismatchError } from '../src';
 
 describe('Multi-Provider Errors', () => {
   describe('constructAggregateError', () => {
+    it.each([1, 2])('keeps GENERAL for %i errors with a non-OpenFeature code', (count) => {
+      const error = constructAggregateError(
+        Array.from({ length: count }, (_, i) => ({
+          error: Object.assign(new Error('Connection reset'), { code: 'ECONNRESET' }),
+          providerName: `provider${i}`,
+        })),
+      );
+
+      expect(error.code).toBe(ErrorCode.GENERAL);
+    });
+
+    it('preserves a recognized code without requiring an OpenFeatureError instance', () => {
+      const error = constructAggregateError([
+        {
+          error: Object.assign(new Error('Missing flag'), { code: ErrorCode.FLAG_NOT_FOUND }),
+          providerName: 'provider',
+        },
+      ]);
+
+      expect(error.code).toBe(ErrorCode.FLAG_NOT_FOUND);
+    });
+
+    it.each([1, 2])('preserves a common error code from %i provider errors', (count) => {
+      const providerErrors = Array.from({ length: count }, (_, i) => ({
+        error: new FlagNotFoundError(`Missing flag from provider ${i}`),
+        providerName: `provider${i}`,
+      }));
+
+      const error = constructAggregateError(providerErrors);
+
+      expect(error.code).toBe(ErrorCode.FLAG_NOT_FOUND);
+      expect(error.originalErrors.map(({ error }) => error)).toEqual(providerErrors.map(({ error }) => error));
+    });
+
+    it.each([new TypeMismatchError(), new Error('unknown error'), null])(
+      'keeps GENERAL when provider error codes do not agree: %p',
+      (otherError) => {
+        const error = constructAggregateError([
+          { error: new FlagNotFoundError(), providerName: 'missing' },
+          { error: otherError, providerName: 'other' },
+        ]);
+
+        expect(error.code).toBe(ErrorCode.GENERAL);
+      },
+    );
+
     it('should create an AggregateError with provider errors', () => {
       const providerErrors = [
         { error: new Error('Provider 1 failed'), providerName: 'provider1' },
@@ -41,6 +88,7 @@ describe('Multi-Provider Errors', () => {
       expect(error).toBeInstanceOf(AggregateError);
       expect(error.message).toBe('Provider errors occurred');
       expect(error.originalErrors).toHaveLength(0);
+      expect(error.code).toBe(ErrorCode.GENERAL);
     });
 
     it('should handle non-Error objects as errors', () => {


### PR DESCRIPTION
Fixes #1452.

Wrapping an `InMemoryProvider` in `MultiProvider` currently changes `TYPE_MISMATCH` and `FLAG_NOT_FOUND` into `GENERAL`. Preserve the common error code when every aggregated error has the same recognized OpenFeature code, as suggested in the issue. Missing flags now retain the default strategy's documented `FLAG_NOT_FOUND` result. Different codes, uncoded errors, non-OpenFeature codes such as `ECONNRESET`, and empty aggregates keep `GENERAL`.

The aggregate still retains its original error objects, source names, message, and class. Evaluation order and strategy selection are unchanged. The change is in the shared aggregate constructor used by both SDKs and by their lifecycle error aggregation.

Regression tests cover public client details for missing flags across one or two providers, type mismatch through FirstMatch and FirstSuccessful strategies, homogeneous error aggregation, mixed/uncoded errors, foreign error codes, structurally compatible errors, and empty aggregates. Six new tests failed on the unmodified implementation; the original public API reproduction passes after the fix with its assertions unchanged.

Validation on Windows with Node 25.8.1 and npm 11.11.0:

- `npm run test:jest -- --runInBand --coverage=false`: 35 suites, 624 tests passed.
- `npm run build --workspace=packages/shared --workspace=packages/server --workspace=packages/web`: passed.
- ESLint and Prettier checks for all three changed files: passed.
- `git diff --check`: passed.

Angular tests, Linux, and the CI Node 22/24/26 matrix were not run locally. Node 25 satisfies the server package's `>=20` engine range but is outside that CI matrix.

This patch and its tests were prepared with AI assistance.
